### PR TITLE
EVG-15034: make stop and delete idempotent

### DIFF
--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -73,7 +73,7 @@ func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPo
 	if len(runOut.Failures) > 0 {
 		catcher := grip.NewBasicCatcher()
 		for _, failure := range runOut.Failures {
-			catcher.Errorf("task '%s': %s: %s\n", *failure.Arn, *failure.Detail, *failure.Reason)
+			catcher.Errorf("task '%s': %s: %s\n", utility.FromStringPtr(failure.Arn), utility.FromStringPtr(failure.Detail), utility.FromStringPtr(failure.Reason))
 		}
 		return nil, errors.Wrap(catcher.Resolve(), "running task")
 	}

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -64,7 +64,7 @@ func TestBasicECSPodCreator(t *testing.T) {
 			require.NoError(t, err)
 			defer c.Close(ctx)
 
-			secretsClient, err := secret.NewBasicSecretsManagerClient(awsutil.ClientOptions{
+			smc, err := secret.NewBasicSecretsManagerClient(awsutil.ClientOptions{
 				Creds:  credentials.NewEnvCredentials(),
 				Region: aws.String(testutil.AWSRegion()),
 				Role:   aws.String(testutil.AWSRole()),
@@ -75,9 +75,11 @@ func TestBasicECSPodCreator(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, c)
-			defer secretsClient.Close(ctx)
+			defer func() {
+				assert.NoError(t, smc.Close(tctx))
+			}()
 
-			m := secret.NewBasicSecretsManager(secretsClient)
+			m := secret.NewBasicSecretsManager(smc)
 			require.NotNil(t, m)
 
 			tCase(tctx, t, c, m)
@@ -134,7 +136,7 @@ func TestECSPodCreator(t *testing.T) {
 			require.NoError(t, err)
 			defer c.Close(tctx)
 
-			secretsClient, err := secret.NewBasicSecretsManagerClient(awsutil.ClientOptions{
+			smc, err := secret.NewBasicSecretsManagerClient(awsutil.ClientOptions{
 				Creds:  credentials.NewEnvCredentials(),
 				Region: aws.String(testutil.AWSRegion()),
 				Role:   aws.String(testutil.AWSRole()),
@@ -144,9 +146,11 @@ func TestECSPodCreator(t *testing.T) {
 				HTTPClient: hc,
 			})
 			require.NoError(t, err)
-			defer secretsClient.Close(tctx)
+			defer func() {
+				assert.NoError(t, smc.Close(tctx))
+			}()
 
-			m := secret.NewBasicSecretsManager(secretsClient)
+			m := secret.NewBasicSecretsManager(smc)
 			require.NotNil(t, m)
 
 			podCreator, err := NewBasicECSPodCreator(c, m)

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -386,27 +386,35 @@ func (s *ECSService) taskDefIndexFromARN(arn string) (family string, revNum int,
 type ECSClient struct {
 	RegisterTaskDefinitionInput  *ecs.RegisterTaskDefinitionInput
 	RegisterTaskDefinitionOutput *ecs.RegisterTaskDefinitionOutput
+	RegisterTaskDefinitionError  error
 
 	DescribeTaskDefinitionInput  *ecs.DescribeTaskDefinitionInput
 	DescribeTaskDefinitionOutput *ecs.DescribeTaskDefinitionOutput
+	DescribeTaskDefinitionError  error
 
 	ListTaskDefinitionsInput  *ecs.ListTaskDefinitionsInput
 	ListTaskDefinitionsOutput *ecs.ListTaskDefinitionsOutput
+	ListTaskDefinitionsError  error
 
 	DeregisterTaskDefinitionInput  *ecs.DeregisterTaskDefinitionInput
 	DeregisterTaskDefinitionOutput *ecs.DeregisterTaskDefinitionOutput
+	DeregisterTaskDefinitionError  error
 
 	RunTaskInput  *ecs.RunTaskInput
 	RunTaskOutput *ecs.RunTaskOutput
+	RunTaskError  error
 
 	DescribeTasksInput  *ecs.DescribeTasksInput
 	DescribeTasksOutput *ecs.DescribeTasksOutput
+	DescribeTasksError  error
 
 	ListTasksInput  *ecs.ListTasksInput
 	ListTasksOutput *ecs.ListTasksOutput
+	ListTasksError  error
 
 	StopTaskInput  *ecs.StopTaskInput
 	StopTaskOutput *ecs.StopTaskOutput
+	StopTaskError  error
 
 	CloseError error
 }
@@ -417,8 +425,8 @@ type ECSClient struct {
 func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
 	c.RegisterTaskDefinitionInput = in
 
-	if c.RegisterTaskDefinitionOutput != nil {
-		return c.RegisterTaskDefinitionOutput, nil
+	if c.RegisterTaskDefinitionOutput != nil || c.RegisterTaskDefinitionError != nil {
+		return c.RegisterTaskDefinitionOutput, c.RegisterTaskDefinitionError
 	}
 
 	if in.Family == nil {
@@ -444,8 +452,8 @@ func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.Register
 func (c *ECSClient) DescribeTaskDefinition(ctx context.Context, in *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
 	c.DescribeTaskDefinitionInput = in
 
-	if c.DescribeTaskDefinitionOutput != nil {
-		return c.DescribeTaskDefinitionOutput, nil
+	if c.DescribeTaskDefinitionOutput != nil || c.DescribeTaskDefinitionError != nil {
+		return c.DescribeTaskDefinitionOutput, c.DescribeTaskDefinitionError
 	}
 
 	id := utility.FromStringPtr(in.TaskDefinition)
@@ -466,8 +474,8 @@ func (c *ECSClient) DescribeTaskDefinition(ctx context.Context, in *ecs.Describe
 func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDefinitionsInput) (*ecs.ListTaskDefinitionsOutput, error) {
 	c.ListTaskDefinitionsInput = in
 
-	if c.ListTaskDefinitionsOutput != nil {
-		return c.ListTaskDefinitionsOutput, nil
+	if c.ListTaskDefinitionsOutput != nil || c.ListTaskDefinitionsError != nil {
+		return c.ListTaskDefinitionsOutput, c.ListTaskDefinitionsError
 	}
 
 	var arns []*string
@@ -495,8 +503,8 @@ func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDef
 func (c *ECSClient) DeregisterTaskDefinition(ctx context.Context, in *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error) {
 	c.DeregisterTaskDefinitionInput = in
 
-	if c.DeregisterTaskDefinitionOutput != nil {
-		return c.DeregisterTaskDefinitionOutput, nil
+	if c.DeregisterTaskDefinitionOutput != nil || c.DeregisterTaskDefinitionError != nil {
+		return c.DeregisterTaskDefinitionOutput, c.DeregisterTaskDefinitionError
 	}
 
 	if in.TaskDefinition == nil {
@@ -540,8 +548,8 @@ func parseFamilyAndRevision(taskDef string) (family string, revNum int, err erro
 func (c *ECSClient) RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
 	c.RunTaskInput = in
 
-	if c.RunTaskOutput != nil {
-		return c.RunTaskOutput, nil
+	if c.RunTaskOutput != nil || c.RunTaskError != nil {
+		return c.RunTaskOutput, c.RunTaskError
 	}
 
 	if in.TaskDefinition == nil {
@@ -583,8 +591,8 @@ func (c *ECSClient) getOrDefaultCluster(name *string) string {
 func (c *ECSClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
 	c.DescribeTasksInput = in
 
-	if c.DescribeTasksOutput != nil {
-		return c.DescribeTasksOutput, nil
+	if c.DescribeTasksOutput != nil || c.DescribeTasksError != nil {
+		return c.DescribeTasksOutput, c.DescribeTasksError
 	}
 
 	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]
@@ -621,8 +629,8 @@ func (c *ECSClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInpu
 func (c *ECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
 	c.ListTasksInput = in
 
-	if c.ListTasksOutput != nil {
-		return c.ListTasksOutput, nil
+	if c.ListTasksOutput != nil || c.ListTasksError != nil {
+		return c.ListTasksOutput, c.ListTasksError
 	}
 
 	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]
@@ -654,8 +662,8 @@ func (c *ECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs
 func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.StopTaskOutput, error) {
 	c.StopTaskInput = in
 
-	if c.StopTaskOutput != nil {
-		return c.StopTaskOutput, nil
+	if c.StopTaskOutput != nil || c.StopTaskError != nil {
+		return c.StopTaskOutput, c.StopTaskError
 	}
 
 	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -24,7 +24,7 @@ func TestECSPodCreator(t *testing.T) {
 
 	GlobalECSService.Clusters[testutil.ECSClusterName()] = ECSCluster{}
 
-	for tName, tCase := range ecsPodCreatorInputTests() {
+	for tName, tCase := range ecsPodCreatorTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, time.Second)
 			defer tcancel()
@@ -96,7 +96,9 @@ func TestECSPodCreator(t *testing.T) {
 	}
 }
 
-func ecsPodCreatorInputTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
+// ecsPodCreatorTests are mock-specific tests for ECS and Secrets Manager with
+// the ECS pod creator.
+func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
 	return map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient){
 		"RegistersTaskDefinitionAndRunsTaskWithAllFieldsSet": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
 			envVar := cocoa.NewEnvironmentVariable().

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -5,11 +5,15 @@ import (
 	"testing"
 	"time"
 
+	awsECS "github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/ecs"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/cocoa/secret"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,27 +26,208 @@ func TestECSPod(t *testing.T) {
 
 	GlobalECSService.Clusters[testutil.ECSClusterName()] = ECSCluster{}
 
-	c := &ECSClient{}
-	defer func() {
-		assert.NoError(t, c.Close(ctx))
-	}()
+	for tName, tCase := range ecsPodTests() {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			defer tcancel()
+
+			c := &ECSClient{}
+			defer func() {
+				assert.NoError(t, c.Close(ctx))
+			}()
+
+			smc := &SecretsManagerClient{}
+			defer func() {
+				assert.NoError(t, smc.Close(tctx))
+			}()
+			v := NewVault(secret.NewBasicSecretsManager(smc))
+
+			pc, err := ecs.NewBasicECSPodCreator(c, v)
+			require.NoError(t, err)
+			mpc := NewECSPodCreator(pc)
+
+			tCase(tctx, t, mpc, c, smc)
+		})
+	}
 
 	for tName, tCase := range testcase.ECSPodTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, time.Second)
 			defer tcancel()
 
-			sm := &SecretsManagerClient{}
+			c := &ECSClient{}
 			defer func() {
-				assert.NoError(t, c.Close(tctx))
+				assert.NoError(t, c.Close(ctx))
 			}()
-			v := NewVault(secret.NewBasicSecretsManager(sm))
+
+			smc := &SecretsManagerClient{}
+			defer func() {
+				assert.NoError(t, smc.Close(tctx))
+			}()
+			v := NewVault(secret.NewBasicSecretsManager(smc))
 
 			pc, err := ecs.NewBasicECSPodCreator(c, v)
 			require.NoError(t, err)
-			podCreator := NewECSPodCreator(pc)
+			mpc := NewECSPodCreator(pc)
 
-			tCase(tctx, t, v, podCreator)
+			tCase(tctx, t, mpc, c, v)
 		})
+	}
+}
+
+// ecsPodTests are mock-specific tests for ECS and Secrets Manager with ECS
+// pods.
+func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
+	makeSecretEnvVar := func(t *testing.T) *cocoa.EnvironmentVariable {
+		return cocoa.NewEnvironmentVariable().
+			SetName(t.Name()).
+			SetSecretOptions(*cocoa.NewSecretOptions().
+				SetName(t.Name()).
+				SetValue(utility.RandomString()).
+				SetOwned(true))
+	}
+	makeContainerDef := func(t *testing.T) *cocoa.ECSContainerDefinition {
+		return cocoa.NewECSContainerDefinition().
+			SetImage("image").
+			SetMemoryMB(128).
+			SetCPU(128).
+			SetName("container")
+	}
+
+	makePodCreationOpts := func(t *testing.T) *cocoa.ECSPodCreationOptions {
+		return cocoa.NewECSPodCreationOptions().
+			SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+			SetMemoryMB(128).
+			SetCPU(128).
+			SetTaskRole(testutil.TaskRole()).
+			SetExecutionRole(testutil.ExecutionRole()).
+			SetExecutionOptions(*cocoa.NewECSPodExecutionOptions().
+				SetCluster(testutil.ECSClusterName()))
+	}
+
+	checkPodDeleted := func(ctx context.Context, t *testing.T, p cocoa.ECSPod, c cocoa.ECSClient, smc cocoa.SecretsManagerClient, opts cocoa.ECSPodCreationOptions) {
+		info, err := p.Info(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, cocoa.StatusDeleted, info.Status)
+
+		describeTaskDef, err := c.DescribeTaskDefinition(ctx, &awsECS.DescribeTaskDefinitionInput{
+			TaskDefinition: info.Resources.TaskDefinition.ID,
+		})
+		require.NoError(t, err)
+		require.NotZero(t, describeTaskDef.TaskDefinition)
+		assert.Equal(t, utility.FromStringPtr(opts.Name), utility.FromStringPtr(describeTaskDef.TaskDefinition.Family))
+
+		describeTasks, err := c.DescribeTasks(ctx, &awsECS.DescribeTasksInput{
+			Cluster: info.Resources.Cluster,
+			Tasks:   []*string{info.Resources.TaskID},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, describeTasks.Failures)
+		require.Len(t, describeTasks.Tasks, 1)
+		assert.Equal(t, awsECS.DesiredStatusStopped, utility.FromStringPtr(describeTasks.Tasks[0].LastStatus))
+
+		for _, s := range info.Resources.Secrets {
+			_, err := smc.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{
+				SecretId: s.Name,
+			})
+			assert.NoError(t, err)
+			_, err = smc.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+				SecretId: s.Name,
+			})
+			assert.Error(t, err)
+		}
+	}
+
+	return map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient){
+		"StopIsIdempotentWhenItFails": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
+			opts := makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t))
+			p, err := pc.CreatePod(ctx, opts)
+			require.NoError(t, err)
+
+			c.StopTaskError = errors.New("fake error")
+
+			require.Error(t, p.Stop(ctx))
+
+			info, err := p.Info(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
+
+			c.StopTaskError = nil
+
+			require.NoError(t, p.Stop(ctx))
+			info, err = p.Info(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, cocoa.StatusStopped, info.Status)
+		},
+		"DeleteIsIdempotentWhenStoppingTaskFails": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
+			opts := makePodCreationOpts(t).AddContainerDefinitions(
+				*makeContainerDef(t).AddEnvironmentVariables(
+					*makeSecretEnvVar(t),
+				),
+			)
+			p, err := pc.CreatePod(ctx, opts)
+			require.NoError(t, err)
+
+			c.StopTaskError = errors.New("fake error")
+
+			require.Error(t, p.Delete(ctx))
+
+			info, err := p.Info(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, cocoa.StatusRunning, info.Status)
+
+			c.StopTaskError = nil
+
+			require.NoError(t, p.Delete(ctx))
+
+			checkPodDeleted(ctx, t, p, c, smc, *opts)
+		},
+		"DeleteIsIdempotentWhenDeregisteringTaskDefinitionFails": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
+			opts := makePodCreationOpts(t).AddContainerDefinitions(
+				*makeContainerDef(t).AddEnvironmentVariables(
+					*makeSecretEnvVar(t),
+				),
+			)
+			p, err := pc.CreatePod(ctx, opts)
+			require.NoError(t, err)
+
+			c.DeregisterTaskDefinitionError = errors.New("fake error")
+
+			require.Error(t, p.Delete(ctx))
+
+			info, err := p.Info(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, cocoa.StatusStopped, info.Status)
+
+			c.DeregisterTaskDefinitionError = nil
+
+			require.NoError(t, p.Delete(ctx))
+
+			checkPodDeleted(ctx, t, p, c, smc, *opts)
+		},
+		"DeleteIsIdempotentWhenDeletingSecretsFails": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
+			opts := makePodCreationOpts(t).AddContainerDefinitions(
+				*makeContainerDef(t).AddEnvironmentVariables(
+					*makeSecretEnvVar(t),
+				),
+			)
+			p, err := pc.CreatePod(ctx, opts)
+			require.NoError(t, err)
+
+			smc.DeleteSecretError = errors.New("fake error")
+
+			require.Error(t, p.Delete(ctx))
+
+			info, err := p.Info(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, cocoa.StatusStopped, info.Status)
+
+			smc.DeleteSecretError = nil
+
+			require.NoError(t, p.Delete(ctx))
+
+			checkPodDeleted(ctx, t, p, c, smc, *opts)
+
+		},
 	}
 }

--- a/mock/secrets_manager_client.go
+++ b/mock/secrets_manager_client.go
@@ -40,18 +40,22 @@ func init() {
 type SecretsManagerClient struct {
 	CreateSecretInput  *secretsmanager.CreateSecretInput
 	CreateSecretOutput *secretsmanager.CreateSecretOutput
+	CreateSecretError  error
 
 	GetSecretValueInput  *secretsmanager.GetSecretValueInput
 	GetSecretValueOutput *secretsmanager.GetSecretValueOutput
+	GetSecretValueError  error
 
 	DescribeSecretInput  *secretsmanager.DescribeSecretInput
 	DescribeSecretOutput *secretsmanager.DescribeSecretOutput
 
 	UpdateSecretInput  *secretsmanager.UpdateSecretInput
 	UpdateSecretOutput *secretsmanager.UpdateSecretOutput
+	UpdateSecretError  error
 
 	DeleteSecretInput  *secretsmanager.DeleteSecretInput
 	DeleteSecretOutput *secretsmanager.DeleteSecretOutput
+	DeleteSecretError  error
 }
 
 // CreateSecret saves the input options and returns a new mock secret. The mock
@@ -60,8 +64,8 @@ type SecretsManagerClient struct {
 func (c *SecretsManagerClient) CreateSecret(ctx context.Context, in *secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error) {
 	c.CreateSecretInput = in
 
-	if c.CreateSecretOutput != nil {
-		return c.CreateSecretOutput, nil
+	if c.CreateSecretOutput != nil || c.CreateSecretError != nil {
+		return c.CreateSecretOutput, c.CreateSecretError
 	}
 
 	if in.Name == nil {
@@ -94,8 +98,8 @@ func (c *SecretsManagerClient) CreateSecret(ctx context.Context, in *secretsmana
 func (c *SecretsManagerClient) GetSecretValue(ctx context.Context, in *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
 	c.GetSecretValueInput = in
 
-	if c.GetSecretValueOutput != nil {
-		return c.GetSecretValueOutput, nil
+	if c.GetSecretValueOutput != nil || c.GetSecretValueError != nil {
+		return c.GetSecretValueOutput, c.GetSecretValueError
 	}
 
 	if in.SecretId == nil {
@@ -159,8 +163,8 @@ func (c *SecretsManagerClient) DescribeSecret(ctx context.Context, in *secretsma
 func (c *SecretsManagerClient) UpdateSecretValue(ctx context.Context, in *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error) {
 	c.UpdateSecretInput = in
 
-	if c.UpdateSecretOutput != nil {
-		return c.UpdateSecretOutput, nil
+	if c.UpdateSecretOutput != nil || c.UpdateSecretError != nil {
+		return c.UpdateSecretOutput, c.UpdateSecretError
 	}
 
 	if in.SecretId == nil {
@@ -203,8 +207,8 @@ func (c *SecretsManagerClient) UpdateSecretValue(ctx context.Context, in *secret
 func (c *SecretsManagerClient) DeleteSecret(ctx context.Context, in *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error) {
 	c.DeleteSecretInput = in
 
-	if c.DeleteSecretOutput != nil {
-		return c.DeleteSecretOutput, nil
+	if c.DeleteSecretOutput != nil || c.DeleteSecretError != nil {
+		return c.DeleteSecretOutput, c.DeleteSecretError
 	}
 
 	if in.SecretId == nil {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15034

* Make stop and delete idempotent operations.
* Do more to clean up resources in ECS created by tests.
* Allow the mock clients to return fake errors.