### PR TITLE
EVG-15098: rename enums to be type-prefixed instead of type-suffixed

### DIFF
--- a/ecs/pod.go
+++ b/ecs/pod.go
@@ -126,8 +126,8 @@ func (p *BasicECSPod) Info(ctx context.Context) (*cocoa.ECSPodInfo, error) {
 // Stop stops the running pod without cleaning up any of its underlying
 // resources.
 func (p *BasicECSPod) Stop(ctx context.Context) error {
-	if p.status != cocoa.RunningStatus {
-		return errors.Errorf("pod can only be stopped when status is '%s', but current status is '%s'", cocoa.RunningStatus, p.status)
+	if p.status != cocoa.StatusRunning {
+		return errors.Errorf("pod can only be stopped when status is '%s', but current status is '%s'", cocoa.StatusRunning, p.status)
 	}
 
 	stopTask := &ecs.StopTaskInput{}
@@ -137,7 +137,7 @@ func (p *BasicECSPod) Stop(ctx context.Context) error {
 		return errors.Wrap(err, "stopping pod")
 	}
 
-	p.status = cocoa.StoppedStatus
+	p.status = cocoa.StatusStopped
 
 	return nil
 }
@@ -165,7 +165,7 @@ func (p *BasicECSPod) Delete(ctx context.Context) error {
 		}
 	}
 
-	p.status = cocoa.DeletedStatus
+	p.status = cocoa.StatusDeleted
 
 	return nil
 }

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -90,7 +90,7 @@ func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPo
 	options := NewBasicECSPodOptions().
 		SetClient(m.client).
 		SetVault(m.vault).
-		SetStatus(cocoa.RunningStatus).
+		SetStatus(cocoa.StatusRunning).
 		SetResources(*resources)
 
 	p, err := NewBasicECSPod(options)

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -34,7 +34,7 @@ func TestBasicECSPod(t *testing.T) {
 		},
 		"InfoIsPopulated": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			res := cocoa.NewECSPodResources().SetTaskID("task_id")
-			stat := cocoa.StartingStatus
+			stat := cocoa.StatusStarting
 			opts := NewBasicECSPodOptions().SetClient(c).SetResources(*res).SetStatus(stat)
 
 			p, err := NewBasicECSPod(opts)
@@ -146,7 +146,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 		assert.Equal(t, *res, *opts.Resources)
 	})
 	t.Run("SetStatus", func(t *testing.T) {
-		stat := cocoa.StartingStatus
+		stat := cocoa.StatusStarting
 		opts := NewBasicECSPodOptions().SetStatus(stat)
 		require.NotNil(t, opts.Status)
 		assert.Equal(t, stat, *opts.Status)
@@ -168,7 +168,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetClient(ecsClient).
 				SetVault(v).
 				SetResources(*res).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("MissingClientIsInvalid", func(t *testing.T) {
@@ -180,7 +180,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
 				SetResources(*res).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("MissingVaultIsValid", func(t *testing.T) {
@@ -191,7 +191,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			opts := NewBasicECSPodOptions().
 				SetClient(ecsClient).
 				SetResources(*res).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("MissingResourcesIsInvalid", func(t *testing.T) {
@@ -203,7 +203,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
 				SetResources(*res).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("BadResourcesIsInvalid", func(t *testing.T) {
@@ -213,7 +213,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 			v := secret.NewBasicSecretsManager(smClient)
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
-				SetStatus(cocoa.StartingStatus)
+				SetStatus(cocoa.StatusStarting)
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("MissingStatusIsInvalid", func(t *testing.T) {

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -105,22 +105,22 @@ func (s *PodSecret) SetOwned(owned bool) *PodSecret {
 type ECSPodStatus string
 
 const (
-	// StartingStatus indicates that the ECS pod is being prepared to run.
-	StartingStatus ECSPodStatus = "starting"
-	// RunningStatus indicates that the ECS pod is actively running.
-	RunningStatus ECSPodStatus = "running"
-	// StoppedStatus indicates the that ECS pod is stopped, but all of its
+	// StatusStarting indicates that the ECS pod is being prepared to run.
+	StatusStarting ECSPodStatus = "starting"
+	// StatusRunning indicates that the ECS pod is actively running.
+	StatusRunning ECSPodStatus = "running"
+	// StatusStopped indicates the that ECS pod is stopped, but all of its
 	// resources are still available.
-	StoppedStatus ECSPodStatus = "stopped"
-	// DeletedStatus indicates that the ECS pod has been cleaned up completely,
+	StatusStopped ECSPodStatus = "stopped"
+	// StatusDeleted indicates that the ECS pod has been cleaned up completely,
 	// including all of its resources.
-	DeletedStatus ECSPodStatus = "deleted"
+	StatusDeleted ECSPodStatus = "deleted"
 )
 
 // Validate checks that the ECS pod status is one of the recognized statuses.
 func (s ECSPodStatus) Validate() error {
 	switch s {
-	case StartingStatus, RunningStatus, StoppedStatus, DeletedStatus:
+	case StatusStarting, StatusRunning, StatusStopped, StatusDeleted:
 		return nil
 	default:
 		return errors.Errorf("unrecognized status '%s'", s)

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -659,13 +659,13 @@ func (s ECSPlacementStrategy) Validate() error {
 type ECSStrategyParameter = string
 
 const (
-	// BinpackMemory indicates ECS should optimize its binpacking strategy based
+	// StrategyParamBinpackMemory indicates ECS should optimize its binpacking strategy based
 	// on memory usage.
 	StrategyParamBinpackMemory ECSStrategyParameter = "memory"
-	// BinpackCPU indicates ECS should optimize its binpacking strategy based
+	// StrategyParamBinpackCPU indicates ECS should optimize its binpacking strategy based
 	// on CPU usage.
 	StrategyParamBinpackCPU ECSStrategyParameter = "cpu"
-	// SpreadHost indicates the ECS should spread pods evenly across all
+	// StrategyParamSpreadHost indicates the ECS should spread pods evenly across all
 	// container instances (i.e. hosts).
 	StrategyParamSpreadHost ECSStrategyParameter = "host"
 )

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -183,7 +183,7 @@ func (o *ECSPodCreationOptions) Validate() error {
 	}
 
 	if o.ExecutionOpts == nil {
-		placementOpts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(BinpackMemory)
+		placementOpts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackMemory)
 		o.ExecutionOpts = NewECSPodExecutionOptions().SetPlacementOptions(*placementOpts)
 	}
 
@@ -553,7 +553,7 @@ func (o *ECSPodExecutionOptions) Validate() error {
 	}
 
 	if o.PlacementOpts == nil {
-		o.PlacementOpts = NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(BinpackMemory)
+		o.PlacementOpts = NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackMemory)
 	}
 
 	return nil
@@ -602,8 +602,8 @@ func (o *ECSPodPlacementOptions) Validate() error {
 		catcher.Add(o.Strategy.Validate())
 	}
 	if o.Strategy != nil && o.StrategyParameter != nil {
-		catcher.ErrorfWhen(*o.Strategy == BinpackPlacement && *o.StrategyParameter != BinpackMemory && *o.StrategyParameter != BinpackCPU, "strategy parameter cannot be '%s' when the strategy is '%s'", *o.StrategyParameter, *o.Strategy)
-		catcher.ErrorfWhen(*o.Strategy != SpreadPlacement && *o.StrategyParameter == SpreadHost, "strategy parameter cannot be '%s' when the strategy is not '%s'", *o.StrategyParameter, SpreadPlacement)
+		catcher.ErrorfWhen(*o.Strategy == StrategyBinpack && *o.StrategyParameter != StrategyParamBinpackMemory && *o.StrategyParameter != StrategyParamBinpackCPU, "strategy parameter cannot be '%s' when the strategy is '%s'", *o.StrategyParameter, *o.Strategy)
+		catcher.ErrorfWhen(*o.Strategy != StrategySpread && *o.StrategyParameter == StrategyParamSpreadHost, "strategy parameter cannot be '%s' when the strategy is not '%s'", *o.StrategyParameter, StrategySpread)
 	}
 
 	if catcher.HasErrors() {
@@ -611,16 +611,16 @@ func (o *ECSPodPlacementOptions) Validate() error {
 	}
 
 	if o.Strategy == nil {
-		strategy := BinpackPlacement
+		strategy := StrategyBinpack
 		o.Strategy = &strategy
 	}
 
 	if o.Strategy != nil && o.StrategyParameter == nil {
-		if *o.Strategy == BinpackPlacement {
-			o.StrategyParameter = utility.ToStringPtr(BinpackMemory)
+		if *o.Strategy == StrategyBinpack {
+			o.StrategyParameter = utility.ToStringPtr(StrategyParamBinpackMemory)
 		}
-		if *o.Strategy == SpreadPlacement {
-			o.StrategyParameter = utility.ToStringPtr(SpreadHost)
+		if *o.Strategy == StrategySpread {
+			o.StrategyParameter = utility.ToStringPtr(StrategyParamSpreadHost)
 		}
 	}
 
@@ -631,23 +631,23 @@ func (o *ECSPodPlacementOptions) Validate() error {
 type ECSPlacementStrategy string
 
 const (
-	// SpreadPlacement indicates that the ECS pod will be assigned in such a way
+	// StrategySpread indicates that the ECS pod will be assigned in such a way
 	// to achieve an even spread based on the given ECSStrategyParameter.
-	SpreadPlacement ECSPlacementStrategy = ecs.PlacementStrategyTypeSpread
-	// RandomPlacement indicates that the ECS pod should be assigned to a
+	StrategySpread ECSPlacementStrategy = ecs.PlacementStrategyTypeSpread
+	// StrategyRandom indicates that the ECS pod should be assigned to a
 	// container instance randomly.
-	RandomPlacement ECSPlacementStrategy = ecs.PlacementStrategyTypeRandom
-	// BinpackPlacement indicates that the the ECS pod will be placed on a
+	StrategyRandom ECSPlacementStrategy = ecs.PlacementStrategyTypeRandom
+	// StrategyBinpack indicates that the the ECS pod will be placed on a
 	// container instance with the least amount of memory or CPU that will be
 	// sufficient for the pod's requirements if possible.
-	BinpackPlacement ECSPlacementStrategy = ecs.PlacementStrategyTypeBinpack
+	StrategyBinpack ECSPlacementStrategy = ecs.PlacementStrategyTypeBinpack
 )
 
 // Validate checks that the ECS pod status is one of the recognized placement
 // strategies.
 func (s ECSPlacementStrategy) Validate() error {
 	switch s {
-	case SpreadPlacement, RandomPlacement, BinpackPlacement:
+	case StrategySpread, StrategyRandom, StrategyBinpack:
 		return nil
 	default:
 		return errors.Errorf("unrecognized placement strategy '%s'", s)
@@ -661,13 +661,13 @@ type ECSStrategyParameter = string
 const (
 	// BinpackMemory indicates ECS should optimize its binpacking strategy based
 	// on memory usage.
-	BinpackMemory ECSStrategyParameter = "memory"
+	StrategyParamBinpackMemory ECSStrategyParameter = "memory"
 	// BinpackCPU indicates ECS should optimize its binpacking strategy based
 	// on CPU usage.
-	BinpackCPU ECSStrategyParameter = "cpu"
+	StrategyParamBinpackCPU ECSStrategyParameter = "cpu"
 	// SpreadHost indicates the ECS should spread pods evenly across all
 	// container instances (i.e. hosts).
-	SpreadHost ECSStrategyParameter = "host"
+	StrategyParamSpreadHost ECSStrategyParameter = "host"
 )
 
 // ECSTaskDefinition represents options for an existing ECS task definition.

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -412,7 +412,7 @@ func TestECSPodExecutionOptions(t *testing.T) {
 		assert.Equal(t, cluster, utility.FromStringPtr(opts.Cluster))
 	})
 	t.Run("SetPlacementOptions", func(t *testing.T) {
-		placementOpts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement)
+		placementOpts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack)
 		opts := NewECSPodExecutionOptions().SetPlacementOptions(*placementOpts)
 		require.NotZero(t, opts.PlacementOpts)
 		assert.Equal(t, *placementOpts, *opts.PlacementOpts)
@@ -455,8 +455,8 @@ func TestECSPodExecutionOptions(t *testing.T) {
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.PlacementOpts)
 			require.NotZero(t, opts.PlacementOpts.Strategy)
-			assert.Equal(t, BinpackPlacement, *opts.PlacementOpts.Strategy)
-			assert.Equal(t, BinpackMemory, utility.FromStringPtr(opts.PlacementOpts.StrategyParameter))
+			assert.Equal(t, StrategyBinpack, *opts.PlacementOpts.Strategy)
+			assert.Equal(t, StrategyParamBinpackMemory, utility.FromStringPtr(opts.PlacementOpts.StrategyParameter))
 		})
 		t.Run("BadPlacementOptionsAreInvalid", func(t *testing.T) {
 			placementOpts := NewECSPodPlacementOptions().SetStrategy("foo")
@@ -473,13 +473,13 @@ func TestECSPodPlacementOptions(t *testing.T) {
 		assert.Zero(t, *opts)
 	})
 	t.Run("SetStrategy", func(t *testing.T) {
-		strategy := BinpackPlacement
+		strategy := StrategyBinpack
 		opts := NewECSPodPlacementOptions().SetStrategy(strategy)
 		require.NotZero(t, opts.Strategy)
 		assert.Equal(t, strategy, *opts.Strategy)
 	})
 	t.Run("SetStrategyParameter", func(t *testing.T) {
-		param := BinpackCPU
+		param := StrategyParamBinpackCPU
 		opts := NewECSPodPlacementOptions().SetStrategyParameter(param)
 		assert.Equal(t, param, utility.FromStringPtr(opts.StrategyParameter))
 	})
@@ -493,57 +493,57 @@ func TestECSPodPlacementOptions(t *testing.T) {
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
 			require.NotZero(t, opts.StrategyParameter)
-			assert.Equal(t, BinpackPlacement, *opts.Strategy)
-			assert.Equal(t, BinpackMemory, *opts.StrategyParameter)
+			assert.Equal(t, StrategyBinpack, *opts.Strategy)
+			assert.Equal(t, StrategyParamBinpackMemory, *opts.StrategyParameter)
 		})
-		t.Run("BinpackStrategyWithoutParameterDefaultsToMemoryBinpacking", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement)
+		t.Run("BinpackWithoutParameterDefaultsToMemoryBinpacking", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, BinpackPlacement, *opts.Strategy)
-			assert.Equal(t, BinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategyBinpack, *opts.Strategy)
+			assert.Equal(t, StrategyParamBinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("BinpackStrategyWithMemoryBinpackingIsValid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(BinpackMemory)
+		t.Run("BinpackWithMemoryBinpackingIsValid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackMemory)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, BinpackPlacement, *opts.Strategy)
-			assert.Equal(t, BinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategyBinpack, *opts.Strategy)
+			assert.Equal(t, StrategyParamBinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("BinpackStrategyWithCPUBinpackingIsValid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(BinpackCPU)
+		t.Run("BinpackWithCPUBinpackingIsValid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackCPU)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, BinpackPlacement, *opts.Strategy)
-			assert.Equal(t, BinpackCPU, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategyBinpack, *opts.Strategy)
+			assert.Equal(t, StrategyParamBinpackCPU, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("BinpackStrategyWithSpreadHostIsInvalid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter(SpreadHost)
+		t.Run("BinpackWithSpreadHostIsInvalid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamSpreadHost)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("BinpackStrategyWithInvalidParameterIsInvalid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(BinpackPlacement).SetStrategyParameter("foo")
+		t.Run("BinpackWithInvalidParameterIsInvalid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter("foo")
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("SpreadStrategyWithoutParameterDefaultsToHostSpread", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(SpreadPlacement)
+		t.Run("SpreadyWithoutParameterDefaultsToHostSpread", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategySpread)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, SpreadPlacement, *opts.Strategy)
-			assert.Equal(t, SpreadHost, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategySpread, *opts.Strategy)
+			assert.Equal(t, StrategyParamSpreadHost, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("SpreadStrategyWithoutWithHostSpreadIsValid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(SpreadPlacement).SetStrategyParameter(SpreadHost)
+		t.Run("SpreadWithHostSpreadIsValid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategySpread).SetStrategyParameter(StrategyParamSpreadHost)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, SpreadPlacement, *opts.Strategy)
-			assert.Equal(t, SpreadHost, utility.FromStringPtr(opts.StrategyParameter))
+			assert.Equal(t, StrategySpread, *opts.Strategy)
+			assert.Equal(t, StrategyParamSpreadHost, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("SpreadStrategyWithCustomParameterIsValid", func(t *testing.T) {
-			opts := NewECSPodPlacementOptions().SetStrategy(SpreadPlacement).SetStrategyParameter("custom")
+		t.Run("SpreadWithCustomParameterIsValid", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetStrategy(StrategySpread).SetStrategyParameter("custom")
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
-			assert.Equal(t, SpreadPlacement, *opts.Strategy)
+			assert.Equal(t, StrategySpread, *opts.Strategy)
 			assert.Equal(t, "custom", utility.FromStringPtr(opts.StrategyParameter))
 		})
 	})

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -55,7 +55,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StoppedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusStopped, info.Status)
 		},
 		"StopSucceedsWithSecrets": func(ctx context.Context, t *testing.T, v cocoa.Vault, pc cocoa.ECSPodCreator) {
 			secret := cocoa.NewEnvironmentVariable().
@@ -81,7 +81,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 			assert.Len(t, info.Resources.Secrets, 2)
 
 			require.NoError(t, p.Stop(ctx))
@@ -89,7 +89,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err = p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StoppedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusStopped, info.Status)
 			require.Len(t, info.Resources.Secrets, 2)
 
 			arn := info.Resources.Secrets[0].Name
@@ -112,7 +112,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotZero(t, info)
-			assert.Equal(t, cocoa.StoppedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusStopped, info.Status)
 
 			require.Error(t, p.Stop(ctx))
 		},
@@ -125,14 +125,14 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 
 			require.NoError(t, p.Delete(ctx))
 
 			info, err = p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.DeletedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusDeleted, info.Status)
 		},
 		"DeleteSucceedsWithSecrets": func(ctx context.Context, t *testing.T, v cocoa.Vault, pc cocoa.ECSPodCreator) {
 			secret := cocoa.NewEnvironmentVariable().SetName(t.Name()).
@@ -149,7 +149,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 			require.Len(t, info.Resources.Secrets, 2)
 
 			require.NoError(t, p.Delete(ctx))
@@ -157,7 +157,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			info, err = p.Info(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, info)
-			assert.Equal(t, cocoa.DeletedStatus, info.Status)
+			assert.Equal(t, cocoa.StatusDeleted, info.Status)
 			require.Len(t, info.Resources.Secrets, 2)
 
 			arn0 := info.Resources.Secrets[0].Name

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -82,7 +82,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 		},
 	}
 }
@@ -160,7 +160,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 
 			info, err := p.Info(ctx)
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.RunningStatus, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
 		},
 	}
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15098

Rename enums to use type prefixes instead of type suffixes for consistency and to make autocomplete easier.