### PR TITLE
EVG-15108: add working directory container option

### DIFF
--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -46,23 +46,35 @@ func TestECSPodCreationOptions(t *testing.T) {
 		assert.Equal(t, cpu, utility.FromIntPtr(def.CPU))
 	})
 	t.Run("SetTags", func(t *testing.T) {
-		key := "tagKey"
-		value := "tagValue"
-		def := NewECSPodCreationOptions().SetTags(map[string]string{key: value})
-		require.Len(t, def.Tags, 1)
-		assert.Equal(t, value, def.Tags[key])
+		tags := map[string]string{"key": "value"}
+		opts := NewECSPodCreationOptions().SetTags(tags)
+		require.Len(t, opts.Tags, len(tags))
+		for k, v := range tags {
+			assert.Equal(t, v, opts.Tags[k])
+		}
+	})
+	t.Run("SetTaskRole", func(t *testing.T) {
+		r := "task_role"
+		opts := NewECSPodCreationOptions().SetTaskRole(r)
+		assert.Equal(t, r, utility.FromStringPtr(opts.TaskRole))
+	})
+	t.Run("SetExecutionRole", func(t *testing.T) {
+		r := "execution_role"
+		opts := NewECSPodCreationOptions().SetExecutionRole(r)
+		assert.Equal(t, r, utility.FromStringPtr(opts.ExecutionRole))
 	})
 	t.Run("AddTags", func(t *testing.T) {
-		key0 := "key0"
-		val0 := "val0"
-		key1 := "key1"
-		val1 := "val1"
-		def := NewECSPodCreationOptions().AddTags(map[string]string{key0: val0, key1: val1})
-		require.Len(t, def.Tags, 2)
-		assert.Equal(t, val0, def.Tags[key0])
-		assert.Equal(t, val1, def.Tags[key1])
-		def.AddTags(map[string]string{})
-		assert.Len(t, def.Tags, 2)
+		tags := map[string]string{"key0": "val0", "key1": "val1"}
+		opts := NewECSPodCreationOptions().AddTags(tags)
+		require.Len(t, opts.Tags, len(tags))
+		for k, v := range tags {
+			assert.Equal(t, v, opts.Tags[k])
+		}
+		opts.AddTags(map[string]string{})
+		assert.Len(t, opts.Tags, len(tags))
+		for k, v := range tags {
+			assert.Equal(t, v, opts.Tags[k])
+		}
 	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("EmptyIsInvalid", func(t *testing.T) {
@@ -202,6 +214,11 @@ func TestECSContainerDefinition(t *testing.T) {
 		def := NewECSContainerDefinition().SetCommand(cmd)
 		assert.Equal(t, cmd, def.Command)
 	})
+	t.Run("SetWorkingDir", func(t *testing.T) {
+		dir := "working_dir"
+		def := NewECSContainerDefinition().SetWorkingDir(dir)
+		assert.Equal(t, dir, utility.FromStringPtr(def.WorkingDir))
+	})
 	t.Run("SetMemoryMB", func(t *testing.T) {
 		mem := 128
 		def := NewECSContainerDefinition().SetMemoryMB(mem)
@@ -211,22 +228,6 @@ func TestECSContainerDefinition(t *testing.T) {
 		cpu := 128
 		def := NewECSContainerDefinition().SetCPU(cpu)
 		assert.Equal(t, cpu, utility.FromIntPtr(def.CPU))
-	})
-	t.Run("SetTags", func(t *testing.T) {
-		tag := "tag"
-		def := NewECSContainerDefinition().SetTags([]string{tag})
-		require.Len(t, def.Tags, 1)
-		assert.Equal(t, tag, def.Tags[0])
-	})
-	t.Run("AddTags", func(t *testing.T) {
-		tag0 := "tag0"
-		tag1 := "tag1"
-		def := NewECSContainerDefinition().AddTags(tag0, tag1)
-		require.Len(t, def.Tags, 2)
-		assert.Equal(t, tag0, def.Tags[0])
-		assert.Equal(t, tag1, def.Tags[1])
-		def.AddTags()
-		assert.Len(t, def.Tags, 2)
 	})
 	t.Run("SetEnvironmentVariables", func(t *testing.T) {
 		ev := NewEnvironmentVariable().SetName("name").SetValue("value")
@@ -270,8 +271,7 @@ func TestECSContainerDefinition(t *testing.T) {
 				SetMemoryMB(128).
 				SetCPU(128).
 				SetCommand([]string{"echo"}).
-				AddEnvironmentVariables(*ev).
-				AddTags("tag")
+				AddEnvironmentVariables(*ev)
 			assert.NoError(t, def.Validate())
 		})
 		t.Run("ZeroCPUIsInvalid", func(t *testing.T) {
@@ -439,11 +439,6 @@ func TestECSPodExecutionOptions(t *testing.T) {
 		assert.Equal(t, val1, opts.Tags[key1])
 		opts.AddTags(map[string]string{})
 		assert.Len(t, opts.Tags, 2)
-	})
-	t.Run("SetExecutionRole", func(t *testing.T) {
-		role := "role"
-		opts := NewECSPodExecutionOptions().SetExecutionRole(role)
-		assert.Equal(t, role, *opts.ExecutionRole)
 	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("EmptyIsValid", func(t *testing.T) {

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -34,9 +34,9 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			SetMemoryMB(128).
 			SetCPU(128).
 			SetTaskRole(testutil.TaskRole()).
+			SetExecutionRole(testutil.ExecutionRole()).
 			SetExecutionOptions(*cocoa.NewECSPodExecutionOptions().
-				SetCluster(testutil.ECSClusterName()).
-				SetExecutionRole(testutil.ExecutionRole()))
+				SetCluster(testutil.ECSClusterName()))
 	}
 
 	return map[string]ECSPodTestCase{

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -35,7 +35,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetName("container")
 			require.NotNil(t, containerDef.EnvVars)
 
-			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName()).SetExecutionRole(testutil.ExecutionRole())
+			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 			assert.NoError(t, execOpts.Validate())
 
 			opts := cocoa.NewECSPodCreationOptions().
@@ -44,6 +44,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetMemoryMB(128).
 				SetCPU(128).
 				SetTaskRole(testutil.TaskRole()).
+				SetExecutionRole(testutil.ExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -137,8 +138,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 			require.NotNil(t, containerDef.EnvVars)
 
 			execOpts := cocoa.NewECSPodExecutionOptions().
-				SetCluster(testutil.ECSClusterName()).
-				SetExecutionRole(testutil.ExecutionRole())
+				SetCluster(testutil.ECSClusterName())
 			assert.NoError(t, execOpts.Validate())
 
 			opts := cocoa.NewECSPodCreationOptions().
@@ -147,6 +147,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetMemoryMB(128).
 				SetCPU(128).
 				SetTaskRole(testutil.TaskRole()).
+				SetExecutionRole(testutil.ExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/cocoa/secret"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,15 +24,41 @@ func TestECSPodCreator(t *testing.T) {
 
 	GlobalECSService.Clusters[testutil.ECSClusterName()] = ECSCluster{}
 
-	c := &ECSClient{}
-	defer func() {
-		assert.NoError(t, c.Close(ctx))
-	}()
+	for tName, tCase := range ecsPodCreatorInputTests() {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			defer tcancel()
+
+			c := &ECSClient{}
+			defer func() {
+				assert.NoError(t, c.Close(ctx))
+			}()
+
+			sm := &SecretsManagerClient{}
+			defer func() {
+				assert.NoError(t, sm.Close(tctx))
+			}()
+
+			v := NewVault(secret.NewBasicSecretsManager(sm))
+
+			pc, err := ecs.NewBasicECSPodCreator(c, v)
+			require.NoError(t, err)
+
+			mpc := NewECSPodCreator(pc)
+
+			tCase(tctx, t, mpc, c, sm)
+		})
+	}
 
 	for tName, tCase := range testcase.ECSPodCreatorTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, time.Second)
 			defer tcancel()
+
+			c := &ECSClient{}
+			defer func() {
+				assert.NoError(t, c.Close(ctx))
+			}()
 
 			pc, err := ecs.NewBasicECSPodCreator(c, nil)
 			require.NoError(t, err)
@@ -45,6 +73,11 @@ func TestECSPodCreator(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, time.Second)
 			defer tcancel()
+
+			c := &ECSClient{}
+			defer func() {
+				assert.NoError(t, c.Close(ctx))
+			}()
 
 			sm := &SecretsManagerClient{}
 			defer func() {
@@ -61,5 +94,128 @@ func TestECSPodCreator(t *testing.T) {
 			tCase(tctx, t, podCreator)
 		})
 	}
+}
 
+func ecsPodCreatorInputTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
+	return map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient){
+		"RegistersTaskDefinitionAndRunsTaskWithAllFieldsSet": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
+			envVar := cocoa.NewEnvironmentVariable().
+				SetName("env_var_name").
+				SetValue("env_var_value")
+			containerDef := cocoa.NewECSContainerDefinition().
+				SetName("name").
+				SetImage("image").
+				SetCommand([]string{"echo", "foo"}).
+				SetWorkingDir("working_dir").
+				SetMemoryMB(128).
+				SetCPU(256).
+				AddEnvironmentVariables(*envVar)
+			placementOpts := cocoa.NewECSPodPlacementOptions().
+				SetStrategy(cocoa.StrategyBinpack).
+				SetStrategyParameter(cocoa.StrategyParamBinpackMemory)
+			execOpts := cocoa.NewECSPodExecutionOptions().
+				SetCluster(testutil.ECSClusterName()).
+				SetPlacementOptions(*placementOpts).
+				SetTags(map[string]string{"execution_tag": "execution_val"}).
+				SetSupportsDebugMode(true)
+			opts := cocoa.NewECSPodCreationOptions().
+				SetMemoryMB(512).
+				SetCPU(1024).
+				SetTaskRole("task_role").
+				SetExecutionRole("execution_role").
+				SetTags(map[string]string{"creation_tag": "creation_val"}).
+				AddContainerDefinitions(*containerDef).
+				SetExecutionOptions(*execOpts)
+
+			_, err := pc.CreatePod(ctx, opts)
+			require.NoError(t, err)
+
+			require.NotZero(t, c.RegisterTaskDefinitionInput)
+
+			mem, err := strconv.Atoi(utility.FromStringPtr(c.RegisterTaskDefinitionInput.Memory))
+			require.NoError(t, err)
+			assert.Equal(t, utility.FromIntPtr(opts.MemoryMB), mem)
+			cpu, err := strconv.Atoi(utility.FromStringPtr(c.RegisterTaskDefinitionInput.Cpu))
+			require.NoError(t, err)
+			assert.Equal(t, utility.FromIntPtr(opts.CPU), cpu)
+			assert.Equal(t, utility.FromStringPtr(opts.TaskRole), utility.FromStringPtr(c.RegisterTaskDefinitionInput.TaskRoleArn))
+			assert.Equal(t, utility.FromStringPtr(opts.ExecutionRole), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ExecutionRoleArn))
+			require.Len(t, c.RegisterTaskDefinitionInput.Tags, 1)
+			assert.Equal(t, "creation_tag", utility.FromStringPtr(c.RegisterTaskDefinitionInput.Tags[0].Key))
+			assert.Equal(t, opts.Tags["creation_tag"], utility.FromStringPtr(c.RegisterTaskDefinitionInput.Tags[0].Value))
+			require.Len(t, c.RegisterTaskDefinitionInput.ContainerDefinitions, 1)
+			left, right := utility.StringSliceSymmetricDifference(containerDef.Command, utility.FromStringPtrSlice(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Command))
+			assert.Empty(t, left)
+			assert.Empty(t, right)
+			assert.Equal(t, utility.FromStringPtr(containerDef.WorkingDir), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].WorkingDirectory))
+			assert.EqualValues(t, utility.FromIntPtr(containerDef.MemoryMB), utility.FromInt64Ptr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Memory))
+			assert.EqualValues(t, utility.FromIntPtr(containerDef.CPU), utility.FromInt64Ptr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Cpu))
+			require.Len(t, c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Environment, 1)
+			assert.Equal(t, utility.FromStringPtr(envVar.Name), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Environment[0].Name))
+			assert.Equal(t, utility.FromStringPtr(envVar.Value), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Environment[0].Value))
+
+			require.NotZero(t, c.RunTaskInput)
+			require.Len(t, c.RunTaskInput.PlacementStrategy, 1)
+			assert.EqualValues(t, *placementOpts.Strategy, utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Type))
+			assert.Equal(t, utility.FromStringPtr(placementOpts.StrategyParameter), utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Field))
+			require.Len(t, c.RunTaskInput.Tags, 1)
+			assert.Equal(t, "execution_tag", utility.FromStringPtr(c.RunTaskInput.Tags[0].Key))
+			assert.Equal(t, execOpts.Tags["execution_tag"], utility.FromStringPtr(c.RunTaskInput.Tags[0].Value))
+			assert.True(t, utility.FromBoolPtr(c.RunTaskInput.EnableExecuteCommand))
+		},
+		"RegistersTaskDefinitionAndRunsTaskWithCreatedSecrets": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
+			secretOpts := cocoa.NewSecretOptions().
+				SetName("secret_name").
+				SetValue("secret_value")
+			envVar := cocoa.NewEnvironmentVariable().
+				SetName("env_var_name").
+				SetSecretOptions(*secretOpts)
+			containerDef := cocoa.NewECSContainerDefinition().
+				SetName("name").
+				SetImage("image").
+				SetCommand([]string{"echo", "foo"}).
+				AddEnvironmentVariables(*envVar)
+			placementOpts := cocoa.NewECSPodPlacementOptions().
+				SetStrategy(cocoa.StrategyBinpack).
+				SetStrategyParameter(cocoa.StrategyParamBinpackMemory)
+			execOpts := cocoa.NewECSPodExecutionOptions().
+				SetCluster(testutil.ECSClusterName()).
+				SetPlacementOptions(*placementOpts)
+			opts := cocoa.NewECSPodCreationOptions().
+				SetMemoryMB(512).
+				SetCPU(1024).
+				SetExecutionRole("execution_role").
+				AddContainerDefinitions(*containerDef).
+				SetExecutionOptions(*execOpts)
+
+			_, err := pc.CreatePod(ctx, opts)
+			require.NoError(t, err)
+
+			require.NotZero(t, c.RegisterTaskDefinitionInput)
+
+			mem, err := strconv.Atoi(utility.FromStringPtr(c.RegisterTaskDefinitionInput.Memory))
+			require.NoError(t, err)
+			assert.Equal(t, utility.FromIntPtr(opts.MemoryMB), mem)
+			cpu, err := strconv.Atoi(utility.FromStringPtr(c.RegisterTaskDefinitionInput.Cpu))
+			require.NoError(t, err)
+			assert.Equal(t, utility.FromIntPtr(opts.CPU), cpu)
+			assert.Equal(t, utility.FromStringPtr(opts.TaskRole), utility.FromStringPtr(c.RegisterTaskDefinitionInput.TaskRoleArn))
+			assert.Equal(t, utility.FromStringPtr(opts.ExecutionRole), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ExecutionRoleArn))
+			require.Len(t, c.RegisterTaskDefinitionInput.ContainerDefinitions, 1)
+			left, right := utility.StringSliceSymmetricDifference(containerDef.Command, utility.FromStringPtrSlice(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Command))
+			assert.Empty(t, left)
+			assert.Empty(t, right)
+			require.Len(t, c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Secrets, 1)
+			assert.Equal(t, utility.FromStringPtr(envVar.Name), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Secrets[0].Name))
+			assert.Equal(t, utility.FromStringPtr(secretOpts.Name), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Secrets[0].ValueFrom))
+
+			assert.Equal(t, utility.FromStringPtr(secretOpts.Name), utility.FromStringPtr(sm.CreateSecretInput.Name))
+			assert.Equal(t, utility.FromStringPtr(secretOpts.Value), utility.FromStringPtr(sm.CreateSecretInput.SecretString))
+
+			require.NotZero(t, c.RunTaskInput)
+			require.Len(t, c.RunTaskInput.PlacementStrategy, 1)
+			assert.EqualValues(t, *placementOpts.Strategy, utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Type))
+			assert.Equal(t, utility.FromStringPtr(placementOpts.StrategyParameter), utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Field))
+		},
+	}
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15108

* Add working directory as a parameter to the container definition.
* Remove tags from the container definition since container definitions can't be tagged.
* Move execution role to the creation options instead of execution options because it must be set when the task definition is first registered.
* Add mock tests to verify that the inputs from the ECS pod creator to the ECS/Secrets Manager API are mapped correctly.
* Fix some small copy-pasting bugs in the ECS pod creator implementation.