### PR TITLE
EVG-15027: fix up miscellaneous minor issues

### DIFF
--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -21,11 +21,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestECSClientInterface(t *testing.T) {
-	assert.Implements(t, (*cocoa.ECSClient)(nil), &BasicECSClient{})
-}
-
 func TestECSClient(t *testing.T) {
+	assert.Implements(t, (*cocoa.ECSClient)(nil), &BasicECSClient{})
+
 	testutil.CheckAWSEnvVarsForECS(t)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/ecs/pod.go
+++ b/ecs/pod.go
@@ -126,8 +126,8 @@ func (p *BasicECSPod) Info(ctx context.Context) (*cocoa.ECSPodInfo, error) {
 // Stop stops the running pod without cleaning up any of its underlying
 // resources.
 func (p *BasicECSPod) Stop(ctx context.Context) error {
-	if p.status != cocoa.Running {
-		return errors.Errorf("pod can only be stopped when status is '%s', but current status is '%s'", cocoa.Running, p.status)
+	if p.status != cocoa.RunningStatus {
+		return errors.Errorf("pod can only be stopped when status is '%s', but current status is '%s'", cocoa.RunningStatus, p.status)
 	}
 
 	stopTask := &ecs.StopTaskInput{}
@@ -137,7 +137,7 @@ func (p *BasicECSPod) Stop(ctx context.Context) error {
 		return errors.Wrap(err, "stopping pod")
 	}
 
-	p.status = cocoa.Stopped
+	p.status = cocoa.StoppedStatus
 
 	return nil
 }
@@ -165,7 +165,7 @@ func (p *BasicECSPod) Delete(ctx context.Context) error {
 		}
 	}
 
-	p.status = cocoa.Deleted
+	p.status = cocoa.DeletedStatus
 
 	return nil
 }

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -90,7 +90,7 @@ func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPo
 	options := NewBasicECSPodOptions().
 		SetClient(m.client).
 		SetVault(m.vault).
-		SetStatus(cocoa.Running).
+		SetStatus(cocoa.RunningStatus).
 		SetResources(*resources)
 
 	p, err := NewBasicECSPod(options)
@@ -133,8 +133,9 @@ func (m *BasicECSPodCreator) createSecrets(ctx context.Context, secrets []cocoa.
 			if err != nil {
 				return err
 			}
+			// Pods must use the secret's ARN once the secret is created
+			// because that uniquely identifies the resource.
 			secret.SetName(arn)
-			secret.PodSecret.SetName(arn)
 		}
 	}
 

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -17,11 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestECSPodCreatorInterface(t *testing.T) {
-	assert.Implements(t, (*cocoa.ECSPodCreator)(nil), &BasicECSPodCreator{})
-}
-
 func TestBasicECSPodCreator(t *testing.T) {
+	assert.Implements(t, (*cocoa.ECSPodCreator)(nil), &BasicECSPodCreator{})
+
 	testutil.CheckAWSEnvVarsForECSAndSecretsManager(t)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -17,11 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestECSPodInterface(t *testing.T) {
+func TestBasicECSPod(t *testing.T) {
 	assert.Implements(t, (*cocoa.ECSPod)(nil), &BasicECSPod{})
-}
 
-func TestECSPodBasics(t *testing.T) {
 	testutil.CheckAWSEnvVarsForECSAndSecretsManager(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -79,7 +77,7 @@ func TestECSPod(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	for tName, tCase := range testcase.ECSPodTests(t) {
+	for tName, tCase := range testcase.ECSPodTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
 			defer tcancel()

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -36,7 +36,7 @@ func TestECSPodBasics(t *testing.T) {
 		},
 		"InfoIsPopulated": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			res := cocoa.NewECSPodResources().SetTaskID("task_id")
-			stat := cocoa.Starting
+			stat := cocoa.StartingStatus
 			opts := NewBasicECSPodOptions().SetClient(c).SetResources(*res).SetStatus(stat)
 
 			p, err := NewBasicECSPod(opts)
@@ -79,7 +79,7 @@ func TestECSPod(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	for tName, tCase := range testcase.ECSPodTests() {
+	for tName, tCase := range testcase.ECSPodTests(t) {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
 			defer tcancel()
@@ -148,7 +148,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 		assert.Equal(t, *res, *opts.Resources)
 	})
 	t.Run("SetStatus", func(t *testing.T) {
-		stat := cocoa.Starting
+		stat := cocoa.StartingStatus
 		opts := NewBasicECSPodOptions().SetStatus(stat)
 		require.NotNil(t, opts.Status)
 		assert.Equal(t, stat, *opts.Status)
@@ -170,7 +170,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetClient(ecsClient).
 				SetVault(v).
 				SetResources(*res).
-				SetStatus(cocoa.Starting)
+				SetStatus(cocoa.StartingStatus)
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("MissingClientIsInvalid", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
 				SetResources(*res).
-				SetStatus(cocoa.Starting)
+				SetStatus(cocoa.StartingStatus)
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("MissingVaultIsValid", func(t *testing.T) {
@@ -193,7 +193,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			opts := NewBasicECSPodOptions().
 				SetClient(ecsClient).
 				SetResources(*res).
-				SetStatus(cocoa.Starting)
+				SetStatus(cocoa.StartingStatus)
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("MissingResourcesIsInvalid", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
 				SetResources(*res).
-				SetStatus(cocoa.Starting)
+				SetStatus(cocoa.StartingStatus)
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("BadResourcesIsInvalid", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			v := secret.NewBasicSecretsManager(smClient)
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
-				SetStatus(cocoa.Starting)
+				SetStatus(cocoa.StartingStatus)
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("MissingStatusIsInvalid", func(t *testing.T) {

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -105,22 +105,22 @@ func (s *PodSecret) SetOwned(owned bool) *PodSecret {
 type ECSPodStatus string
 
 const (
-	// Starting indicates that the ECS pod is being prepared to run.
-	Starting ECSPodStatus = "starting"
-	// Running indicates that the ECS pod is actively running.
-	Running ECSPodStatus = "running"
-	// Stopped indicates the that ECS pod is stopped, but all of its resources
-	// are still available.
-	Stopped ECSPodStatus = "stopped"
-	// Deleted indicates that the ECS pod has been cleaned up completely,
+	// StartingStatus indicates that the ECS pod is being prepared to run.
+	StartingStatus ECSPodStatus = "starting"
+	// RunningStatus indicates that the ECS pod is actively running.
+	RunningStatus ECSPodStatus = "running"
+	// StoppedStatus indicates the that ECS pod is stopped, but all of its
+	// resources are still available.
+	StoppedStatus ECSPodStatus = "stopped"
+	// DeletedStatus indicates that the ECS pod has been cleaned up completely,
 	// including all of its resources.
-	Deleted ECSPodStatus = "deleted"
+	DeletedStatus ECSPodStatus = "deleted"
 )
 
 // Validate checks that the ECS pod status is one of the recognized statuses.
 func (s ECSPodStatus) Validate() error {
 	switch s {
-	case Starting, Running, Stopped, Deleted:
+	case StartingStatus, RunningStatus, StoppedStatus, DeletedStatus:
 		return nil
 	default:
 		return errors.Errorf("unrecognized status '%s'", s)

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -454,6 +454,12 @@ func (s *SecretOptions) SetExists(exists bool) *SecretOptions {
 	return s
 }
 
+// SetOwned returns whether or not the secret is owned by its pod.
+func (s *SecretOptions) SetOwned(owned bool) *SecretOptions {
+	s.Owned = &owned
+	return s
+}
+
 // Validate validates that the secret name is given and that either the secret
 // already exists or the new secret's value is given.
 func (s *SecretOptions) Validate() error {
@@ -684,7 +690,7 @@ func (d *ECSTaskDefinition) SetID(id string) *ECSTaskDefinition {
 	return d
 }
 
-// SetOwned sets if the task definition should be owned by its pod.
+// SetOwned sets if the task definition is owned by its pod.
 func (d *ECSTaskDefinition) SetOwned(owned bool) *ECSTaskDefinition {
 	d.Owned = &owned
 	return d

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -396,7 +396,7 @@ func TestSecretOptions(t *testing.T) {
 	})
 	t.Run("SetOwned", func(t *testing.T) {
 		opts := NewSecretOptions().SetOwned(true)
-		assert.True(t, utility.FromBoolPtr(opts.Exists))
+		assert.True(t, utility.FromBoolPtr(opts.Owned))
 	})
 }
 

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -394,6 +394,10 @@ func TestSecretOptions(t *testing.T) {
 		opts := NewSecretOptions().SetExists(true)
 		assert.True(t, utility.FromBoolPtr(opts.Exists))
 	})
+	t.Run("SetOwned", func(t *testing.T) {
+		opts := NewSecretOptions().SetOwned(true)
+		assert.True(t, utility.FromBoolPtr(opts.Exists))
+	})
 }
 
 func TestECSPodExecutionOptions(t *testing.T) {

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -14,9 +14,9 @@ import (
 type ECSPodTestCase func(ctx context.Context, t *testing.T, v cocoa.Vault, pc cocoa.ECSPodCreator)
 
 // ECSPodTests returns common test cases that a cocoa.ECSPod should support.
-func ECSPodTests() map[string]ECSPodTestCase {
+func ECSPodTests(t *testing.T) map[string]ECSPodTestCase {
 
-	envVar := cocoa.NewEnvironmentVariable().SetName("name").SetValue("value")
+	envVar := cocoa.NewEnvironmentVariable().SetName(t.Name()).SetValue("value")
 
 	containerDef := cocoa.NewECSContainerDefinition().
 		SetImage("image").
@@ -30,7 +30,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 		SetExecutionRole(testutil.ExecutionRole())
 
 	opts := cocoa.NewECSPodCreationOptions().
-		SetName(testutil.NewTaskDefinitionFamily("name")).
+		SetName(testutil.NewTaskDefinitionFamily(t.Name())).
 		AddContainerDefinitions(*containerDef).
 		SetMemoryMB(128).
 		SetCPU(128).
@@ -38,7 +38,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 		SetExecutionOptions(*execOpts)
 
 	optsSecret := cocoa.NewECSPodCreationOptions().
-		SetName(testutil.NewTaskDefinitionFamily("name")).
+		SetName(testutil.NewTaskDefinitionFamily(t.Name())).
 		SetMemoryMB(128).
 		SetCPU(128).
 		SetTaskRole(testutil.TaskRole()).
@@ -55,14 +55,13 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.Stopped, info.Status)
+			assert.Equal(t, cocoa.StoppedStatus, info.Status)
 		},
 		"StopSucceedsWithSecrets": func(ctx context.Context, t *testing.T, v cocoa.Vault, pc cocoa.ECSPodCreator) {
 			secret := cocoa.NewEnvironmentVariable().SetName("secret1").
 				SetSecretOptions(*cocoa.NewSecretOptions().SetName(testutil.NewSecretName("name1")).SetValue("value1"))
 			secretOwned := cocoa.NewEnvironmentVariable().SetName("secret2").
-				SetSecretOptions(*cocoa.NewSecretOptions().SetName(testutil.NewSecretName("name2")).SetValue("value2"))
-			secretOwned.SecretOpts.SetOwned(true)
+				SetSecretOptions(*cocoa.NewSecretOptions().SetName(testutil.NewSecretName("name2")).SetValue("value2").SetOwned(true))
 
 			optsSecret := optsSecret.SetContainerDefinitions(
 				[]cocoa.ECSContainerDefinition{*containerDef.SetEnvironmentVariables(
@@ -75,7 +74,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.Running, info.Status)
+			assert.Equal(t, cocoa.RunningStatus, info.Status)
 			assert.Len(t, info.Resources.Secrets, 2)
 
 			require.NoError(t, p.Stop(ctx))
@@ -83,7 +82,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err = p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.Stopped, info.Status)
+			assert.Equal(t, cocoa.StoppedStatus, info.Status)
 			require.Len(t, info.Resources.Secrets, 2)
 
 			arn := info.Resources.Secrets[0].Name
@@ -101,7 +100,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotZero(t, info)
-			assert.Equal(t, cocoa.Stopped, info.Status)
+			assert.Equal(t, cocoa.StoppedStatus, info.Status)
 
 			require.Error(t, p.Stop(ctx))
 		},
@@ -113,21 +112,20 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.Running, info.Status)
+			assert.Equal(t, cocoa.RunningStatus, info.Status)
 
 			require.NoError(t, p.Delete(ctx))
 
 			info, err = p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.Deleted, info.Status)
+			assert.Equal(t, cocoa.DeletedStatus, info.Status)
 		},
 		"DeleteSucceedsWithSecrets": func(ctx context.Context, t *testing.T, v cocoa.Vault, pc cocoa.ECSPodCreator) {
 			secret := cocoa.NewEnvironmentVariable().SetName("secret1").
 				SetSecretOptions(*cocoa.NewSecretOptions().SetName(testutil.NewSecretName("name1")).SetValue("value1"))
 			secretOwned := cocoa.NewEnvironmentVariable().SetName("secret2").
-				SetSecretOptions(*cocoa.NewSecretOptions().SetName(testutil.NewSecretName("name2")).SetValue("value2"))
-			secretOwned.SecretOpts.SetOwned(true)
+				SetSecretOptions(*cocoa.NewSecretOptions().SetName(testutil.NewSecretName("name2")).SetValue("value2").SetOwned(true))
 
 			optsSecret := optsSecret.SetContainerDefinitions(
 				[]cocoa.ECSContainerDefinition{*containerDef.SetEnvironmentVariables(
@@ -140,7 +138,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.Running, info.Status)
+			assert.Equal(t, cocoa.RunningStatus, info.Status)
 			require.Len(t, info.Resources.Secrets, 2)
 
 			require.NoError(t, p.Delete(ctx))
@@ -148,7 +146,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err = p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.Deleted, info.Status)
+			assert.Equal(t, cocoa.DeletedStatus, info.Status)
 			require.Len(t, info.Resources.Secrets, 2)
 
 			arn0 := info.Resources.Secrets[0].Name

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -82,7 +82,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.Running, info.Status)
+			assert.Equal(t, cocoa.RunningStatus, info.Status)
 		},
 	}
 }
@@ -160,7 +160,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.Running, info.Status)
+			assert.Equal(t, cocoa.RunningStatus, info.Status)
 		},
 	}
 }

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -27,7 +27,7 @@ func TestECSPod(t *testing.T) {
 		assert.NoError(t, c.Close(ctx))
 	}()
 
-	for tName, tCase := range testcase.ECSPodTests() {
+	for tName, tCase := range testcase.ECSPodTests(t) {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, time.Second)
 			defer tcancel()

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -27,7 +27,7 @@ func TestECSPod(t *testing.T) {
 		assert.NoError(t, c.Close(ctx))
 	}()
 
-	for tName, tCase := range testcase.ECSPodTests(t) {
+	for tName, tCase := range testcase.ECSPodTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, time.Second)
 			defer tcancel()
@@ -45,5 +45,4 @@ func TestECSPod(t *testing.T) {
 			tCase(tctx, t, v, podCreator)
 		})
 	}
-
 }

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -16,11 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestVaultInterface(t *testing.T) {
-	assert.Implements(t, (*cocoa.Vault)(nil), &BasicSecretsManager{})
-}
-
 func TestSecretsManager(t *testing.T) {
+	assert.Implements(t, (*cocoa.Vault)(nil), &BasicSecretsManager{})
+
 	testutil.CheckAWSEnvVarsForSecretsManager(t)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15027

* Rename pod status enum values slightly.
* Remove duplicate `SetName` when updating the secret name from the friendly alias to the ARN.
* Add comment on why the secret name has to be updated.
* Add `SetOwned` for `SecretOptions`.
* Fix up a bunch of tests that depend on common shared structs which could lead to inter-test dependencies.