### PR TITLE
EVG-15130: implement DescribeTaskDefinition and DescribeSecret

### DIFF
--- a/ecs_client.go
+++ b/ecs_client.go
@@ -11,17 +11,20 @@ import (
 type ECSClient interface {
 	// RegisterTaskDefinition registers the definition for a new task with ECS.
 	RegisterTaskDefinition(context.Context, *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error)
-	// DeregisterTaskDefinition deregisters an existing ECS task definition.
-	DeregisterTaskDefinition(ctx context.Context, in *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error)
+	// DescribeTaskDefinitions gets information about the configuration and
+	// status of a task definition.
+	DescribeTaskDefinition(ctx context.Context, in *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error)
 	// ListTaskDefinitions lists all ECS task definitions matching the input.
 	ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDefinitionsInput) (*ecs.ListTaskDefinitionsOutput, error)
+	// DeregisterTaskDefinition deregisters an existing ECS task definition.
+	DeregisterTaskDefinition(ctx context.Context, in *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error)
 	// RunTask runs a registered task.
 	RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
+	// DescribeTasks gets information about the configuration and status of
+	// tasks.
+	DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
 	// ListTasks lists all ECS tasks matching the input.
 	ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
-	// DescribeTasks gets information about the configuration and status of the
-	// task.
-	DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
 	// StopTask stops a running task.
 	StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.StopTaskOutput, error)
 	// Close closes the client and cleans up its resources. Implementations

--- a/secrets_manager_client.go
+++ b/secrets_manager_client.go
@@ -14,6 +14,8 @@ type SecretsManagerClient interface {
 	CreateSecret(ctx context.Context, in *secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error)
 	// GetSecretValue gets the decrypted value of a secret.
 	GetSecretValue(ctx context.Context, in *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
+	// DescribeSecret gets metadata information about a secret.
+	DescribeSecret(ctx context.Context, in *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error)
 	// UpdateSecret updates the value of an existing secret.
 	UpdateSecretValue(ctx context.Context, in *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error)
 	// DeleteSecret deletes an existing secret.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15130

* Implement DescribeTaskDefinition in ECS and DescribeSecret in Secrets Manager. These are mostly useful for testing purposes.
* Improve functionality in mock implementations of ECS and Secrets Manager services for Describe API calls.
* Reorganize some of the tests for tidiness.