### PR TITLE
EVG-15128: split pod info into resources and status

### DIFF
--- a/ecs/pod.go
+++ b/ecs/pod.go
@@ -115,12 +115,16 @@ func NewBasicECSPod(opts ...*BasicECSPodOptions) (*BasicECSPod, error) {
 	}, nil
 }
 
-// Info returns information about the current state of the pod.
-func (p *BasicECSPod) Info(ctx context.Context) (*cocoa.ECSPodInfo, error) {
-	return &cocoa.ECSPodInfo{
-		Status:    p.status,
-		Resources: p.resources,
-	}, nil
+// Resources returns information about the resources used by the pod.
+func (p *BasicECSPod) Resources() cocoa.ECSPodResources {
+	return p.resources
+}
+
+// Status returns the cached status of the pod.
+func (p *BasicECSPod) Status() cocoa.ECSPodStatusInfo {
+	return cocoa.ECSPodStatusInfo{
+		Status: p.status,
+	}
 }
 
 // Stop stops the running pod without cleaning up any of its underlying

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -88,13 +88,13 @@ func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPo
 		SetTaskDefinition(*taskDef).
 		SetTaskID(utility.FromStringPtr(runOut.Tasks[0].TaskArn))
 
-	options := NewBasicECSPodOptions().
+	podOpts := NewBasicECSPodOptions().
 		SetClient(m.client).
 		SetVault(m.vault).
-		SetStatus(cocoa.StatusRunning).
+		SetStatus(cocoa.StatusStarting).
 		SetResources(*resources)
 
-	p, err := NewBasicECSPod(options)
+	p, err := NewBasicECSPod(podOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating pod")
 	}

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -40,10 +40,9 @@ func TestBasicECSPod(t *testing.T) {
 			p, err := NewBasicECSPod(opts)
 			require.NoError(t, err)
 
-			info, err := p.Info(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, *res, info.Resources)
-			assert.Equal(t, stat, info.Status)
+			podRes := p.Resources()
+			assert.Equal(t, *res, podRes)
+			assert.Equal(t, stat, p.Status().Status)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -8,8 +8,12 @@ import (
 
 // ECSPod provides an abstraction of a pod backed by AWS ECS.
 type ECSPod interface {
-	// Info returns information about the current state of the pod.
-	Info(ctx context.Context) (*ECSPodInfo, error)
+	// Resources returns information about the current resources being used by
+	// the pod.
+	Resources() ECSPodResources
+	// Status returns the current cached status of the pod.
+	Status() ECSPodStatusInfo
+	// TODO (EVG-15161): add GetLatestStatus method to get non-cached status.
 	// Stop stops the running pod without cleaning up any of its underlying
 	// resources.
 	Stop(ctx context.Context) error
@@ -17,13 +21,9 @@ type ECSPod interface {
 	Delete(ctx context.Context) error
 }
 
-// ECSPodInfo provides information about the current status of the pod.
-type ECSPodInfo struct {
-	// Status is the current status of the pod.
+// ECSPodStatusInfo represents the current status of the pod.
+type ECSPodStatusInfo struct {
 	Status ECSPodStatus `bson:"-" json:"-" yaml:"-"`
-	// Resources provides information about the underlying ECS resources being
-	// used by the pod.
-	Resources ECSPodResources `bson:"-" json:"-" yaml:"-"`
 }
 
 // ECSPodResources are ECS-specific resources that a pod uses.
@@ -105,6 +105,9 @@ func (s *PodSecret) SetOwned(owned bool) *PodSecret {
 type ECSPodStatus string
 
 const (
+	// StatusUnknown indicates that the status of the ECS pod cannot be
+	// determined.
+	StatusUnknown ECSPodStatus = "unknown"
 	// StatusStarting indicates that the ECS pod is being prepared to run.
 	StatusStarting ECSPodStatus = "starting"
 	// StatusRunning indicates that the ECS pod is actively running.

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -72,9 +72,6 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			assert.NotZero(t, res.TaskDefinition)
 			assert.Equal(t, opts.ExecutionOpts.Cluster, res.Cluster)
 
-			stat := p.Status()
-			assert.Equal(t, cocoa.StatusStarting, stat.Status)
-
 			require.Len(t, res.Secrets, len(opts.ContainerDefinitions[0].EnvVars))
 			for _, s := range res.Secrets {
 				val, err := v.GetValue(ctx, utility.FromStringPtr(s.Name))

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -63,32 +63,37 @@ func ECSPodTests() map[string]ECSPodTestCase {
 
 			defer cleanupPod(ctx, t, p, c, v)
 
-			info, err := p.Info(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusRunning, info.Status)
-			assert.NotZero(t, info.Resources.TaskID)
-			assert.NotZero(t, info.Resources.TaskDefinition)
-			assert.Equal(t, opts.ExecutionOpts.Cluster, info.Resources.Cluster)
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusStarting, stat.Status)
 
-			require.Len(t, info.Resources.Secrets, len(opts.ContainerDefinitions[0].EnvVars))
-			for _, s := range info.Resources.Secrets {
+			res := p.Resources()
+			require.NoError(t, err)
+			assert.NotZero(t, res.TaskID)
+			assert.NotZero(t, res.TaskDefinition)
+			assert.Equal(t, opts.ExecutionOpts.Cluster, res.Cluster)
+
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusStarting, stat.Status)
+
+			require.Len(t, res.Secrets, len(opts.ContainerDefinitions[0].EnvVars))
+			for _, s := range res.Secrets {
 				val, err := v.GetValue(ctx, utility.FromStringPtr(s.Name))
 				require.NoError(t, err)
 				assert.Equal(t, utility.FromStringPtr(s.Value), val)
 				assert.True(t, utility.FromBoolPtr(s.Owned))
 			}
 
-			require.True(t, utility.FromBoolPtr(info.Resources.TaskDefinition.Owned))
+			require.True(t, utility.FromBoolPtr(res.TaskDefinition.Owned))
 			def, err := c.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
-				TaskDefinition: info.Resources.TaskDefinition.ID,
+				TaskDefinition: res.TaskDefinition.ID,
 			})
 			require.NoError(t, err)
 			require.NotZero(t, def.TaskDefinition)
 			assert.Equal(t, utility.FromStringPtr(opts.Name), utility.FromStringPtr(def.TaskDefinition.Family))
 
 			task, err := c.DescribeTasks(ctx, &ecs.DescribeTasksInput{
-				Cluster: info.Resources.Cluster,
-				Tasks:   []*string{info.Resources.TaskID},
+				Cluster: res.Cluster,
+				Tasks:   []*string{res.TaskID},
 			})
 			require.NoError(t, err)
 			require.Len(t, task.Tasks, 1)
@@ -108,10 +113,8 @@ func ECSPodTests() map[string]ECSPodTestCase {
 
 			require.NoError(t, p.Stop(ctx))
 
-			info, err := p.Info(ctx)
-			require.NoError(t, err)
-			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StatusStopped, info.Status)
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusStopped, stat.Status)
 		},
 		"StopSucceedsWithSecrets": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
 			secret := cocoa.NewEnvironmentVariable().
@@ -130,24 +133,22 @@ func ECSPodTests() map[string]ECSPodTestCase {
 
 			defer cleanupPod(ctx, t, p, c, v)
 
-			info, err := p.Info(ctx)
-			require.NoError(t, err)
-			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StatusRunning, info.Status)
-			assert.Len(t, info.Resources.Secrets, 2)
+			res := p.Resources()
+			assert.Len(t, res.Secrets, 2)
+
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusStarting, stat.Status)
 
 			require.NoError(t, p.Stop(ctx))
 
-			info, err = p.Info(ctx)
+			res = p.Resources()
+			require.Len(t, res.Secrets, 2)
+			val, err := v.GetValue(ctx, utility.FromStringPtr(res.Secrets[0].Name))
 			require.NoError(t, err)
-			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StatusStopped, info.Status)
-			require.Len(t, info.Resources.Secrets, 2)
+			assert.Equal(t, utility.FromStringPtr(secret.SecretOpts.Value), val)
 
-			arn := info.Resources.Secrets[0].Name
-			id, err := v.GetValue(ctx, *arn)
-			require.NoError(t, err)
-			require.NotNil(t, id)
+			stat = p.Status()
+			assert.Equal(t, cocoa.StatusStopped, stat.Status)
 		},
 		"StopIsIdempotent": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
 			opts := makePodCreationOpts(t).AddContainerDefinitions(
@@ -162,9 +163,8 @@ func ECSPodTests() map[string]ECSPodTestCase {
 
 			require.NoError(t, p.Stop(ctx))
 
-			info, err := p.Info(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusStopped, info.Status)
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusStopped, stat.Status)
 
 			require.NoError(t, p.Stop(ctx))
 		},
@@ -179,17 +179,13 @@ func ECSPodTests() map[string]ECSPodTestCase {
 
 			defer cleanupPod(ctx, t, p, c, v)
 
-			info, err := p.Info(ctx)
-			require.NoError(t, err)
-			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StatusRunning, info.Status)
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusStarting, stat.Status)
 
 			require.NoError(t, p.Delete(ctx))
 
-			info, err = p.Info(ctx)
-			require.NoError(t, err)
-			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StatusDeleted, info.Status)
+			stat = p.Status()
+			assert.Equal(t, cocoa.StatusDeleted, stat.Status)
 		},
 		"DeleteSucceedsWithSecrets": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
 			secret := cocoa.NewEnvironmentVariable().SetName(t.Name()).
@@ -204,28 +200,32 @@ func ECSPodTests() map[string]ECSPodTestCase {
 
 			defer cleanupPod(ctx, t, p, c, v)
 
-			info, err := p.Info(ctx)
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusStarting, stat.Status)
+
+			res := p.Resources()
+			require.Len(t, res.Secrets, 2)
+			val, err := v.GetValue(ctx, utility.FromStringPtr(res.Secrets[0].Name))
 			require.NoError(t, err)
-			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StatusRunning, info.Status)
-			require.Len(t, info.Resources.Secrets, 2)
+			assert.Equal(t, utility.FromStringPtr(secret.SecretOpts.Value), val)
+
+			val, err = v.GetValue(ctx, utility.FromStringPtr(res.Secrets[1].Name))
+			require.NoError(t, err)
+			assert.Equal(t, utility.FromStringPtr(ownedSecret.SecretOpts.Value), val)
 
 			require.NoError(t, p.Delete(ctx))
 
-			info, err = p.Info(ctx)
-			require.NoError(t, err)
-			require.NotNil(t, info)
-			assert.Equal(t, cocoa.StatusDeleted, info.Status)
-			require.Len(t, info.Resources.Secrets, 2)
+			stat = p.Status()
+			assert.Equal(t, cocoa.StatusDeleted, stat.Status)
 
-			arn0 := info.Resources.Secrets[0].Name
-			val, err := v.GetValue(ctx, *arn0)
-			require.NoError(t, err)
-			require.NotZero(t, val)
-			assert.Equal(t, *info.Resources.Secrets[0].NamedSecret.Value, *secret.SecretOpts.NamedSecret.Value)
+			res = p.Resources()
+			require.Len(t, res.Secrets, 2)
 
-			arn1 := info.Resources.Secrets[1].Name
-			_, err = v.GetValue(ctx, *arn1)
+			val, err = v.GetValue(ctx, utility.FromStringPtr(res.Secrets[0].Name))
+			require.NoError(t, err)
+			assert.Equal(t, utility.FromStringPtr(secret.SecretOpts.Value), val)
+
+			_, err = v.GetValue(ctx, utility.FromStringPtr(res.Secrets[1].Name))
 			require.Error(t, err)
 		},
 		"DeleteIsIdempotent": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
@@ -246,21 +246,20 @@ func ECSPodTests() map[string]ECSPodTestCase {
 // cleanupPod cleans up all resources regardless of whether they're owned by the
 // pod or not.
 func cleanupPod(ctx context.Context, t *testing.T, p cocoa.ECSPod, c cocoa.ECSClient, v cocoa.Vault) {
-	info, err := p.Info(ctx)
-	require.NoError(t, err)
+	res := p.Resources()
 
-	_, err = c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
-		TaskDefinition: info.Resources.TaskDefinition.ID,
+	_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
+		TaskDefinition: res.TaskDefinition.ID,
 	})
 	assert.NoError(t, err)
 
 	_, err = c.StopTask(ctx, &ecs.StopTaskInput{
-		Cluster: info.Resources.Cluster,
-		Task:    info.Resources.TaskID,
+		Cluster: res.Cluster,
+		Task:    res.TaskID,
 	})
 	assert.NoError(t, err)
 
-	for _, s := range info.Resources.Secrets {
+	for _, s := range res.Secrets {
 		assert.NoError(t, v.DeleteSecret(ctx, utility.FromStringPtr(s.Name)))
 	}
 }

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -81,9 +81,8 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				require.NoError(t, p.Delete(ctx))
 			}()
 
-			info, err := p.Info(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusRunning, info.Status)
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusStarting, stat.Status)
 		},
 	}
 }
@@ -159,9 +158,9 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				require.NoError(t, p.Delete(ctx))
 			}()
 
-			info, err := p.Info(ctx)
+			stat := p.Status()
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusRunning, info.Status)
+			assert.Equal(t, cocoa.StatusStarting, stat.Status)
 		},
 	}
 }

--- a/mock/ecs_pod.go
+++ b/mock/ecs_pod.go
@@ -6,12 +6,18 @@ import (
 	"github.com/evergreen-ci/cocoa"
 )
 
-// ECSPod provides a mock implementation of a cocoa.ECSPod. By default, it is
-// backed by a mock ECS pod.
+// ECSPod provides a mock implementation of a cocoa.ECSPod backed by another ECS
+// pod implementation.
 type ECSPod struct {
 	cocoa.ECSPod
 
-	InfoOutput *cocoa.ECSPodInfo
+	ResourcesOutput *cocoa.ECSPodResources
+
+	StatusOutput *cocoa.ECSPodStatusInfo
+
+	StopError error
+
+	DeleteError error
 }
 
 // NewECSPod creates a mock ECS Pod backed by the given ECSPod.
@@ -21,25 +27,45 @@ func NewECSPod(p cocoa.ECSPod) *ECSPod {
 	}
 }
 
-// Info returns mock information about the pod. The mock output can be
-// customized. By default, it will return its cached information.
-func (p *ECSPod) Info(ctx context.Context) (*cocoa.ECSPodInfo, error) {
-	if p.InfoOutput != nil {
-		return p.InfoOutput, nil
+// Status returns mock cached status information about the pod. The mock output
+// can be customized. By default, it will return the result of the backing ECS
+// pod.
+func (p *ECSPod) Status(ctx context.Context) cocoa.ECSPodStatusInfo {
+	if p.StatusOutput != nil {
+		return *p.StatusOutput
 	}
 
-	return p.ECSPod.Info(ctx)
+	return p.ECSPod.Status()
+}
+
+// Resources returns mock resource information about the pod. The mock output
+// can be customized. By default, it will return the result of the backing ECS
+// pod.
+func (p *ECSPod) Resources() cocoa.ECSPodResources {
+	if p.ResourcesOutput != nil {
+		return *p.ResourcesOutput
+	}
+
+	return p.ECSPod.Resources()
 }
 
 // Stop stops the mock pod. The mock output can be customized. By default, it
 // will set the cached status to stopped.
 func (p *ECSPod) Stop(ctx context.Context) error {
+	if p.StopError != nil {
+		return p.StopError
+	}
+
 	return p.ECSPod.Stop(ctx)
 }
 
 // Delete deletes the mock pod and all of its underlying resources. The mock
-// output can be customized. By default, it will delete its secrets from its
-// Vault. If it succeeds, it will set the cached status to deleted.
+// output can be customized. By default, it will return the result of the
+// backing ECS pod.
 func (p *ECSPod) Delete(ctx context.Context) error {
+	if p.DeleteError != nil {
+		return p.DeleteError
+	}
+
 	return p.ECSPod.Delete(ctx)
 }

--- a/mock/ecs_pod.go
+++ b/mock/ecs_pod.go
@@ -30,7 +30,7 @@ func NewECSPod(p cocoa.ECSPod) *ECSPod {
 // Status returns mock cached status information about the pod. The mock output
 // can be customized. By default, it will return the result of the backing ECS
 // pod.
-func (p *ECSPod) Status(ctx context.Context) cocoa.ECSPodStatusInfo {
+func (p *ECSPod) Status() cocoa.ECSPodStatusInfo {
 	if p.StatusOutput != nil {
 		return *p.StatusOutput
 	}

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -150,7 +150,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			require.Error(t, p.Stop(ctx))
 
 			stat := p.Status()
-			assert.Equal(t, cocoa.StatusRunning, stat.Status)
+			assert.Equal(t, cocoa.StatusStarting, stat.Status)
 
 			c.StopTaskError = nil
 
@@ -173,7 +173,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			stat := p.Status()
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusRunning, stat.Status)
+			assert.Equal(t, cocoa.StatusStarting, stat.Status)
 
 			c.StopTaskError = nil
 

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -106,27 +106,28 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 	}
 
 	checkPodDeleted := func(ctx context.Context, t *testing.T, p cocoa.ECSPod, c cocoa.ECSClient, smc cocoa.SecretsManagerClient, opts cocoa.ECSPodCreationOptions) {
-		info, err := p.Info(ctx)
-		require.NoError(t, err)
-		assert.Equal(t, cocoa.StatusDeleted, info.Status)
+		stat := p.Status()
+		assert.Equal(t, cocoa.StatusDeleted, stat.Status)
+
+		res := p.Resources()
 
 		describeTaskDef, err := c.DescribeTaskDefinition(ctx, &awsECS.DescribeTaskDefinitionInput{
-			TaskDefinition: info.Resources.TaskDefinition.ID,
+			TaskDefinition: res.TaskDefinition.ID,
 		})
 		require.NoError(t, err)
 		require.NotZero(t, describeTaskDef.TaskDefinition)
 		assert.Equal(t, utility.FromStringPtr(opts.Name), utility.FromStringPtr(describeTaskDef.TaskDefinition.Family))
 
 		describeTasks, err := c.DescribeTasks(ctx, &awsECS.DescribeTasksInput{
-			Cluster: info.Resources.Cluster,
-			Tasks:   []*string{info.Resources.TaskID},
+			Cluster: res.Cluster,
+			Tasks:   []*string{res.TaskID},
 		})
 		require.NoError(t, err)
 		assert.Empty(t, describeTasks.Failures)
 		require.Len(t, describeTasks.Tasks, 1)
 		assert.Equal(t, awsECS.DesiredStatusStopped, utility.FromStringPtr(describeTasks.Tasks[0].LastStatus))
 
-		for _, s := range info.Resources.Secrets {
+		for _, s := range res.Secrets {
 			_, err := smc.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{
 				SecretId: s.Name,
 			})
@@ -148,16 +149,14 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			require.Error(t, p.Stop(ctx))
 
-			info, err := p.Info(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusRunning, info.Status)
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusRunning, stat.Status)
 
 			c.StopTaskError = nil
 
 			require.NoError(t, p.Stop(ctx))
-			info, err = p.Info(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusStopped, info.Status)
+			stat = p.Status()
+			assert.Equal(t, cocoa.StatusStopped, stat.Status)
 		},
 		"DeleteIsIdempotentWhenStoppingTaskFails": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
 			opts := makePodCreationOpts(t).AddContainerDefinitions(
@@ -172,9 +171,9 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			require.Error(t, p.Delete(ctx))
 
-			info, err := p.Info(ctx)
+			stat := p.Status()
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusRunning, info.Status)
+			assert.Equal(t, cocoa.StatusRunning, stat.Status)
 
 			c.StopTaskError = nil
 
@@ -195,9 +194,9 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			require.Error(t, p.Delete(ctx))
 
-			info, err := p.Info(ctx)
+			stat := p.Status()
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusStopped, info.Status)
+			assert.Equal(t, cocoa.StatusStopped, stat.Status)
 
 			c.DeregisterTaskDefinitionError = nil
 
@@ -218,16 +217,14 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			require.Error(t, p.Delete(ctx))
 
-			info, err := p.Info(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusStopped, info.Status)
+			stat := p.Status()
+			assert.Equal(t, cocoa.StatusStopped, stat.Status)
 
 			smc.DeleteSecretError = nil
 
 			require.NoError(t, p.Delete(ctx))
 
 			checkPodDeleted(ctx, t, p, c, smc, *opts)
-
 		},
 	}
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15128

I split the info method for separation of concerns since we might want to get resources without getting the status and vice versa - I originally wrote the info method and combined the two just for convenience, but it makes sense to keep them separate. It also makes it easier to organize information when the statuses include both the aggregate pod status and each individual container's status (which will be done in a later ticket).