### PR TITLE
EVG-14962: add container instance filter queries

### DIFF
--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -162,6 +162,18 @@ func exportStrategy(strategy *cocoa.ECSPlacementStrategy, param *cocoa.ECSStrate
 	return []*ecs.PlacementStrategy{&placementStrat}
 }
 
+// exportPlacementConstraints converts the placement options into placement
+// constraints.
+func exportPlacementConstraints(opts *cocoa.ECSPodPlacementOptions) []*ecs.PlacementConstraint {
+	var constraints []*ecs.PlacementConstraint
+	for _, filter := range opts.InstanceFilters {
+		var constraint ecs.PlacementConstraint
+		constraint.SetType("memberOf").SetExpression(filter)
+		constraints = append(constraints, &constraint)
+	}
+	return constraints
+}
+
 // exportEnvVars converts the non-secret environment variables into ECS
 // environment variables.
 func exportEnvVars(envVars []cocoa.EnvironmentVariable) []*ecs.KeyValuePair {
@@ -258,6 +270,7 @@ func (m *BasicECSPodCreator) exportTaskExecutionOptions(opts cocoa.ECSPodExecuti
 		SetTaskDefinition(utility.FromStringPtr(taskDef.ID)).
 		SetTags(exportTags(opts.Tags)).
 		SetEnableExecuteCommand(utility.FromBoolPtr(opts.SupportsDebugMode)).
-		SetPlacementStrategy(exportStrategy(opts.PlacementOpts.Strategy, opts.PlacementOpts.StrategyParameter))
+		SetPlacementStrategy(exportStrategy(opts.PlacementOpts.Strategy, opts.PlacementOpts.StrategyParameter)).
+		SetPlacementConstraints(exportPlacementConstraints(opts.PlacementOpts))
 	return &runTask
 }

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -569,7 +569,6 @@ type ECSPodPlacementOptions struct {
 	// of the pod to a set of container instances in the cluster that match the
 	// query filter.
 	// Docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html
-	// kim: TODO: implement
 	InstanceFilters []string
 }
 

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -564,6 +564,13 @@ type ECSPodPlacementOptions struct {
 	// If the strategy is binpack, it defaults to "memory".
 	// If the strategy is random, this does not apply.
 	StrategyParameter *ECSStrategyParameter
+
+	// InstanceFilter is a set of query expressions that restrict the placement
+	// of the pod to a set of container instances in the cluster that match the
+	// query filter.
+	// Docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html
+	// kim: TODO: implement
+	InstanceFilters []string
 }
 
 // NewECSPodPlacementOptions creates new options to specify how an ECS pod
@@ -582,6 +589,20 @@ func (o *ECSPodPlacementOptions) SetStrategy(s ECSPlacementStrategy) *ECSPodPlac
 // on a container instance.
 func (o *ECSPodPlacementOptions) SetStrategyParameter(p ECSStrategyParameter) *ECSPodPlacementOptions {
 	o.StrategyParameter = &p
+	return o
+}
+
+// SetInstanceFilters sets the instance filters to constrain pod placement to
+// one in the set of matching container instances.
+func (o *ECSPodPlacementOptions) SetInstanceFilters(filters []string) *ECSPodPlacementOptions {
+	o.InstanceFilters = filters
+	return o
+}
+
+// AddInstanceFilters adds new instance filters to the existing ones to
+// constrain pod placement to one in the set of matching container instances.
+func (o *ECSPodPlacementOptions) AddInstanceFilters(filters ...string) *ECSPodPlacementOptions {
+	o.InstanceFilters = append(o.InstanceFilters, filters...)
 	return o
 }
 

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -33,7 +33,9 @@ func TestECSPodCreationOptions(t *testing.T) {
 		assert.Equal(t, *containerDef0, def.ContainerDefinitions[0])
 		assert.Equal(t, *containerDef1, def.ContainerDefinitions[1])
 		def.AddContainerDefinitions()
-		assert.Len(t, def.ContainerDefinitions, 2)
+		require.Len(t, def.ContainerDefinitions, 2)
+		assert.Equal(t, *containerDef0, def.ContainerDefinitions[0])
+		assert.Equal(t, *containerDef1, def.ContainerDefinitions[1])
 	})
 	t.Run("SetMemoryMB", func(t *testing.T) {
 		mem := 128
@@ -243,7 +245,9 @@ func TestECSContainerDefinition(t *testing.T) {
 		assert.Equal(t, *ev0, def.EnvVars[0])
 		assert.Equal(t, *ev1, def.EnvVars[1])
 		def.AddEnvironmentVariables()
-		assert.Len(t, def.EnvVars, 2)
+		require.Len(t, def.EnvVars, 2)
+		assert.Equal(t, *ev0, def.EnvVars[0])
+		assert.Equal(t, *ev1, def.EnvVars[1])
 	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("EmptyIsInvalid", func(t *testing.T) {
@@ -439,6 +443,8 @@ func TestECSPodExecutionOptions(t *testing.T) {
 		assert.Equal(t, val1, opts.Tags[key1])
 		opts.AddTags(map[string]string{})
 		assert.Len(t, opts.Tags, 2)
+		assert.Equal(t, val0, opts.Tags[key0])
+		assert.Equal(t, val1, opts.Tags[key1])
 	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("EmptyIsValid", func(t *testing.T) {
@@ -477,6 +483,21 @@ func TestECSPodPlacementOptions(t *testing.T) {
 		param := StrategyParamBinpackCPU
 		opts := NewECSPodPlacementOptions().SetStrategyParameter(param)
 		assert.Equal(t, param, utility.FromStringPtr(opts.StrategyParameter))
+	})
+	t.Run("SetInstanceFilters", func(t *testing.T) {
+		filters := []string{"runningTasksCount == 0"}
+		opts := NewECSPodPlacementOptions().SetInstanceFilters(filters)
+		assert.ElementsMatch(t, filters, opts.InstanceFilters)
+	})
+	t.Run("AddInstanceFilters", func(t *testing.T) {
+		filter := "runningTasksCount == 0"
+		opts := NewECSPodPlacementOptions().AddInstanceFilters(filter)
+		require.Len(t, opts.InstanceFilters, 1)
+		assert.Equal(t, filter, opts.InstanceFilters[0])
+
+		opts.AddInstanceFilters()
+		require.Len(t, opts.InstanceFilters, 1)
+		assert.Equal(t, filter, opts.InstanceFilters[0])
 	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("EmptyIsValid", func(t *testing.T) {

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -112,7 +112,8 @@ func ecsPodCreatorInputTests() map[string]func(ctx context.Context, t *testing.T
 				AddEnvironmentVariables(*envVar)
 			placementOpts := cocoa.NewECSPodPlacementOptions().
 				SetStrategy(cocoa.StrategyBinpack).
-				SetStrategyParameter(cocoa.StrategyParamBinpackMemory)
+				SetStrategyParameter(cocoa.StrategyParamBinpackMemory).
+				AddInstanceFilters("runningTaskCount == 0")
 			execOpts := cocoa.NewECSPodExecutionOptions().
 				SetCluster(testutil.ECSClusterName()).
 				SetPlacementOptions(*placementOpts).
@@ -158,6 +159,9 @@ func ecsPodCreatorInputTests() map[string]func(ctx context.Context, t *testing.T
 			require.Len(t, c.RunTaskInput.PlacementStrategy, 1)
 			assert.EqualValues(t, *placementOpts.Strategy, utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Type))
 			assert.Equal(t, utility.FromStringPtr(placementOpts.StrategyParameter), utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Field))
+			require.Len(t, c.RunTaskInput.PlacementConstraints, 1)
+			assert.Equal(t, placementOpts.InstanceFilters[0], utility.FromStringPtr(c.RunTaskInput.PlacementConstraints[0].Expression))
+			assert.Equal(t, "memberOf", utility.FromStringPtr(c.RunTaskInput.PlacementConstraints[0].Type))
 			require.Len(t, c.RunTaskInput.Tags, 1)
 			assert.Equal(t, "execution_tag", utility.FromStringPtr(c.RunTaskInput.Tags[0].Key))
 			assert.Equal(t, execOpts.Tags["execution_tag"], utility.FromStringPtr(c.RunTaskInput.Tags[0].Value))


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14962

Add an option to constrain placement of pods to a subset of all available hosts in the cluster using the ECS cluster query language. This is useful for things like enforcing single-tenant pods.