### PR TITLE
EVG-14841: make credentials optional if role is set

### DIFF
--- a/awsutil/client_options.go
+++ b/awsutil/client_options.go
@@ -79,7 +79,7 @@ func (o *ClientOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 
 	catcher.NewWhen(o.Region == nil, "must provide geographical region")
-	catcher.NewWhen(o.Creds == nil, "must provide credentials")
+	catcher.NewWhen(o.Role == nil && o.Creds == nil, "must provide either explicit credentials, role to assume, or both")
 
 	if catcher.HasErrors() {
 		return catcher.Resolve()
@@ -100,6 +100,9 @@ func (o *ClientOptions) Validate() error {
 
 // GetCredentials retrieves the appropriate credentials to use for the client.
 func (o *ClientOptions) GetCredentials() (*credentials.Credentials, error) {
+	if o.Role == nil && o.Creds == nil {
+		return nil, errors.New("cannot get client credentials when neither explicit credentials are given, nor the role to assume is given")
+	}
 	if o.Role == nil {
 		return o.Creds, nil
 	}

--- a/awsutil/client_options_test.go
+++ b/awsutil/client_options_test.go
@@ -76,7 +76,24 @@ func TestClientOptions(t *testing.T) {
 			assert.Equal(t, hc, opts.HTTPClient)
 			assert.False(t, opts.ownsHTTPClient)
 		})
-		t.Run("SucceedsWithoutRole", func(t *testing.T) {
+		t.Run("SucceedsWithoutCredentialsWhenRoleIsGiven", func(t *testing.T) {
+			role := "role"
+			region := "region"
+			retryOpts := utility.RetryOptions{
+				MaxAttempts: 10,
+				MinDelay:    100 * time.Millisecond,
+				MaxDelay:    time.Second,
+			}
+			hc := http.DefaultClient
+			opts := NewClientOptions().
+				SetRole(role).
+				SetRegion(region).
+				SetRetryOptions(retryOpts).
+				SetHTTPClient(hc)
+
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("SucceedsWithoutRoleWhenCredentialsAreGiven", func(t *testing.T) {
 			creds := credentials.NewEnvCredentials()
 			region := "region"
 			retryOpts := utility.RetryOptions{
@@ -91,17 +108,9 @@ func TestClientOptions(t *testing.T) {
 				SetRetryOptions(retryOpts).
 				SetHTTPClient(hc)
 
-			require.NoError(t, opts.Validate())
-
-			assert.Equal(t, creds, opts.Creds)
-			assert.Equal(t, region, *opts.Region)
-			assert.Zero(t, opts.Role)
-			assert.Equal(t, retryOpts, *opts.RetryOpts)
-			assert.Equal(t, hc, opts.HTTPClient)
-			assert.False(t, opts.ownsHTTPClient)
+			assert.NoError(t, opts.Validate())
 		})
-		t.Run("FailsWithoutCredentials", func(t *testing.T) {
-			role := "role"
+		t.Run("FailsWithNeitherCredentialsNorRoleAreGiven", func(t *testing.T) {
 			region := "region"
 			retryOpts := utility.RetryOptions{
 				MaxAttempts: 10,
@@ -110,7 +119,6 @@ func TestClientOptions(t *testing.T) {
 			}
 			hc := http.DefaultClient
 			opts := NewClientOptions().
-				SetRole(role).
 				SetRegion(region).
 				SetRetryOptions(retryOpts).
 				SetHTTPClient(hc)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14841

Make the access credentials optional as long as a role is given. Build should have configured the app server's EC2 instances to allow us to assume the correct role without passing any credentials to STS (as long as the call to STS is made from Evergreen's app servers). This means that the app server can call `AssumeRole` to get authorized credentials to use ECS/Secrets Manager without passing in any initial access key or secret access key and we don't have to store/manage AWS keys anymore.