### PR TITLE
EVG-14857: implement mock vault

### DIFF
--- a/internal/testcase/secrets_manager_vault.go
+++ b/internal/testcase/secrets_manager_vault.go
@@ -1,0 +1,90 @@
+package testcase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/cocoa/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// VaultTestCase represents a test case for a cocoa.Vault.
+type VaultTestCase func(ctx context.Context, t *testing.T, v cocoa.Vault)
+
+// VaultTests returns common test cases that a cocoa.Vault should support.
+func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Vault, id string)) map[string]VaultTestCase {
+	return map[string]VaultTestCase{
+		"CreateSecretFailsWithInvalidInput": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			id, err := v.CreateSecret(ctx, cocoa.NamedSecret{})
+			assert.Error(t, err)
+			assert.Zero(t, id)
+		},
+		"DeleteSecretFailsWithInvalidInput": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			assert.Error(t, v.DeleteSecret(ctx, ""))
+		},
+		"DeleteSecretWithExistingSecretSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			out, err := v.CreateSecret(ctx, cocoa.NamedSecret{
+				Name:  aws.String(testutil.NewSecretName(t.Name())),
+				Value: aws.String("hello")})
+
+			require.NoError(t, err)
+			require.NotZero(t, out)
+
+			defer cleanupSecret(ctx, t, v, out)
+		},
+		"GetValueFailsWithInvalidInput": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			out, err := v.GetValue(ctx, "")
+			assert.Error(t, err)
+			assert.Zero(t, out)
+		},
+		"UpdateFailsWithInvalidInput": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			assert.Error(t, v.UpdateValue(ctx, *cocoa.NewNamedSecret().SetName("").SetValue("")))
+		},
+		"GetValueWithExistingSecretSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			id, err := v.CreateSecret(ctx, cocoa.NamedSecret{
+				Name:  aws.String(testutil.NewSecretName(t.Name())),
+				Value: aws.String("eggs")})
+
+			require.NoError(t, err)
+			require.NotZero(t, id)
+
+			defer cleanupSecret(ctx, t, v, id)
+
+			val, err := v.GetValue(ctx, id)
+			require.NoError(t, err)
+			require.NotZero(t, val)
+			assert.Equal(t, "eggs", val)
+		},
+		"UpdateValueSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			id, err := v.CreateSecret(ctx, cocoa.NamedSecret{
+				Name:  aws.String(testutil.NewSecretName(t.Name())),
+				Value: aws.String("eggs"),
+			})
+			require.NoError(t, err)
+			require.NotZero(t, id)
+
+			defer cleanupSecret(ctx, t, v, id)
+
+			require.NoError(t, v.UpdateValue(ctx, *cocoa.NewNamedSecret().SetName(id).SetValue("ham")))
+
+			val, err := v.GetValue(ctx, id)
+			require.NoError(t, err)
+			require.NotZero(t, val)
+			assert.Equal(t, "ham", val)
+		},
+		"DeleteSecretWithValidNonexistentInputWillNoop": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			assert.NoError(t, v.DeleteSecret(ctx, testutil.NewSecretName(t.Name())))
+		},
+		"GetValueWithValidNonexistentInputFails": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			out, err := v.GetValue(ctx, testutil.NewSecretName(t.Name()))
+			assert.Error(t, err)
+			assert.Zero(t, out)
+		},
+		"UpdateValueWithValidNonexistentInputFails": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			assert.Error(t, v.UpdateValue(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue("leaf")))
+		},
+	}
+}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -10,6 +10,4 @@ import (
 func TestInterfaces(t *testing.T) {
 	assert.Implements(t, (*cocoa.ECSPodCreator)(nil), &ECSPodCreator{})
 	assert.Implements(t, (*cocoa.ECSPod)(nil), &ECSPod{})
-
-	assert.Implements(t, (*cocoa.Vault)(nil), &Vault{})
 }

--- a/mock/secrets_manager_vault_test.go
+++ b/mock/secrets_manager_vault_test.go
@@ -1,0 +1,41 @@
+package mock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/cocoa/internal/testcase"
+	"github.com/evergreen-ci/cocoa/secret"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVaultWithSecretsManager(t *testing.T) {
+	assert.Implements(t, (*cocoa.Vault)(nil), &Vault{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cleanupSecret := func(ctx context.Context, t *testing.T, v cocoa.Vault, id string) {
+		if id != "" {
+			require.NoError(t, v.DeleteSecret(ctx, id))
+		}
+	}
+
+	for tName, tCase := range testcase.VaultTests(cleanupSecret) {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			defer tcancel()
+
+			c := &SecretsManagerClient{}
+			defer func() {
+				assert.NoError(t, c.Close(ctx))
+			}()
+			v := NewVault(secret.NewBasicSecretsManager(c))
+
+			tCase(tctx, t, v)
+		})
+	}
+}

--- a/mock/vault.go
+++ b/mock/vault.go
@@ -2,40 +2,75 @@ package mock
 
 import (
 	"context"
-	"errors"
 
 	"github.com/evergreen-ci/cocoa"
 )
 
-// Vault provides a mock implementation of a cocoa.Vault. This makes it
-// possible to introspect on inputs to the vault and control the vault's output.
-// It provides some default implementations where possible.
-type Vault struct{}
+// Vault provides a mock implementation of a cocoa.Vault backed by any vault by
+// default. This makes it possible to introspect on inputs to the vault and
+// control the vault's output. It provides some default implementations where
+// possible.
+type Vault struct {
+	cocoa.Vault
+
+	CreateSecretInput  *cocoa.NamedSecret
+	CreateSecretOutput *string
+
+	GetValueInput  *string
+	GetValueOutput *string
+
+	UpdateValueInput *cocoa.NamedSecret
+
+	DeleteSecretInput *string
+}
+
+// NewVault creates a mock Vault backed by the given Vault.
+func NewVault(v cocoa.Vault) *Vault {
+	return &Vault{
+		Vault: v,
+	}
+}
 
 // CreateSecret saves the input options and returns a mock secret ID. The mock
-// output can be customized. By default, it will create a cached mock secret
-// based on the input.
+// output can be customized. By default, it will call the backing Vault
+// implementation's CreateSecret.
 func (m *Vault) CreateSecret(ctx context.Context, s cocoa.NamedSecret) (id string, err error) {
-	return "", errors.New("TODO: implement")
+	m.CreateSecretInput = &s
+
+	if m.CreateSecretOutput != nil {
+		return *m.CreateSecretOutput, nil
+	}
+
+	return m.Vault.CreateSecret(ctx, s)
 }
 
 // GetValue saves the input options and returns an existing mock secret's value.
-// The mock output can be customized. By default, it will return a cached mock
-// secret's value if it exists.
+// The mock output can be customized. By default, it will call the backing Vault
+// implementation's GetValue.
 func (m *Vault) GetValue(ctx context.Context, id string) (val string, err error) {
-	return "", errors.New("TODO: implement")
+	m.GetValueInput = &id
+
+	if m.GetValueOutput != nil {
+		return *m.GetValueOutput, nil
+	}
+
+	return m.Vault.GetValue(ctx, id)
 }
 
 // UpdateValue saves the input options and updates an existing mock secret. The
-// mock output can be customized. By default, it will update a cached mock
-// secret if it exists.
-func (m *Vault) UpdateValue(ctx context.Context, id, val string) error {
-	return errors.New("TODO: implement")
+// mock output can be customized. By default, it will call the backing Vault
+// implementation's UpdateValue.
+func (m *Vault) UpdateValue(ctx context.Context, s cocoa.NamedSecret) error {
+	m.UpdateValueInput = &s
+
+	return m.Vault.UpdateValue(ctx, s)
 }
 
 // DeleteSecret saves the input options and deletes an existing mock secret. The
-// mock output can be customized. By default, it will delete a cached mock
-// secret if it exists.
+// mock output can be customized. By default, it will call the backing Vault
+// implementation's DeleteSecret.
 func (m *Vault) DeleteSecret(ctx context.Context, id string) error {
-	return errors.New("TODO: implement")
+	m.DeleteSecretInput = &id
+
+	return m.Vault.DeleteSecret(ctx, id)
 }

--- a/secret/secrets_manager_client.go
+++ b/secret/secrets_manager_client.go
@@ -196,6 +196,8 @@ func (c *BasicSecretsManagerClient) isNonRetryableErrorCode(code string) bool {
 	case "AccessDeniedException",
 		secretsmanager.ErrCodeInvalidParameterException,
 		secretsmanager.ErrCodeInvalidRequestException,
+		secretsmanager.ErrCodeResourceNotFoundException,
+		secretsmanager.ErrCodeResourceExistsException,
 		request.InvalidParameterErrCode,
 		request.ParamRequiredErrCode:
 		return true

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/awsutil"
+	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
@@ -25,94 +26,13 @@ func TestSecretsManager(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cleanupSecret := func(ctx context.Context, t *testing.T, m *BasicSecretsManager, id string) {
+	cleanupSecret := func(ctx context.Context, t *testing.T, v cocoa.Vault, id string) {
 		if id != "" {
-			require.NoError(t, m.DeleteSecret(ctx, id))
+			require.NoError(t, v.DeleteSecret(ctx, id))
 		}
 	}
 
-	for tName, tCase := range map[string]func(context.Context, *testing.T, *BasicSecretsManager){
-		"CreateFailsWithInvalidInput": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			out, err := m.CreateSecret(ctx, cocoa.NamedSecret{})
-			assert.Error(t, err)
-			assert.Zero(t, out)
-		},
-		"DeleteFailsWithInvalidInput": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			err := m.DeleteSecret(ctx, "")
-			assert.Error(t, err)
-		},
-		"DeleteSecretWithExistingSecretSucceeds": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			out, err := m.CreateSecret(ctx, cocoa.NamedSecret{
-				Name:  aws.String(testutil.NewSecretName(t.Name())),
-				Value: aws.String("hello")})
-
-			require.NoError(t, err)
-			require.NotZero(t, out)
-
-			defer cleanupSecret(ctx, t, m, out)
-		},
-		"GetValueFailsWithInvalidInput": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			out, err := m.GetValue(ctx, "")
-			assert.Error(t, err)
-			assert.Zero(t, out)
-		},
-		"UpdateFailsWithInvalidInput": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			err := m.UpdateValue(ctx, "", "")
-			assert.Error(t, err)
-		},
-		"GetValueWithExistingSecretSucceeds": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			out, err := m.CreateSecret(ctx, cocoa.NamedSecret{
-				Name:  aws.String(testutil.NewSecretName(t.Name())),
-				Value: aws.String("eggs")})
-
-			require.NoError(t, err)
-			require.NotZero(t, out)
-
-			defer cleanupSecret(ctx, t, m, out)
-
-			if out != "" {
-				out, err := m.GetValue(ctx, out)
-				require.NoError(t, err)
-				require.NotZero(t, out)
-				assert.Equal(t, "eggs", out)
-			}
-		},
-		"UpdateValueSucceeds": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			out, err := m.CreateSecret(ctx, cocoa.NamedSecret{
-				Name:  aws.String(testutil.NewSecretName(t.Name())),
-				Value: aws.String("eggs"),
-			})
-			require.NoError(t, err)
-			require.NotZero(t, out)
-
-			defer cleanupSecret(ctx, t, m, out)
-
-			if out != "" {
-				err := m.UpdateValue(ctx, out, "ham")
-				require.NoError(t, err)
-			}
-
-			if out != "" {
-				out, err := m.GetValue(ctx, out)
-				require.NoError(t, err)
-				require.NotZero(t, out)
-				assert.Equal(t, "ham", out)
-			}
-		},
-		"DeleteSecretWithValidNonexistentInputWillNoop": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			err := m.DeleteSecret(ctx, testutil.NewSecretName(t.Name()))
-			assert.NoError(t, err)
-		},
-		"GetValueWithValidNonexistentInputFails": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			out, err := m.GetValue(ctx, testutil.NewSecretName(t.Name()))
-			assert.Error(t, err)
-			assert.Zero(t, out)
-		},
-		"UpdateValueWithValidNonexistentInputFails": func(ctx context.Context, t *testing.T, m *BasicSecretsManager) {
-			err := m.UpdateValue(ctx, testutil.NewSecretName(t.Name()), "leaf")
-			assert.Error(t, err)
-		},
-	} {
+	for tName, tCase := range testcase.VaultTests(cleanupSecret) {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
 			defer tcancel()

--- a/vault.go
+++ b/vault.go
@@ -14,14 +14,15 @@ type Vault interface {
 	// GetValue returns the value of the secret identified by ID.
 	GetValue(ctx context.Context, id string) (val string, err error)
 	// UpdateValue updates an existing secret's value by ID.
-	UpdateValue(ctx context.Context, id, val string) error
+	UpdateValue(ctx context.Context, s NamedSecret) error
 	// DeleteSecret deletes a secret by ID.
 	DeleteSecret(ctx context.Context, id string) error
 }
 
 // NamedSecret represents a secret with a name.
 type NamedSecret struct {
-	// Name is the friendly human-readable name of the secret.
+	// Name is either the friendly human-readable name to assign to the secret
+	// or the resource name.
 	Name *string
 	// Value is the stored value of the secret.
 	Value *string


### PR DESCRIPTION
JIra: https://jira.mongodb.org/browse/EVG-14857

* Implement a mock Vault which can be backed by any other Vault implementation by default. In my case, I just tested the mock using the actual Secrets Manager Vault implementation with a mock Secrets Manager client to fake out the actual Secrets Manager service.
* Refactor Secrets Manager Vault tests into the common testcase package.
* Make some minor error-checking fixes to the Secrets Manager Vault implementation.