### PR TITLE
EVG-14860: implement mock ECS client

### DIFF
--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -105,7 +105,7 @@ func TestECSClient(t *testing.T) {
 // teardown.
 func cleanupTaskDefinitions(ctx context.Context, t *testing.T, c cocoa.ECSClient) []string {
 	out, err := c.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
-		Status: aws.String("ACTIVE"),
+		Status: aws.String(ecs.TaskDefinitionStatusActive),
 	})
 	require.NoError(t, err)
 	require.NotZero(t, out)

--- a/glide.lock
+++ b/glide.lock
@@ -23,7 +23,7 @@ imports:
 
     # utility and its dependent libraries
   - name: github.com/evergreen-ci/utility
-    version: 9a40a71c1784193533247813b8361f534fe4101b
+    version: 05c74e17438dda266dd99e593054c0a9db6d86c1
   - name: github.com/evergreen-ci/gimlet
     version: ca35738ff88824eab0bbbe7950a81b30b6bfde9e
   - name: github.com/mongodb/grip

--- a/internal/testcase/ecs_client.go
+++ b/internal/testcase/ecs_client.go
@@ -48,7 +48,7 @@ func ECSClientTaskDefinitionTests() map[string]ECSClientTestCase {
 			require.NotNil(t, registerOut.TaskDefinition)
 			require.NotNil(t, registerOut.TaskDefinition.TaskDefinitionArn)
 			require.NotZero(t, registerOut.TaskDefinition.Status)
-			assert.Equal(t, "ACTIVE", *registerOut.TaskDefinition.Status)
+			assert.Equal(t, ecs.TaskDefinitionStatusActive, *registerOut.TaskDefinition.Status)
 			require.NotZero(t, registerOut.TaskDefinition.RegisteredAt)
 			assert.NotZero(t, *registerOut.TaskDefinition.RegisteredAt)
 
@@ -118,7 +118,7 @@ func ECSClientRegisteredTaskDefinitionTests(registerIn ecs.RegisterTaskDefinitio
 		},
 		"RunAndStopTaskSucceedsWithRegisteredTaskDefinition": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			require.NotZero(t, registerOut.TaskDefinition.Status)
-			assert.Equal(t, "ACTIVE", *registerOut.TaskDefinition.Status)
+			assert.Equal(t, ecs.TaskDefinitionStatusActive, *registerOut.TaskDefinition.Status)
 
 			runOut, err := c.RunTask(ctx, &ecs.RunTaskInput{
 				Cluster:        aws.String(testutil.ECSClusterName()),
@@ -141,7 +141,7 @@ func ECSClientRegisteredTaskDefinitionTests(registerIn ecs.RegisterTaskDefinitio
 		},
 		"DescribeTaskSucceedsWithRunningTask": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			require.NotZero(t, registerOut.TaskDefinition.Status)
-			assert.Equal(t, "ACTIVE", *registerOut.TaskDefinition.Status)
+			assert.Equal(t, ecs.TaskDefinitionStatusActive, *registerOut.TaskDefinition.Status)
 
 			runOut, err := c.RunTask(ctx, &ecs.RunTaskInput{
 				Cluster:        aws.String(testutil.ECSClusterName()),

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -2,49 +2,108 @@ package mock
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/pkg/errors"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/evergreen-ci/utility"
 )
 
-// ECSCluster represents a mock ECS cluster running tasks.
+// ECSCluster represents a mock ECS cluster running tasks in the global ECS
+// service.
 type ECSCluster map[string]ECSTask
 
 // ECSTask represents a mock ECS task.
 type ECSTask struct {
-	ID          string
-	Cluster     string
-	ExecEnabled bool
+	ARN         *string
+	Cluster     *string
+	ExecEnabled *bool
 	Tags        []string
 }
 
-// ECSTask represents a mock ECS task definition.
+// ECSTaskDefinition represents a mock ECS task definition in the global ECS service.
 type ECSTaskDefinition struct {
-	ID            string
+	ARN           *string
+	Family        *string
+	Revision      *int64
 	ContainerDefs []ECSContainerDefinition
-	MemoryMB      int
-	CPU           int
-	TaskRole      string
-	Tags          []string
+	MemoryMB      *string
+	CPU           *string
+	TaskRole      *string
+	Tags          map[string]string
+	Status        *string
+	Registered    *time.Time
 }
 
-// ECSContainerDefinition represents a mock ECS container definition.
+func (d *ECSTaskDefinition) export() *ecs.TaskDefinition {
+	var containerDefs []*ecs.ContainerDefinition
+	for _, def := range d.ContainerDefs {
+		containerDefs = append(containerDefs, def.export())
+	}
+	return &ecs.TaskDefinition{
+		TaskDefinitionArn:    d.ARN,
+		Family:               d.Family,
+		Revision:             d.Revision,
+		Cpu:                  d.CPU,
+		Memory:               d.MemoryMB,
+		TaskRoleArn:          d.TaskRole,
+		Status:               d.Status,
+		ContainerDefinitions: containerDefs,
+	}
+}
+
+// ECSContainerDefinition represents a mock ECS container definition in a mock
+// ECS task definition.
 type ECSContainerDefinition struct {
-	Name     string
-	Image    string
+	Name     *string
+	Image    *string
 	Command  []string
-	MemoryMB int
-	CPU      int
+	MemoryMB *int64
+	CPU      *int64
 	EnvVars  map[string]string
 	Secrets  map[string]string
-	Tags     []string
+	Tags     map[string]string
 }
 
-// ECSService represents an in-memory fake implementation of ECS for testing and
-// integration with the mock ECSClient.
+func (d *ECSContainerDefinition) export() *ecs.ContainerDefinition {
+	var env []*ecs.KeyValuePair
+	for k, v := range d.EnvVars {
+		env = append(env, &ecs.KeyValuePair{
+			Name:  utility.ToStringPtr(k),
+			Value: utility.ToStringPtr(v),
+		})
+	}
+	var tags []*ecs.Tag
+	for k, v := range d.Tags {
+		tags = append(tags, &ecs.Tag{
+			Key:   utility.ToStringPtr(k),
+			Value: utility.ToStringPtr(v),
+		})
+	}
+	return &ecs.ContainerDefinition{
+		Name:        d.Name,
+		Image:       d.Image,
+		Command:     utility.ToStringPtrSlice(d.Command),
+		Memory:      d.MemoryMB,
+		Cpu:         d.CPU,
+		Environment: env,
+	}
+}
+
+// ECSService is a global implementation of ECS that provides a simplified
+// in-memory implementation of the service that only stores metadata and does
+// not orchestrate real containers or container instances. This can be used
+// indirectly with the ECSClient to access or modify ECS resources, or used
+// directly.
 type ECSService struct {
+	// kim: TODO: need mutexes for multi-threaded?
 	Clusters map[string]ECSCluster
-	TaskDefs map[string]ECSTaskDefinition
+	TaskDefs map[string][]ECSTaskDefinition
 }
 
 // GlobalECSService represents the global fake ECS service state.
@@ -53,35 +112,161 @@ var GlobalECSService ECSService
 func init() {
 	GlobalECSService = ECSService{
 		Clusters: map[string]ECSCluster{},
-		TaskDefs: map[string]ECSTaskDefinition{},
+		TaskDefs: map[string][]ECSTaskDefinition{},
 	}
 }
 
 // ECSClient provides a mock implementation of a cocoa.ECSClient. This makes
 // it possible to introspect on inputs to the client and control the client's
 // output. It provides some default implementations where possible.
-type ECSClient struct{}
+type ECSClient struct {
+	RegisterTaskDefinitionInput  *ecs.RegisterTaskDefinitionInput
+	RegisterTaskDefinitionOutput *ecs.RegisterTaskDefinitionOutput
+
+	DeregisterTaskDefinitionInput  *ecs.DeregisterTaskDefinitionInput
+	DeregisterTaskDefinitionOutput *ecs.DeregisterTaskDefinitionOutput
+}
 
 // RegisterTaskDefinition saves the input and returns a new mock task
 // definition. The mock output can be customized. By default, it will create a
 // cached task definition based on the input.
 func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
-	// kim: TODO: implement on top of mock ECS service
-	return nil, errors.New("TODO: implement")
+	c.RegisterTaskDefinitionInput = in
+
+	if c.RegisterTaskDefinitionOutput != nil {
+		return c.RegisterTaskDefinitionOutput, nil
+	}
+
+	revisions := GlobalECSService.TaskDefs[utility.FromStringPtr(in.Family)]
+	rev := len(revisions) + 1
+
+	id := arn.ARN{
+		Partition: "aws",
+		Service:   "ecs",
+		Resource:  fmt.Sprintf("%s:%s", utility.FromStringPtr(in.Family), strconv.Itoa(rev)),
+	}
+
+	taskDef := ECSTaskDefinition{
+		ARN:        utility.ToStringPtr(id.String()),
+		Family:     in.Family,
+		Revision:   utility.ToInt64Ptr(int64(rev)),
+		CPU:        in.Cpu,
+		MemoryMB:   in.Memory,
+		TaskRole:   in.TaskRoleArn,
+		Tags:       map[string]string{},
+		Status:     utility.ToStringPtr(ecs.TaskDefinitionStatusActive),
+		Registered: utility.ToTimePtr(time.Now()),
+	}
+
+	for _, t := range in.Tags {
+		if t == nil {
+			continue
+		}
+		taskDef.Tags[utility.FromStringPtr(t.Key)] = utility.FromStringPtr(t.Value)
+	}
+	for _, def := range in.ContainerDefinitions {
+		containerDef := ECSContainerDefinition{
+			Name:     def.Name,
+			Image:    def.Image,
+			Command:  utility.FromStringPtrSlice(def.Command),
+			MemoryMB: def.Memory,
+			CPU:      def.Cpu,
+			EnvVars:  map[string]string{},
+			Secrets:  map[string]string{},
+		}
+		for _, s := range def.Secrets {
+			containerDef.EnvVars[utility.FromStringPtr(s.Name)] = utility.FromStringPtr(s.ValueFrom)
+		}
+		taskDef.ContainerDefs = append(taskDef.ContainerDefs, containerDef)
+	}
+
+	GlobalECSService.TaskDefs[utility.FromStringPtr(in.Family)] = append(revisions, taskDef)
+
+	return &ecs.RegisterTaskDefinitionOutput{
+		TaskDefinition: taskDef.export(),
+		Tags:           in.Tags,
+	}, nil
 }
 
 // DeregisterTaskDefinition saves the input and deletes an existing mock task
 // definition. The mock output can be customized. By default, it will delete a
 // cached task definition if it exists.
 func (c *ECSClient) DeregisterTaskDefinition(ctx context.Context, in *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error) {
-	return nil, errors.New("TODO: implement")
+	c.DeregisterTaskDefinitionInput = in
+
+	if c.DeregisterTaskDefinitionOutput != nil {
+		return c.DeregisterTaskDefinitionOutput, nil
+	}
+
+	id := utility.FromStringPtr(in.TaskDefinition)
+
+	var taskDef ECSTaskDefinition
+	if arn.IsARN(id) {
+		var found bool
+		for family, revisions := range GlobalECSService.TaskDefs {
+			for revNum, def := range revisions {
+				if utility.FromStringPtr(def.ARN) == id {
+					taskDef = def
+					taskDef.Status = utility.ToStringPtr(ecs.TaskDefinitionStatusInactive)
+					GlobalECSService.TaskDefs[family][revNum] = taskDef
+					break
+				}
+			}
+		}
+		if !found {
+			return nil, errors.New("resource not found")
+		}
+	} else {
+		splitIdx := strings.LastIndex(id, ":")
+		if splitIdx == -1 {
+			return nil, errors.New("malformed task definition input")
+		}
+
+		family := id[:splitIdx]
+
+		revNum, err := strconv.Atoi(id[splitIdx+1:])
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing revision")
+		}
+
+		revisions, ok := GlobalECSService.TaskDefs[family]
+		if !ok {
+			return nil, errors.New("family not found")
+		}
+		if len(revisions) < revNum {
+			return nil, errors.New("revision not found")
+		}
+
+		taskDef = revisions[revNum]
+		taskDef.Status = utility.ToStringPtr(ecs.TaskDefinitionStatusInactive)
+		GlobalECSService.TaskDefs[family][revNum] = taskDef
+	}
+
+	return &ecs.DeregisterTaskDefinitionOutput{
+		TaskDefinition: taskDef.export(),
+	}, nil
 }
 
 // ListTaskDefinitions saves the input and lists all matching task definitions.
 // The mock output can be customized. By default, it will list all cached task
 // definitions that match the input filters.
 func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDefinitionsInput) (*ecs.ListTaskDefinitionsOutput, error) {
-	return nil, errors.New("TODO: implement")
+	var arns []*string
+	for _, revisions := range GlobalECSService.TaskDefs {
+		for _, def := range revisions {
+			if in.FamilyPrefix != nil && utility.FromStringPtr(def.Family) != *in.FamilyPrefix {
+				continue
+			}
+			if in.Status != nil && utility.FromStringPtr(def.Status) != *in.Status {
+				continue
+			}
+
+			arns = append(arns, def.ARN)
+		}
+	}
+	return &ecs.ListTaskDefinitionsOutput{
+		TaskDefinitionArns: arns,
+	}, nil
 }
 
 // RunTask saves the input options and returns the mock result of running a task
@@ -115,5 +300,5 @@ func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.S
 // Close closes the mock client. The mock output can be customized. By default,
 // it is a no-op that returns no error.
 func (c *ECSClient) Close(ctx context.Context) error {
-	return errors.New("TODO: implement")
+	return nil
 }

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -7,22 +7,52 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
+// ECSCluster represents a mock ECS cluster running tasks.
+type ECSCluster map[string]ECSTask
+
+// ECSTask represents a mock ECS task.
 type ECSTask struct {
+	ID          string
+	Cluster     string
+	ExecEnabled bool
+	Tags        []string
 }
 
+// ECSTask represents a mock ECS task definition.
 type ECSTaskDefinition struct {
+	ID            string
+	ContainerDefs []ECSContainerDefinition
+	MemoryMB      int
+	CPU           int
+	TaskRole      string
+	Tags          []string
 }
 
+// ECSContainerDefinition represents a mock ECS container definition.
+type ECSContainerDefinition struct {
+	Name     string
+	Image    string
+	Command  []string
+	MemoryMB int
+	CPU      int
+	EnvVars  map[string]string
+	Secrets  map[string]string
+	Tags     []string
+}
+
+// ECSService represents an in-memory fake implementation of ECS for testing and
+// integration with the mock ECSClient.
 type ECSService struct {
-	Tasks    map[string]ECSTask
+	Clusters map[string]ECSCluster
 	TaskDefs map[string]ECSTaskDefinition
 }
 
+// GlobalECSService represents the global fake ECS service state.
 var GlobalECSService ECSService
 
 func init() {
 	GlobalECSService = ECSService{
-		Tasks:    map[string]ECSTask{},
+		Clusters: map[string]ECSCluster{},
 		TaskDefs: map[string]ECSTaskDefinition{},
 	}
 }
@@ -36,6 +66,7 @@ type ECSClient struct{}
 // definition. The mock output can be customized. By default, it will create a
 // cached task definition based on the input.
 func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
+	// kim: TODO: implement on top of mock ECS service
 	return nil, errors.New("TODO: implement")
 }
 

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -110,6 +110,7 @@ func (d *ECSContainerDefinition) export() *ecs.ContainerDefinition {
 		Memory:      d.MemoryMB,
 		Cpu:         d.CPU,
 		Environment: exportEnvVars(d.EnvVars),
+		Secrets:     exportSecrets(d.Secrets),
 	}
 }
 

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -14,18 +14,6 @@ import (
 	"github.com/evergreen-ci/utility"
 )
 
-// ECSCluster represents a mock ECS cluster running tasks in the global ECS
-// service.
-type ECSCluster map[string]ECSTask
-
-// ECSTask represents a mock ECS task.
-type ECSTask struct {
-	ARN         *string
-	Cluster     *string
-	ExecEnabled *bool
-	Tags        []string
-}
-
 // ECSTaskDefinition represents a mock ECS task definition in the global ECS service.
 type ECSTaskDefinition struct {
 	ARN           *string
@@ -40,11 +28,42 @@ type ECSTaskDefinition struct {
 	Registered    *time.Time
 }
 
+func newECSTaskDefinition(def *ecs.RegisterTaskDefinitionInput, rev int) ECSTaskDefinition {
+	id := arn.ARN{
+		Partition: "aws",
+		Service:   "ecs",
+		Resource:  fmt.Sprintf("task-definition:%s/%s", utility.FromStringPtr(def.Family), strconv.Itoa(rev)),
+	}
+
+	taskDef := ECSTaskDefinition{
+		ARN:        utility.ToStringPtr(id.String()),
+		Family:     def.Family,
+		Revision:   utility.ToInt64Ptr(int64(rev)),
+		CPU:        def.Cpu,
+		MemoryMB:   def.Memory,
+		TaskRole:   def.TaskRoleArn,
+		Status:     utility.ToStringPtr(ecs.TaskDefinitionStatusActive),
+		Registered: utility.ToTimePtr(time.Now()),
+	}
+
+	taskDef.Tags = newTags(def.Tags)
+
+	for _, containerDef := range def.ContainerDefinitions {
+		if containerDef == nil {
+			continue
+		}
+		taskDef.ContainerDefs = append(taskDef.ContainerDefs, newECSContainerDefinition(containerDef))
+	}
+
+	return taskDef
+}
+
 func (d *ECSTaskDefinition) export() *ecs.TaskDefinition {
 	var containerDefs []*ecs.ContainerDefinition
 	for _, def := range d.ContainerDefs {
 		containerDefs = append(containerDefs, def.export())
 	}
+
 	return &ecs.TaskDefinition{
 		TaskDefinitionArn:    d.ARN,
 		Family:               d.Family,
@@ -54,6 +73,7 @@ func (d *ECSTaskDefinition) export() *ecs.TaskDefinition {
 		TaskRoleArn:          d.TaskRole,
 		Status:               d.Status,
 		ContainerDefinitions: containerDefs,
+		RegisteredAt:         d.Registered,
 	}
 }
 
@@ -70,29 +90,201 @@ type ECSContainerDefinition struct {
 	Tags     map[string]string
 }
 
+func newECSContainerDefinition(def *ecs.ContainerDefinition) ECSContainerDefinition {
+	return ECSContainerDefinition{
+		Name:     def.Name,
+		Image:    def.Image,
+		Command:  utility.FromStringPtrSlice(def.Command),
+		MemoryMB: def.Memory,
+		CPU:      def.Cpu,
+		EnvVars:  newEnvVars(def.Environment),
+		Secrets:  newSecrets(def.Secrets),
+	}
+}
+
 func (d *ECSContainerDefinition) export() *ecs.ContainerDefinition {
-	var env []*ecs.KeyValuePair
-	for k, v := range d.EnvVars {
-		env = append(env, &ecs.KeyValuePair{
-			Name:  utility.ToStringPtr(k),
-			Value: utility.ToStringPtr(v),
-		})
-	}
-	var tags []*ecs.Tag
-	for k, v := range d.Tags {
-		tags = append(tags, &ecs.Tag{
-			Key:   utility.ToStringPtr(k),
-			Value: utility.ToStringPtr(v),
-		})
-	}
 	return &ecs.ContainerDefinition{
 		Name:        d.Name,
 		Image:       d.Image,
 		Command:     utility.ToStringPtrSlice(d.Command),
 		Memory:      d.MemoryMB,
 		Cpu:         d.CPU,
-		Environment: env,
+		Environment: exportEnvVars(d.EnvVars),
 	}
+}
+
+// ECSCluster represents a mock ECS cluster running tasks in the global ECS
+// service.
+type ECSCluster map[string]ECSTask
+
+// ECSTask represents a mock running ECS task within a cluster.
+type ECSTask struct {
+	ARN         *string
+	TaskDef     ECSTaskDefinition
+	Cluster     *string
+	Containers  []ECSContainer
+	ExecEnabled *bool
+	Status      *string
+	GoalStatus  *string
+	Tags        map[string]string
+}
+
+func newECSTask(in *ecs.RunTaskInput, taskDef ECSTaskDefinition) ECSTask {
+	id := arn.ARN{
+		Partition: "aws",
+		Service:   "ecs",
+		Resource:  fmt.Sprintf("task:%s/%s", utility.FromStringPtr(taskDef.Family), strconv.Itoa(int(utility.FromInt64Ptr(taskDef.Revision)))),
+	}
+
+	t := ECSTask{
+		ARN:         utility.ToStringPtr(id.String()),
+		Cluster:     in.Cluster,
+		ExecEnabled: in.EnableExecuteCommand,
+		Status:      utility.ToStringPtr(ecs.DesiredStatusRunning),
+		GoalStatus:  utility.ToStringPtr(ecs.DesiredStatusRunning),
+		TaskDef:     taskDef,
+		Tags:        newTags(in.Tags),
+	}
+
+	for _, containerDef := range taskDef.ContainerDefs {
+		t.Containers = append(t.Containers, newECSContainer(containerDef, t))
+	}
+
+	return t
+}
+
+func (t *ECSTask) export() *ecs.Task {
+	exported := ecs.Task{
+		TaskArn:           t.ARN,
+		ClusterArn:        t.Cluster,
+		Tags:              exportTags(t.Tags),
+		TaskDefinitionArn: t.TaskDef.ARN,
+		Cpu:               t.TaskDef.CPU,
+		Memory:            t.TaskDef.MemoryMB,
+		LastStatus:        t.Status,
+		DesiredStatus:     t.GoalStatus,
+	}
+
+	for _, container := range t.Containers {
+		exported.Containers = append(exported.Containers, container.export())
+	}
+
+	return &exported
+}
+
+// ECSContainer represents a mock running ECS container within a task.
+type ECSContainer struct {
+	ARN      *string
+	TaskARN  *string
+	Name     *string
+	Image    *string
+	CPU      *int64
+	MemoryMB *int64
+}
+
+func newECSContainer(def ECSContainerDefinition, task ECSTask) ECSContainer {
+	name := utility.FromStringPtr(def.Name)
+	if name == "" {
+		name = utility.RandomString()
+	}
+	id := arn.ARN{
+		Partition: "aws",
+		Service:   "ecs",
+		Resource:  fmt.Sprintf("container-definition:%s-%s/%s", utility.FromStringPtr(task.TaskDef.Family), name, strconv.Itoa(int(utility.FromInt64Ptr(task.TaskDef.Revision)))),
+	}
+
+	return ECSContainer{
+		ARN:      utility.ToStringPtr(id.String()),
+		TaskARN:  task.ARN,
+		Name:     def.Name,
+		Image:    def.Image,
+		CPU:      def.CPU,
+		MemoryMB: def.MemoryMB,
+	}
+}
+
+func (c *ECSContainer) export() *ecs.Container {
+	exported := &ecs.Container{
+		ContainerArn: c.ARN,
+		TaskArn:      c.TaskARN,
+		Name:         c.Name,
+		Image:        c.Image,
+	}
+
+	if c.CPU != nil {
+		exported.Cpu = utility.ToStringPtr(strconv.Itoa(int(utility.FromInt64Ptr(c.CPU))))
+	}
+	if c.MemoryMB != nil {
+		exported.Memory = utility.ToStringPtr(strconv.Itoa(int(utility.FromInt64Ptr(c.MemoryMB))))
+	}
+
+	return exported
+}
+
+func newTags(tags []*ecs.Tag) map[string]string {
+	converted := map[string]string{}
+	for _, t := range tags {
+		if t == nil {
+			continue
+		}
+		converted[utility.FromStringPtr(t.Key)] = utility.FromStringPtr(t.Value)
+	}
+	return converted
+}
+
+func exportTags(tags map[string]string) []*ecs.Tag {
+	var exported []*ecs.Tag
+	for k, v := range tags {
+		exported = append(exported, &ecs.Tag{
+			Key:   utility.ToStringPtr(k),
+			Value: utility.ToStringPtr(v),
+		})
+	}
+	return exported
+}
+
+func newEnvVars(envVars []*ecs.KeyValuePair) map[string]string {
+	converted := map[string]string{}
+	for _, envVar := range envVars {
+		if envVar == nil {
+			continue
+		}
+		converted[utility.FromStringPtr(envVar.Name)] = utility.FromStringPtr(envVar.Value)
+	}
+	return converted
+}
+
+func exportEnvVars(envVars map[string]string) []*ecs.KeyValuePair {
+	var exported []*ecs.KeyValuePair
+	for k, v := range envVars {
+		exported = append(exported, &ecs.KeyValuePair{
+			Name:  utility.ToStringPtr(k),
+			Value: utility.ToStringPtr(v),
+		})
+	}
+	return exported
+}
+
+func newSecrets(secrets []*ecs.Secret) map[string]string {
+	converted := map[string]string{}
+	for _, secret := range secrets {
+		if secret == nil {
+			continue
+		}
+		converted[utility.FromStringPtr(secret.Name)] = utility.FromStringPtr(secret.ValueFrom)
+	}
+	return converted
+}
+
+func exportSecrets(secrets map[string]string) []*ecs.Secret {
+	var exported []*ecs.Secret
+	for k, v := range secrets {
+		exported = append(exported, &ecs.Secret{
+			Name:      utility.ToStringPtr(k),
+			ValueFrom: utility.ToStringPtr(v),
+		})
+	}
+	return exported
 }
 
 // ECSService is a global implementation of ECS that provides a simplified
@@ -101,7 +293,6 @@ func (d *ECSContainerDefinition) export() *ecs.ContainerDefinition {
 // indirectly with the ECSClient to access or modify ECS resources, or used
 // directly.
 type ECSService struct {
-	// kim: TODO: need mutexes for multi-threaded?
 	Clusters map[string]ECSCluster
 	TaskDefs map[string][]ECSTaskDefinition
 }
@@ -125,6 +316,23 @@ type ECSClient struct {
 
 	DeregisterTaskDefinitionInput  *ecs.DeregisterTaskDefinitionInput
 	DeregisterTaskDefinitionOutput *ecs.DeregisterTaskDefinitionOutput
+
+	ListTaskDefinitionsInput  *ecs.ListTaskDefinitionsInput
+	ListTaskDefinitionsOutput *ecs.ListTaskDefinitionsOutput
+
+	RunTaskInput  *ecs.RunTaskInput
+	RunTaskOutput *ecs.RunTaskOutput
+
+	DescribeTasksInput  *ecs.DescribeTasksInput
+	DescribeTasksOutput *ecs.DescribeTasksOutput
+
+	ListTasksInput  *ecs.ListTasksInput
+	ListTasksOutput *ecs.ListTasksOutput
+
+	StopTaskInput  *ecs.StopTaskInput
+	StopTaskOutput *ecs.StopTaskOutput
+
+	CloseError error
 }
 
 // RegisterTaskDefinition saves the input and returns a new mock task
@@ -137,48 +345,14 @@ func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.Register
 		return c.RegisterTaskDefinitionOutput, nil
 	}
 
+	if in.Family == nil {
+		return nil, errors.New("missing family")
+	}
+
 	revisions := GlobalECSService.TaskDefs[utility.FromStringPtr(in.Family)]
 	rev := len(revisions) + 1
 
-	id := arn.ARN{
-		Partition: "aws",
-		Service:   "ecs",
-		Resource:  fmt.Sprintf("%s:%s", utility.FromStringPtr(in.Family), strconv.Itoa(rev)),
-	}
-
-	taskDef := ECSTaskDefinition{
-		ARN:        utility.ToStringPtr(id.String()),
-		Family:     in.Family,
-		Revision:   utility.ToInt64Ptr(int64(rev)),
-		CPU:        in.Cpu,
-		MemoryMB:   in.Memory,
-		TaskRole:   in.TaskRoleArn,
-		Tags:       map[string]string{},
-		Status:     utility.ToStringPtr(ecs.TaskDefinitionStatusActive),
-		Registered: utility.ToTimePtr(time.Now()),
-	}
-
-	for _, t := range in.Tags {
-		if t == nil {
-			continue
-		}
-		taskDef.Tags[utility.FromStringPtr(t.Key)] = utility.FromStringPtr(t.Value)
-	}
-	for _, def := range in.ContainerDefinitions {
-		containerDef := ECSContainerDefinition{
-			Name:     def.Name,
-			Image:    def.Image,
-			Command:  utility.FromStringPtrSlice(def.Command),
-			MemoryMB: def.Memory,
-			CPU:      def.Cpu,
-			EnvVars:  map[string]string{},
-			Secrets:  map[string]string{},
-		}
-		for _, s := range def.Secrets {
-			containerDef.EnvVars[utility.FromStringPtr(s.Name)] = utility.FromStringPtr(s.ValueFrom)
-		}
-		taskDef.ContainerDefs = append(taskDef.ContainerDefs, containerDef)
-	}
+	taskDef := newECSTaskDefinition(in, rev)
 
 	GlobalECSService.TaskDefs[utility.FromStringPtr(in.Family)] = append(revisions, taskDef)
 
@@ -198,59 +372,85 @@ func (c *ECSClient) DeregisterTaskDefinition(ctx context.Context, in *ecs.Deregi
 		return c.DeregisterTaskDefinitionOutput, nil
 	}
 
+	if in.TaskDefinition == nil {
+		return nil, errors.New("missing task definition")
+	}
+
 	id := utility.FromStringPtr(in.TaskDefinition)
 
-	var taskDef ECSTaskDefinition
 	if arn.IsARN(id) {
-		var found bool
-		for family, revisions := range GlobalECSService.TaskDefs {
-			for revNum, def := range revisions {
-				if utility.FromStringPtr(def.ARN) == id {
-					taskDef = def
-					taskDef.Status = utility.ToStringPtr(ecs.TaskDefinitionStatusInactive)
-					GlobalECSService.TaskDefs[family][revNum] = taskDef
-					break
-				}
-			}
-		}
+		family, revNum, found := taskDefIndexFromARN(id)
 		if !found {
-			return nil, errors.New("resource not found")
+			return nil, errors.New("task definition not found")
 		}
-	} else {
-		splitIdx := strings.LastIndex(id, ":")
-		if splitIdx == -1 {
-			return nil, errors.New("malformed task definition input")
-		}
-
-		family := id[:splitIdx]
-
-		revNum, err := strconv.Atoi(id[splitIdx+1:])
-		if err != nil {
-			return nil, errors.Wrap(err, "parsing revision")
-		}
-
-		revisions, ok := GlobalECSService.TaskDefs[family]
-		if !ok {
-			return nil, errors.New("family not found")
-		}
-		if len(revisions) < revNum {
-			return nil, errors.New("revision not found")
-		}
-
-		taskDef = revisions[revNum]
+		taskDef := GlobalECSService.TaskDefs[family][revNum-1]
 		taskDef.Status = utility.ToStringPtr(ecs.TaskDefinitionStatusInactive)
-		GlobalECSService.TaskDefs[family][revNum] = taskDef
+		GlobalECSService.TaskDefs[family][revNum-1] = taskDef
+
+		return &ecs.DeregisterTaskDefinitionOutput{
+			TaskDefinition: taskDef.export(),
+		}, nil
 	}
+
+	family, revNum, err := parseFamilyAndRevision(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid task definition")
+	}
+
+	revisions, ok := GlobalECSService.TaskDefs[family]
+	if !ok {
+		return nil, errors.New("family not found")
+	}
+	if len(revisions) < revNum {
+		return nil, errors.New("revision not found")
+	}
+
+	taskDef := revisions[revNum-1]
+	taskDef.Status = utility.ToStringPtr(ecs.TaskDefinitionStatusInactive)
+	GlobalECSService.TaskDefs[family][revNum-1] = taskDef
 
 	return &ecs.DeregisterTaskDefinitionOutput{
 		TaskDefinition: taskDef.export(),
 	}, nil
 }
 
+func parseFamilyAndRevision(taskDef string) (family string, revNum int, err error) {
+	partition := strings.LastIndex(taskDef, ":")
+	if partition == -1 {
+		return "", -1, errors.New("task definition is not in family:revision format")
+	}
+
+	family = taskDef[:partition]
+
+	revNum, err = strconv.Atoi(taskDef[partition+1:])
+	if err != nil {
+		return "", -1, errors.Wrap(err, "parsing revision")
+	}
+
+	return family, revNum, nil
+}
+
+func taskDefIndexFromARN(arn string) (family string, revNum int, found bool) {
+	for family, revisions := range GlobalECSService.TaskDefs {
+		for revIdx, def := range revisions {
+			if utility.FromStringPtr(def.ARN) == arn {
+				return family, revIdx + 1, true
+			}
+		}
+	}
+	return "", -1, false
+}
+
 // ListTaskDefinitions saves the input and lists all matching task definitions.
 // The mock output can be customized. By default, it will list all cached task
 // definitions that match the input filters.
 func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDefinitionsInput) (*ecs.ListTaskDefinitionsOutput, error) {
+	c.ListTaskDefinitionsInput = in
+
+	if c.ListTaskDefinitionsOutput != nil {
+		return c.ListTaskDefinitionsOutput, nil
+	}
+
 	var arns []*string
 	for _, revisions := range GlobalECSService.TaskDefs {
 		for _, def := range revisions {
@@ -264,6 +464,7 @@ func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDef
 			arns = append(arns, def.ARN)
 		}
 	}
+
 	return &ecs.ListTaskDefinitionsOutput{
 		TaskDefinitionArns: arns,
 	}, nil
@@ -273,32 +474,187 @@ func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDef
 // definition. The mock output can be customized. By default, it will create
 // mock output based on the input.
 func (c *ECSClient) RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
-	return nil, errors.New("TODO: implement")
+	c.RunTaskInput = in
+
+	if c.RunTaskOutput != nil {
+		return c.RunTaskOutput, nil
+	}
+
+	if in.TaskDefinition == nil {
+		return nil, errors.New("missing task definition")
+	}
+
+	clusterName := c.getOrDefaultCluster(in.Cluster)
+	cluster, ok := GlobalECSService.Clusters[clusterName]
+	if !ok {
+		return nil, errors.New("cluster not found")
+	}
+
+	taskDefID := utility.FromStringPtr(in.TaskDefinition)
+
+	if arn.IsARN(taskDefID) {
+		family, revNum, found := taskDefIndexFromARN(taskDefID)
+		if !found {
+			return nil, errors.New("task definition not found")
+		}
+		taskDef := GlobalECSService.TaskDefs[family][revNum-1]
+		task := newECSTask(in, taskDef)
+
+		cluster[utility.FromStringPtr(task.ARN)] = task
+
+		return &ecs.RunTaskOutput{
+			Tasks: []*ecs.Task{task.export()},
+		}, nil
+	}
+
+	family, revNum, err := parseFamilyAndRevision(taskDefID)
+
+	var taskDef ECSTaskDefinition
+	if err == nil {
+		revisions, ok := GlobalECSService.TaskDefs[family]
+		if !ok {
+			return nil, errors.New("task definition family not found")
+		}
+		if len(revisions) < revNum {
+			return nil, errors.New("task definition revision not found")
+		}
+
+		taskDef = revisions[revNum-1]
+	} else {
+		// Use the latest revision if none is specified.
+		family = taskDefID
+		revisions, ok := GlobalECSService.TaskDefs[family]
+		if !ok {
+			return nil, errors.New("task definition family not found")
+		}
+
+		revNum = len(revisions)
+		taskDef = revisions[revNum-1]
+	}
+
+	task := newECSTask(in, taskDef)
+
+	cluster[utility.FromStringPtr(task.ARN)] = task
+
+	return &ecs.RunTaskOutput{
+		Tasks: []*ecs.Task{task.export()},
+	}, nil
+}
+
+func (c *ECSClient) getOrDefaultCluster(name *string) string {
+	if name == nil {
+		return "default"
+	}
+	return *name
 }
 
 // DescribeTasks saves the input and returns information about the existing
 // tasks. The mock output can be customized. By default, it will describe all
 // cached tasks that match.
 func (c *ECSClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
-	return nil, errors.New("TODO: implement")
+	c.DescribeTasksInput = in
+
+	if c.DescribeTasksOutput != nil {
+		return c.DescribeTasksOutput, nil
+	}
+
+	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]
+	if !ok {
+		return nil, errors.New("cluster not found")
+	}
+
+	ids := utility.FromStringPtrSlice(in.Tasks)
+
+	var tasks []*ecs.Task
+	var failures []*ecs.Failure
+	for _, id := range ids {
+		task, ok := cluster[id]
+		if !ok {
+			failures = append(failures, &ecs.Failure{
+				Arn:    utility.ToStringPtr(id),
+				Reason: utility.ToStringPtr("task not found"),
+			})
+			continue
+		}
+
+		tasks = append(tasks, task.export())
+	}
+
+	return &ecs.DescribeTasksOutput{
+		Tasks:    tasks,
+		Failures: failures,
+	}, nil
 }
 
 // ListTasks saves the input and lists all matching tasks. The mock output can
 // be customized. By default, it will list all cached task definitions that
 // match the input filters.
 func (c *ECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
-	return nil, errors.New("TODO: implement")
+	c.ListTasksInput = in
+
+	if c.ListTasksOutput != nil {
+		return c.ListTasksOutput, nil
+	}
+
+	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]
+	if !ok {
+		return nil, errors.New("cluster not found")
+	}
+
+	var arns []string
+	for arn, task := range cluster {
+		if in.DesiredStatus != nil && utility.FromStringPtr(task.GoalStatus) != *in.DesiredStatus {
+			continue
+		}
+
+		if in.Family != nil && utility.FromStringPtr(task.TaskDef.Family) != *in.Family {
+			continue
+		}
+
+		arns = append(arns, arn)
+	}
+
+	return &ecs.ListTasksOutput{
+		TaskArns: utility.ToStringPtrSlice(arns),
+	}, nil
 }
 
 // StopTask saves the input and stops a mock task. The mock output can be
 // customized. By default, it will mark a cached task as stopped if it exists
 // and is running.
 func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.StopTaskOutput, error) {
-	return nil, errors.New("TODO: implement")
+	c.StopTaskInput = in
+
+	if c.StopTaskOutput != nil {
+		return c.StopTaskOutput, nil
+	}
+
+	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]
+	if !ok {
+		return nil, errors.New("cluster not found")
+	}
+
+	task, ok := cluster[utility.FromStringPtr(in.Task)]
+	if !ok {
+		return nil, errors.New("task not found")
+	}
+
+	task.Status = utility.ToStringPtr(ecs.DesiredStatusStopped)
+	task.GoalStatus = utility.ToStringPtr(ecs.DesiredStatusStopped)
+
+	cluster[utility.FromStringPtr(in.Task)] = task
+
+	return &ecs.StopTaskOutput{
+		Task: task.export(),
+	}, nil
 }
 
 // Close closes the mock client. The mock output can be customized. By default,
 // it is a no-op that returns no error.
 func (c *ECSClient) Close(ctx context.Context) error {
+	if c.CloseError != nil {
+		return c.CloseError
+	}
+
 	return nil
 }

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -7,6 +7,26 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
+type ECSTask struct {
+}
+
+type ECSTaskDefinition struct {
+}
+
+type ECSService struct {
+	Tasks    map[string]ECSTask
+	TaskDefs map[string]ECSTaskDefinition
+}
+
+var GlobalECSService ECSService
+
+func init() {
+	GlobalECSService = ECSService{
+		Tasks:    map[string]ECSTask{},
+		TaskDefs: map[string]ECSTaskDefinition{},
+	}
+}
+
 // ECSClient provides a mock implementation of a cocoa.ECSClient. This makes
 // it possible to introspect on inputs to the client and control the client's
 // output. It provides some default implementations where possible.

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -87,7 +87,6 @@ type ECSContainerDefinition struct {
 	CPU      *int64
 	EnvVars  map[string]string
 	Secrets  map[string]string
-	Tags     map[string]string
 }
 
 func newECSContainerDefinition(def *ecs.ContainerDefinition) ECSContainerDefinition {
@@ -518,9 +517,8 @@ func (c *ECSClient) RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.Run
 		}, nil
 	}
 
-	family, revNum, err := parseFamilyAndRevision(taskDefID)
-
 	var taskDef ECSTaskDefinition
+	family, revNum, err := parseFamilyAndRevision(taskDefID)
 	if err == nil {
 		revisions, ok := GlobalECSService.TaskDefs[family]
 		if !ok {
@@ -539,8 +537,7 @@ func (c *ECSClient) RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.Run
 			return nil, errors.New("task definition family not found")
 		}
 
-		revNum = len(revisions)
-		taskDef = revisions[revNum-1]
+		taskDef = revisions[len(revisions)-1]
 	}
 
 	task := newECSTask(in, taskDef)

--- a/mock/ecs_client_test.go
+++ b/mock/ecs_client_test.go
@@ -1,0 +1,212 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/cocoa/internal/testcase"
+	"github.com/evergreen-ci/cocoa/internal/testutil"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestECSClient(t *testing.T) {
+	assert.Implements(t, (*cocoa.ECSClient)(nil), &ECSClient{})
+
+	GlobalECSService.Clusters[testutil.ECSClusterName()] = ECSCluster{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := &ECSClient{}
+	defer func() {
+		assert.NoError(t, c.Close(ctx))
+	}()
+
+	for tName, tCase := range testcase.ECSClientTaskDefinitionTests() {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			defer tcancel()
+
+			tCase(tctx, t, c)
+		})
+	}
+
+	registerIn := &ecs.RegisterTaskDefinitionInput{
+		ContainerDefinitions: []*ecs.ContainerDefinition{
+			{
+				Command: []*string{aws.String("echo"), aws.String("foo")},
+				Image:   aws.String("busybox"),
+				Name:    aws.String("print_foo"),
+			},
+		},
+		Cpu:    aws.String("128"),
+		Memory: aws.String("4"),
+		Family: aws.String(testutil.NewTaskDefinitionFamily(t.Name())),
+	}
+
+	registerOut, err := c.RegisterTaskDefinition(ctx, registerIn)
+	require.NoError(t, err)
+	require.NotZero(t, registerOut)
+	require.NotZero(t, registerOut.TaskDefinition)
+
+	defer func() {
+		taskDefs := cleanupTaskDefinitions(ctx, t, c)
+		grip.InfoWhen(len(taskDefs) > 0, message.Fields{
+			"message":          "cleaned up leftover task definitions",
+			"task_definitions": taskDefs,
+			"test":             t.Name(),
+		})
+		tasks := cleanupTasks(ctx, t, c, taskDefs)
+		grip.InfoWhen(len(tasks) > 0, message.Fields{
+			"message": "cleaned up leftover running tasks",
+			"tasks":   tasks,
+			"test":    t.Name(),
+		})
+		require.NoError(t, c.Close(ctx))
+	}()
+
+	for tName, tCase := range testcase.ECSClientRegisteredTaskDefinitionTests(*registerIn, *registerOut) {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			defer tcancel()
+
+			tCase(tctx, t, c)
+		})
+	}
+}
+
+// cleanupTaskDefinitions cleans up all existing task definitions for testing
+// teardown.
+func cleanupTaskDefinitions(ctx context.Context, t *testing.T, c cocoa.ECSClient) []string {
+	out, err := c.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
+		Status: aws.String(ecs.TaskDefinitionStatusActive),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, out)
+
+	var taskDefs []string
+
+	for _, arn := range out.TaskDefinitionArns {
+		if arn == nil {
+			continue
+		}
+		taskDefArn := *arn
+		// Ignore task definitions that were not generated with testutil.NewTaskDefinitionFamily.
+		name := strings.Join([]string{testutil.TaskDefinitionPrefix(), "cocoa", t.Name()}, "-")
+		if !strings.Contains(taskDefArn, name) {
+			continue
+		}
+		taskDefs = append(taskDefs, *arn)
+		_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
+			TaskDefinition: arn,
+		})
+		assert.NoError(t, err)
+	}
+
+	return taskDefs
+}
+
+// cleanupTasks cleans up all tasks for testing teardown. It only cleans up
+// tasks if they are running and are created from one of the given task
+// definitions.
+func cleanupTasks(ctx context.Context, t *testing.T, c cocoa.ECSClient, taskDefs []string) []string {
+	out, err := c.ListTasks(ctx, &ecs.ListTasksInput{
+		Cluster: aws.String(testutil.ECSClusterName()),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, out)
+
+	if len(out.TaskArns) == 0 {
+		return nil
+	}
+
+	describeOut, err := c.DescribeTasks(ctx, &ecs.DescribeTasksInput{
+		Cluster: aws.String(testutil.ECSClusterName()),
+		Tasks:   out.TaskArns,
+	})
+	require.NoError(t, err)
+
+	var tasks []string
+	for _, task := range describeOut.Tasks {
+		if task == nil {
+			continue
+		}
+
+		if task.TaskDefinitionArn == nil {
+			grip.Notice(message.Fields{
+				"message": "cannot check task for test teardown because it does not have a task definition ARN",
+				"context": "cocoa test teardown",
+				"task":    *task,
+				"test":    t.Name(),
+			})
+			continue
+		}
+		// Ignore tasks started by task definitions outside of the cocoa testing
+		// environment.
+		if taskDef := *task.TaskDefinitionArn; !utility.StringSliceContains(taskDefs, taskDef) {
+			continue
+		}
+
+		if task.LastStatus == nil {
+			grip.Notice(message.Fields{
+				"message": "cannot check task for test teardown because it does not have a status",
+				"context": "cocoa test teardown",
+				"task":    *task,
+				"test":    t.Name(),
+			})
+			continue
+		}
+
+		status := *task.LastStatus
+		switch status {
+		case "PROVISIONING", "PENDING", "ACTIVATING":
+			grip.Notice(message.Fields{
+				"message": "cannot stop the task because it is in an unstoppable state",
+				"context": "cocoa test teardown",
+				"status":  status,
+				"task":    *task,
+				"test":    t.Name(),
+			})
+			continue
+		case "RUNNING":
+			if task.DesiredStatus != nil && *task.DesiredStatus == "STOPPED" {
+				continue
+			}
+			if task.TaskArn == nil {
+				grip.Notice(message.Fields{
+					"message": "cannot stop the task because it is missing a task ARN",
+					"context": "cocoa test teardown",
+					"status":  status,
+					"task":    *task,
+					"test":    t.Name(),
+				})
+				continue
+			}
+			_, err := c.StopTask(ctx, &ecs.StopTaskInput{
+				Cluster: aws.String(testutil.ECSClusterName()),
+				Reason:  aws.String(fmt.Sprintf("cocoa test teardown for test '%s'", t.Name())),
+				Task:    task.TaskArn,
+			})
+			if assert.NoError(t, err) {
+				tasks = append(tasks, *task.TaskArn)
+			}
+		case "DEACTIVATING", "STOPPING", "DEPROVISIONING", "STOPPED":
+			continue
+		default:
+			assert.Fail(t, "unrecognized task status '%s'", status)
+		}
+
+	}
+
+	return tasks
+}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -10,7 +10,6 @@ import (
 func TestInterfaces(t *testing.T) {
 	assert.Implements(t, (*cocoa.ECSPodCreator)(nil), &ECSPodCreator{})
 	assert.Implements(t, (*cocoa.ECSPod)(nil), &ECSPod{})
-	assert.Implements(t, (*cocoa.ECSClient)(nil), &ECSClient{})
 
 	assert.Implements(t, (*cocoa.Vault)(nil), &Vault{})
 }

--- a/mock/secrets_manager_client.go
+++ b/mock/secrets_manager_client.go
@@ -19,8 +19,9 @@ type StoredSecret struct {
 }
 
 // GlobalSecretCache is a global secret storage cache that provides a simplified
-// in-memory implementation of a secrets storage service. This can be used with
-// the SecretsManagerClient to access and modify secrets, or used directly.
+// in-memory implementation of a secrets storage service. This can be used
+// indirectly with the SecretsManagerClient to access and modify secrets, or
+// used directly.
 var GlobalSecretCache map[string]StoredSecret
 
 func init() {

--- a/mock/secrets_manager_client_test.go
+++ b/mock/secrets_manager_client_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
-	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,14 +18,13 @@ func TestSecretsManagerClient(t *testing.T) {
 
 	for tName, tCase := range testcase.SecretsManagerClientTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, time.Second)
 			defer tcancel()
 
-			hc := utility.GetHTTPClient()
-			defer utility.PutHTTPClient(hc)
-
 			c := &SecretsManagerClient{}
-			defer c.Close(tctx)
+			defer func() {
+				assert.NoError(t, c.Close(tctx))
+			}()
 
 			tCase(tctx, t, c)
 		})

--- a/vendor/github.com/evergreen-ci/utility/optional.go
+++ b/vendor/github.com/evergreen-ci/utility/optional.go
@@ -64,6 +64,34 @@ func FromIntPtr(in *int) int {
 	return *in
 }
 
+// ToInt64Ptr returns a pointer to an int64 value.
+func ToInt64Ptr(in int64) *int64 {
+	return &in
+}
+
+// FromInt64Ptr returns the resolved int64 value from the input int64 pointer.
+// For nil pointers, it returns 0.
+func FromInt64Ptr(in *int64) int64 {
+	if in == nil {
+		return 0
+	}
+	return *in
+}
+
+// ToInt32Ptr returns a pointer to an int32 value.
+func ToInt32Ptr(in int32) *int32 {
+	return &in
+}
+
+// FromInt32Ptr returns the resolved int32 value from the input int32 pointer.
+// For nil pointers, it returns 0.
+func FromInt32Ptr(in *int32) int32 {
+	if in == nil {
+		return 0
+	}
+	return *in
+}
+
 // ToUintPtr returns a pointer to a uint value.
 func ToUintPtr(in uint) *uint {
 	return &in


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14860

* Implement mock ECS service that just stores payloads in some in-memory data structures.
* Implement mock ECS client that stores input and returns stub output if specified. Otherwise, it interacts with the mock ECS service to access/modify the stored metadata about tasks. 
* Test the mock ECS client against the same tests as the real implementation to verify correctness.
* Upgrade github.com/evergreen-ci/utility.