### PR TITLE
EVG-14808: add more boilerplate code for pod and pod creator

### DIFF
--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -7,32 +7,56 @@ import (
 	"github.com/evergreen-ci/cocoa/secret"
 )
 
-// ECSPod represents a pod that is backed by ECS.
-type ECSPod struct {
-	TaskID           string      `bson:"-" json:"-" yaml:"-"`
-	TaskDefinitionID string      `bson:"-" json:"-" yaml:"-"`
-	Secrets          []PodSecret `bson:"-" json:"-" yaml:"-"`
+// ECSPod provides an abstraction of a pod backed by ECS.
+type ECSPod interface {
+	// Info returns information about the current state of the pod.
+	Info(ctx context.Context) (*ECSPodInfo, error)
+	// Stop stops the running pod without cleaning up any of its underlying
+	// resources.
+	Stop(ctx context.Context) error
+	// Delete deletes the pod and its owned resources.
+	Delete(ctx context.Context) error
+}
+
+// BasicECSPod represents a pod that is backed by ECS.
+type BasicECSPod struct {
+	client    ECSClient
+	resources ECSPodResources
+	status    ECSPodStatus
+}
+
+// NewBasicECSPod initializes a new pod that is backed by ECS.
+func NewBasicECSPod(c ECSClient, res ECSPodResources, stat ECSPodStatus) *BasicECSPod {
+	return &BasicECSPod{
+		client:    c,
+		resources: res,
+		status:    stat,
+	}
 }
 
 // Info returns information about the current state of the pod.
-func (p *ECSPod) Info(ctx context.Context) (*ECSPodInfo, error) {
+func (p *BasicECSPod) Info(ctx context.Context) (*ECSPodInfo, error) {
 	return nil, errors.New("TODO: implement")
 }
 
-// Stop stops the running pod.
-func (p *ECSPod) Stop(ctx context.Context) error {
+// Stop stops the running pod without cleaning up any of its underlying
+// resources.
+func (p *BasicECSPod) Stop(ctx context.Context) error {
 	return errors.New("TODO: implement")
 }
 
 // Delete deletes the pod and its owned resources.
-func (p *ECSPod) Delete(ctx context.Context) error {
+func (p *BasicECSPod) Delete(ctx context.Context) error {
 	return errors.New("TODO: implement")
 }
 
 // ECSPodInfo provides information about the current status of the pod.
 type ECSPodInfo struct {
 	// Status is the current status of the pod.
-	Status string
+	Status ECSPodStatus `bson:"-" json:"-" yaml:"-"`
+	// Resources provides information about the underlying ECS resources being
+	// used by the pod.
+	Resources ECSPodResources `bson:"-" json:"-" yaml:"-"`
 }
 
 // PodSecret is a named secret that may or may not be owned by its pod.
@@ -41,3 +65,69 @@ type PodSecret struct {
 	// Owned determines whether or not the secret is owned by its pod or not.
 	Owned *bool
 }
+
+// SetName sets the secret's name.
+func (s *PodSecret) SetName(name string) *PodSecret {
+	s.Name = &name
+	return s
+}
+
+// SetValue sets the secret's value.
+func (s *PodSecret) SetValue(val string) *PodSecret {
+	s.Value = &val
+	return s
+}
+
+// SetOwned sets if the secret should be owned by its pod.
+func (s *PodSecret) SetOwned(owned bool) *PodSecret {
+	s.Owned = &owned
+	return s
+}
+
+// ECSPodResources are ECS-specific resources that a pod uses.
+type ECSPodResources struct {
+	TaskID         string            `bson:"-" json:"-" yaml:"-"`
+	TaskDefinition ECSTaskDefinition `bson:"-" json:"-" yaml:"-"`
+	Secrets        []PodSecret       `bson:"-" json:"-" yaml:"-"`
+}
+
+// SetTaskID sets the ECS task ID associated with the pod.
+func (r *ECSPodResources) SetTaskID(id string) *ECSPodResources {
+	r.TaskID = id
+	return r
+}
+
+// SetTaskDefinition sets the ECS task definition associated with the pod.
+func (r *ECSPodResources) SetTaskDefinition(def ECSTaskDefinition) *ECSPodResources {
+	r.TaskDefinition = def
+	return r
+}
+
+// SetSecrets sets the secrets associated with the pod. This overwrites any
+// existing secrets.
+func (r *ECSPodResources) SetSecrets(secrets []PodSecret) *ECSPodResources {
+	r.Secrets = secrets
+	return r
+}
+
+// AddSecrets adds new secrets to the existing ones associated with the pod.
+func (r *ECSPodResources) AddSecrets(secrets ...PodSecret) *ECSPodResources {
+	r.Secrets = append(r.Secrets, secrets...)
+	return r
+}
+
+// ECSPodStatus represents the different statuses possible for an ECS pod.
+type ECSPodStatus = string
+
+const (
+	// Starting indicates that the ECS pod is being prepared to run.
+	Starting ECSPodStatus = "starting"
+	// Running indicates that the ECS pod is actively running.
+	Running ECSPodStatus = "running"
+	// Stopped indicates the that ECS pod is stopped, but all of its resources
+	// are still available.
+	Stopped ECSPodStatus = "stopped"
+	// Deleted indicates that the ECS pod has been cleaned up completely,
+	// including all of its resources.
+	Deleted ECSPodStatus = "deleted"
+)

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -20,17 +20,53 @@ type ECSPod interface {
 
 // BasicECSPod represents a pod that is backed by ECS.
 type BasicECSPod struct {
-	client    ECSClient
-	resources ECSPodResources
-	status    ECSPodStatus
+	opts BasicECSPodOptions
+}
+
+// BasicECSPodOptions are options to create a BasicECSPod.
+type BasicECSPodOptions struct {
+	Client    ECSClient
+	Vault     secret.Vault
+	Resources *ECSPodResources
+	Status    *ECSPodStatus
+}
+
+// MergeECSPodOptions merges all the given options describing an ECS pod.
+// Options are applied in the order that they're specified and conflicting
+// options are overwritten.
+func MergeECSPodOptions(opts ...*BasicECSPodOptions) BasicECSPodOptions {
+	merged := BasicECSPodOptions{}
+
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+
+		if opt.Client != nil {
+			merged.Client = opt.Client
+		}
+
+		if opt.Vault != nil {
+			merged.Vault = opt.Vault
+		}
+
+		if opt.Resources != nil {
+			merged.Resources = opt.Resources
+		}
+
+		if opt.Status != nil {
+			merged.Status = opt.Status
+		}
+	}
+
+	return merged
 }
 
 // NewBasicECSPod initializes a new pod that is backed by ECS.
-func NewBasicECSPod(c ECSClient, res ECSPodResources, stat ECSPodStatus) *BasicECSPod {
+func NewBasicECSPod(opts ...*BasicECSPodOptions) *BasicECSPod {
+	merged := MergeECSPodOptions(opts...)
 	return &BasicECSPod{
-		client:    c,
-		resources: res,
-		status:    stat,
+		opts: merged,
 	}
 }
 

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -3,6 +3,8 @@ package cocoa
 import (
 	"context"
 	"errors"
+
+	"github.com/evergreen-ci/cocoa/secret"
 )
 
 // ECSPodCreator provides a means to create a new pod backed by ECS.
@@ -78,8 +80,10 @@ func (o *ECSPodCreationOptions) AddTags(tags ...string) *ECSPodCreationOptions {
 	return o
 }
 
-//nolint:deadcode
-func mergeECSPodCreationOptions(opts ...*ECSPodCreationOptions) *ECSPodCreationOptions {
+// MergeECSPodCreationOptions merges all the given options to create an ECS pod.
+// Options are applied in the order that they're specified and conflicting
+// options are overwritten.
+func MergeECSPodCreationOptions(opts ...*ECSPodCreationOptions) ECSPodCreationOptions {
 	merged := ECSPodCreationOptions{}
 
 	for _, opt := range opts {
@@ -96,7 +100,7 @@ func mergeECSPodCreationOptions(opts ...*ECSPodCreationOptions) *ECSPodCreationO
 		}
 	}
 
-	return &merged
+	return merged
 }
 
 // ECSTaskDefinition represents options for an existing ECS task definition.
@@ -236,12 +240,14 @@ func (e *EnvironmentVariable) SetSecretOptions(opts SecretOptions) *EnvironmentV
 // ECS pods.
 type BasicECSPodCreator struct {
 	client ECSClient
+	vault  secret.Vault
 }
 
 // NewBasicECSPodCreator creates a helper to create pods backed by ECS.
-func NewBasicECSPodCreator(c ECSClient) *BasicECSPodCreator {
+func NewBasicECSPodCreator(c ECSClient, v secret.Vault) *BasicECSPodCreator {
 	return &BasicECSPodCreator{
 		client: c,
+		vault:  v,
 	}
 }
 

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -10,7 +10,7 @@ type ECSPodCreator interface {
 	// CreatePod creates a new pod backed by ECS with the given options. Options
 	// are applied in the order they're specified and conflicting options are
 	// overwritten.
-	CreatePod(ctx context.Context, opts ...*ECSPodCreationOptions) (*ECSPod, error)
+	CreatePod(ctx context.Context, opts ...*ECSPodCreationOptions) (ECSPod, error)
 }
 
 // ECSPodCreationOptions provide options to create a pod backed by ECS.
@@ -197,24 +197,6 @@ type SecretOptions struct {
 	Exists *bool
 }
 
-// SetName sets the secret's name.
-func (s *SecretOptions) SetName(name string) *SecretOptions {
-	s.Name = &name
-	return s
-}
-
-// SetValue sets the secret's value.
-func (s *SecretOptions) SetValue(val string) *SecretOptions {
-	s.Value = &val
-	return s
-}
-
-// SetOwned sets if the secret should be owned by its pod.
-func (s *SecretOptions) SetOwned(owned bool) *SecretOptions {
-	s.Owned = &owned
-	return s
-}
-
 // SetExists sets whether or not the secret already exists or or must be
 // created.
 func (s *SecretOptions) SetExists(exists bool) *SecretOptions {
@@ -264,6 +246,6 @@ func NewBasicECSPodCreator(c ECSClient) *BasicECSPodCreator {
 }
 
 // CreatePod creates a new pod backed by ECS.
-func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*ECSPodCreationOptions) (*ECSPod, error) {
+func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*ECSPodCreationOptions) (ECSPod, error) {
 	return nil, errors.New("TODO: implement")
 }

--- a/mock/ecs_pod.go
+++ b/mock/ecs_pod.go
@@ -1,0 +1,31 @@
+package mock
+
+import (
+	"context"
+	"errors"
+
+	"github.com/evergreen-ci/cocoa"
+)
+
+// ECSPod provides a mock implementation of a cocoa.ECSPod. By default, it is
+// backed by a mock ECS client.
+type ECSPod struct{}
+
+// Info returns mock information about the pod. The mock output can be
+// customized. By default, it will return its cached information.
+func (p *ECSPod) Info(ctx context.Context) (*cocoa.ECSPodInfo, error) {
+	return nil, errors.New("TODO: implement")
+}
+
+// Stop stops the mock pod. The mock output can be customized. By default, it
+// will set the cached status to stopped.
+func (p *ECSPod) Stop(ctx context.Context) error {
+	return errors.New("TODO: implement")
+}
+
+// Delete deletes the mock pod and all of its underlying resources. The mock
+// output can be customized. By default, it will delete its secrets from its
+// Vault. If it succeeds, it will set the cached status to deleted.
+func (p *ECSPod) Delete(ctx context.Context) error {
+	return errors.New("TODO: implement")
+}

--- a/mock/ecs_pod_creator.go
+++ b/mock/ecs_pod_creator.go
@@ -8,13 +8,13 @@ import (
 )
 
 // ECSPodCreator provides a mock implementation of a cocoa.ECSPodCreator
-// that produces ECS pods backed by ECSClients. It can also be mocked to
-// produce a pre-defined cocoa.ECSPod.
+// that produces mock ECS pods. It can also be mocked to produce a pre-defined
+// cocoa.ECSPod.
 type ECSPodCreator struct{}
 
 // CreatePod saves the input and returns a new mock pod. The mock output can be
 // customized. By default, it will create a new pod based on the input that is
 // backed by a mock ECSClient.
-func (m *ECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPodCreationOptions) (*cocoa.ECSPod, error) {
+func (m *ECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPodCreationOptions) (cocoa.ECSPod, error) {
 	return nil, errors.New("TODO: implement")
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestInterfaces(t *testing.T) {
 	assert.Implements(t, (*cocoa.ECSPodCreator)(nil), &ECSPodCreator{})
+	assert.Implements(t, (*cocoa.ECSPod)(nil), &ECSPod{})
 	assert.Implements(t, (*cocoa.ECSClient)(nil), &ECSClient{})
 
 	assert.Implements(t, (*secret.Vault)(nil), &Vault{})


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14808

* Convert `ECSPod` into an interface for easier mockability and to allow alternative implementations.
* Add constructor for `BasicECSPod`.
* Add more metadata fields that will be relevant to `ECSPod`s.