### PR TITLE
EVG-15104: expose container-level information in pods

### DIFF
--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -62,7 +62,9 @@ func TestBasicECSPodCreator(t *testing.T) {
 
 			c, err := NewBasicECSClient(*awsOpts)
 			require.NoError(t, err)
-			defer c.Close(ctx)
+			defer func() {
+				assert.NoError(t, c.Close(ctx))
+			}()
 
 			smc, err := secret.NewBasicSecretsManagerClient(awsutil.ClientOptions{
 				Creds:  credentials.NewEnvCredentials(),
@@ -109,7 +111,9 @@ func TestECSPodCreator(t *testing.T) {
 
 			c, err := NewBasicECSClient(*awsOpts)
 			require.NoError(t, err)
-			defer c.Close(tctx)
+			defer func() {
+				assert.NoError(t, c.Close(ctx))
+			}()
 
 			podCreator, err := NewBasicECSPodCreator(c, nil)
 			require.NoError(t, err)

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -3,6 +3,8 @@ package cocoa
 import (
 	"context"
 
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
 
@@ -11,8 +13,8 @@ type ECSPod interface {
 	// Resources returns information about the current resources being used by
 	// the pod.
 	Resources() ECSPodResources
-	// Status returns the current cached status of the pod.
-	Status() ECSPodStatusInfo
+	// StatusInfo returns the current cached status information for the pod.
+	StatusInfo() ECSPodStatusInfo
 	// TODO (EVG-15161): add GetLatestStatus method to get non-cached status.
 	// Stop stops the running pod without cleaning up any of its underlying
 	// resources.
@@ -21,17 +23,111 @@ type ECSPod interface {
 	Delete(ctx context.Context) error
 }
 
-// ECSPodStatusInfo represents the current status of the pod.
+// ECSPodStatusInfo represents the current status of a pod and its containers in
+// ECS.
 type ECSPodStatusInfo struct {
-	Status ECSPodStatus `bson:"-" json:"-" yaml:"-"`
+	// Status is the status of the pod as a whole.
+	Status ECSStatus `bson:"-" json:"-" yaml:"-"`
+	// Containers represent the status information of the individual containers
+	// within the pod.
+	Containers []ECSContainerStatusInfo `bson:"-" json:"-" yaml:"-"`
 }
 
-// ECSPodResources are ECS-specific resources that a pod uses.
+// NewECSPodStatusInfo returns a new uninitialized set of status information for
+// a pod.
+func NewECSPodStatusInfo() *ECSPodStatusInfo {
+	return &ECSPodStatusInfo{}
+}
+
+// SetStatus sets the status of the pod as a whole.
+func (i *ECSPodStatusInfo) SetStatus(status ECSStatus) *ECSPodStatusInfo {
+	i.Status = status
+	return i
+}
+
+// SetContainers sets the status information of the individual containers
+// associated with the pod. This overwrites any existing container status
+// information.
+func (i *ECSPodStatusInfo) SetContainers(containers []ECSContainerStatusInfo) *ECSPodStatusInfo {
+	i.Containers = containers
+	return i
+}
+
+// AddContainers adds new container status information to the existing ones
+// associated with the pod.
+func (i *ECSPodStatusInfo) AddContainers(containers ...ECSContainerStatusInfo) *ECSPodStatusInfo {
+	i.Containers = append(i.Containers, containers...)
+	return i
+}
+
+// Validate checks that the required pod status information is populated and the
+// pod status is valid.
+func (i *ECSPodStatusInfo) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.Wrap(i.Status.Validate(), "invalid pod status")
+	catcher.NewWhen(len(i.Containers) == 0, "missing container statuses")
+	for _, c := range i.Containers {
+		catcher.Wrapf(c.Validate(), "container '%s'", utility.FromStringPtr(c.Name))
+	}
+	return catcher.Resolve()
+}
+
+// ECSContainerStatusInfo represents the current status of a container in ECS.
+type ECSContainerStatusInfo struct {
+	// ContainerID is the resource identifier for the container.
+	ContainerID *string
+	// Name is the friendly name of the container.
+	Name *string
+	// Status is the current status of the container.
+	Status ECSStatus
+}
+
+// NewECSContainerStatusInfo returns a new uninitialized set of status
+// information for a container.
+func NewECSContainerStatusInfo() *ECSContainerStatusInfo {
+	return &ECSContainerStatusInfo{}
+}
+
+// SetContainerID sets the ECS container ID.
+func (i *ECSContainerStatusInfo) SetContainerID(id string) *ECSContainerStatusInfo {
+	i.ContainerID = &id
+	return i
+}
+
+// SetName sets the friendly name for the container.
+func (i *ECSContainerStatusInfo) SetName(name string) *ECSContainerStatusInfo {
+	i.Name = &name
+	return i
+}
+
+// SetStatus sets the status of the container.
+func (i *ECSContainerStatusInfo) SetStatus(status ECSStatus) *ECSContainerStatusInfo {
+	i.Status = status
+	return i
+}
+
+// Validate checks that the required container status information is populated
+// and the container status is valid.
+func (i *ECSContainerStatusInfo) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(utility.FromStringPtr(i.ContainerID) == "", "missing container ID")
+	catcher.NewWhen(utility.FromStringPtr(i.Name) == "", "missing container name")
+	catcher.Wrap(i.Status.Validate(), "invalid status")
+	return catcher.Resolve()
+}
+
+// ECSPodResources are ECS-specific resources associated with a pod.
 type ECSPodResources struct {
-	TaskID         *string            `bson:"-" json:"-" yaml:"-"`
+	// TaskID is the resource identifier for the pod.
+	TaskID *string `bson:"-" json:"-" yaml:"-"`
+	// TaskDefinition is the resource identifier for the definition template
+	// that created the pod.
 	TaskDefinition *ECSTaskDefinition `bson:"-" json:"-" yaml:"-"`
-	Cluster        *string            `bson:"-" json:"-" yaml:"-"`
-	Secrets        []PodSecret        `bson:"-" json:"-" yaml:"-"`
+	// Cluster is the name of the cluster namespace in which the pod is running.
+	Cluster *string `bson:"-" json:"-" yaml:"-"`
+	// Containers represent the resources associated with each individual
+	// container in the pod.
+	Containers []ECSContainerResources `bson:"-" json:"-" yaml:"-"`
 }
 
 // NewECSPodResources returns a new uninitialized set of resources used by a
@@ -58,70 +154,117 @@ func (r *ECSPodResources) SetCluster(cluster string) *ECSPodResources {
 	return r
 }
 
-// SetSecrets sets the secrets associated with the pod. This overwrites any
-// existing secrets.
-func (r *ECSPodResources) SetSecrets(secrets []PodSecret) *ECSPodResources {
+// SetContainers sets the containers associated with the pod. This overwrites
+// any existing containers.
+func (r *ECSPodResources) SetContainers(containers []ECSContainerResources) *ECSPodResources {
+	r.Containers = containers
+	return r
+}
+
+// AddContainers adds new containers to the existing ones associated with the
+// pod.
+func (r *ECSPodResources) AddContainers(containers ...ECSContainerResources) *ECSPodResources {
+	r.Containers = append(r.Containers, containers...)
+	return r
+}
+
+// ECSContainerResources are ECS-specific resources associated with a container.
+type ECSContainerResources struct {
+	// ContainerID is the resource identifier for the container.
+	ContainerID *string `bson:"-" json:"-" yaml:"-"`
+	// Name is the friendly name of the container.
+	Name *string `bson:"-" json:"-" yaml:"-"`
+	// Secrets are the secrets associated with the container.
+	Secrets []ContainerSecret `bson:"-" json:"-" yaml:"-"`
+}
+
+// NewECSContainerResources returns a new uninitialized set of resources used by
+// a container.
+func NewECSContainerResources() *ECSContainerResources {
+	return &ECSContainerResources{}
+}
+
+// SetContainerID sets the ECS container ID associated with the container.
+func (r *ECSContainerResources) SetContainerID(id string) *ECSContainerResources {
+	r.ContainerID = &id
+	return r
+}
+
+// SetName sets the friendly name for the container.
+func (r *ECSContainerResources) SetName(name string) *ECSContainerResources {
+	r.Name = &name
+	return r
+}
+
+// SetSecrets sets the secrets associated with the container. This overwrites
+// any existing secrets.
+func (r *ECSContainerResources) SetSecrets(secrets []ContainerSecret) *ECSContainerResources {
 	r.Secrets = secrets
 	return r
 }
 
-// AddSecrets adds new secrets to the existing ones associated with the pod.
-func (r *ECSPodResources) AddSecrets(secrets ...PodSecret) *ECSPodResources {
+// AddSecrets adds new secrets to the existing ones associated with the
+// container.
+func (r *ECSContainerResources) AddSecrets(secrets ...ContainerSecret) *ECSContainerResources {
 	r.Secrets = append(r.Secrets, secrets...)
 	return r
 }
 
-// PodSecret is a named secret that may or may not be owned by its pod.
-type PodSecret struct {
+// ContainerSecret is a named secret that may or may not be owned by its container.
+type ContainerSecret struct {
 	NamedSecret
-	// Owned determines whether or not the secret is owned by its pod or not.
+	// Owned determines whether or not the secret is owned by its container or
+	// not.
 	Owned *bool
 }
 
-// NewPodSecret creates a new uninitialized pod secret.
-func NewPodSecret() *PodSecret {
-	return &PodSecret{}
+// NewContainerSecret creates a new uninitialized container secret.
+func NewContainerSecret() *ContainerSecret {
+	return &ContainerSecret{}
 }
 
 // SetName sets the secret's name.
-func (s *PodSecret) SetName(name string) *PodSecret {
+func (s *ContainerSecret) SetName(name string) *ContainerSecret {
 	s.Name = &name
 	return s
 }
 
 // SetValue sets the secret's value.
-func (s *PodSecret) SetValue(val string) *PodSecret {
+func (s *ContainerSecret) SetValue(val string) *ContainerSecret {
 	s.Value = &val
 	return s
 }
 
-// SetOwned sets if the secret should be owned by its pod.
-func (s *PodSecret) SetOwned(owned bool) *PodSecret {
+// SetOwned sets if the secret should be owned by its container.
+func (s *ContainerSecret) SetOwned(owned bool) *ContainerSecret {
 	s.Owned = &owned
 	return s
 }
 
-// ECSPodStatus represents the different statuses possible for an ECS pod.
-type ECSPodStatus string
+// ECSStatus represents the different statuses possible for an ECS pod or
+// container.
+type ECSStatus string
 
 const (
-	// StatusUnknown indicates that the status of the ECS pod cannot be
+	// StatusUnknown indicates that the ECS pod or container status cannot be
 	// determined.
-	StatusUnknown ECSPodStatus = "unknown"
-	// StatusStarting indicates that the ECS pod is being prepared to run.
-	StatusStarting ECSPodStatus = "starting"
-	// StatusRunning indicates that the ECS pod is actively running.
-	StatusRunning ECSPodStatus = "running"
-	// StatusStopped indicates the that ECS pod is stopped, but all of its
-	// resources are still available.
-	StatusStopped ECSPodStatus = "stopped"
-	// StatusDeleted indicates that the ECS pod has been cleaned up completely,
-	// including all of its resources.
-	StatusDeleted ECSPodStatus = "deleted"
+	StatusUnknown ECSStatus = "unknown"
+	// StatusStarting indicates that the ECS pod or container is being prepared
+	// to run.
+	StatusStarting ECSStatus = "starting"
+	// StatusRunning indicates that the ECS pod or container is actively
+	// running.
+	StatusRunning ECSStatus = "running"
+	// StatusStopped indicates the that ECS pod or container is stopped. For a
+	// pod, all of its resources are still available even if it's stopped.
+	StatusStopped ECSStatus = "stopped"
+	// StatusDeleted indicates that the ECS pod or container has been cleaned up
+	// completely, including all of its resources.
+	StatusDeleted ECSStatus = "deleted"
 )
 
-// Validate checks that the ECS pod status is one of the recognized statuses.
-func (s ECSPodStatus) Validate() error {
+// Validate checks that the ECS status is one of the recognized statuses.
+func (s ECSStatus) Validate() error {
 	switch s {
 	case StatusStarting, StatusRunning, StatusStopped, StatusDeleted:
 		return nil

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -444,9 +444,9 @@ func (e *EnvironmentVariable) Validate() error {
 }
 
 // SecretOptions represents a secret with a name and value that may or may not
-// be owned by its pod.
+// be owned by its container.
 type SecretOptions struct {
-	PodSecret
+	ContainerSecret
 	// Exists determines whether or not the secret already exists or must be
 	// created before it can be used.
 	Exists *bool

--- a/ecs_pod_test.go
+++ b/ecs_pod_test.go
@@ -9,24 +9,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPodSecret(t *testing.T) {
-	t.Run("NewPodSecret", func(t *testing.T) {
-		s := NewPodSecret()
+func TestContainerSecret(t *testing.T) {
+	t.Run("NewContainerSecret", func(t *testing.T) {
+		s := NewContainerSecret()
 		require.NotZero(t, s)
 		assert.Zero(t, *s)
 	})
 	t.Run("SetName", func(t *testing.T) {
 		name := "name"
-		s := NewPodSecret().SetName(name)
+		s := NewContainerSecret().SetName(name)
 		assert.Equal(t, name, utility.FromStringPtr(s.Name))
 	})
 	t.Run("SetValue", func(t *testing.T) {
 		val := "val"
-		s := NewPodSecret().SetValue(val)
+		s := NewContainerSecret().SetValue(val)
 		assert.Equal(t, val, utility.FromStringPtr(s.Value))
 	})
 	t.Run("SetOwned", func(t *testing.T) {
-		s := NewPodSecret().SetOwned(true)
+		s := NewContainerSecret().SetOwned(true)
 		assert.True(t, utility.FromBoolPtr(s.Owned))
 	})
 }
@@ -48,31 +48,130 @@ func TestECSPodResources(t *testing.T) {
 		require.NotZero(t, res.TaskDefinition)
 		assert.Equal(t, *def, *res.TaskDefinition)
 	})
-	t.Run("SetSecrets", func(t *testing.T) {
-		s := NewPodSecret().SetName("name").SetValue("value")
-		res := NewECSPodResources().SetSecrets([]PodSecret{*s})
-		require.Len(t, res.Secrets, 1)
-		assert.Equal(t, *s, res.Secrets[0])
-	})
-	t.Run("AddSecrets", func(t *testing.T) {
-		s0 := NewPodSecret().SetName("name0").SetValue("value0")
-		s1 := NewPodSecret().SetName("name1").SetValue("value1")
-		res := NewECSPodResources().AddSecrets(*s0, *s1)
-		require.Len(t, res.Secrets, 2)
-		assert.Equal(t, *s0, res.Secrets[0])
-		assert.Equal(t, *s1, res.Secrets[1])
-	})
 	t.Run("SetCluster", func(t *testing.T) {
 		cluster := "cluster"
 		res := NewECSPodResources().SetCluster(cluster)
 		require.NotZero(t, res.Cluster)
 		assert.Equal(t, cluster, *res.Cluster)
 	})
+	t.Run("SetContainers", func(t *testing.T) {
+		containerRes := NewECSContainerResources().SetContainerID("id").SetName("name")
+		res := NewECSPodResources().SetContainers([]ECSContainerResources{*containerRes})
+		require.Len(t, res.Containers, 1)
+		assert.Equal(t, *containerRes, res.Containers[0])
+	})
+	t.Run("AddContainers", func(t *testing.T) {
+		containerRes0 := NewECSContainerResources().SetContainerID("id0").SetName("name0")
+		containerRes1 := NewECSContainerResources().SetContainerID("id1").SetName("name1")
+		res := NewECSPodResources().AddContainers(*containerRes0, *containerRes1)
+		require.Len(t, res.Containers, 2)
+		assert.Equal(t, *containerRes0, res.Containers[0])
+		assert.Equal(t, *containerRes1, res.Containers[1])
+	})
 }
 
-func TestECSPodStatus(t *testing.T) {
+func TestECSContainerResources(t *testing.T) {
+	t.Run("NewECSContainerResources", func(t *testing.T) {
+		res := NewECSContainerResources()
+		require.NotZero(t, res)
+		assert.Zero(t, *res)
+	})
+	t.Run("SetContainerID", func(t *testing.T) {
+		id := "id"
+		res := NewECSContainerResources().SetContainerID(id)
+		require.NotZero(t, res.ContainerID)
+		assert.Equal(t, id, utility.FromStringPtr(res.ContainerID))
+	})
+	t.Run("SetName", func(t *testing.T) {
+		id := "id"
+		res := NewECSContainerResources().SetName(id)
+		require.NotZero(t, res.Name)
+		assert.Equal(t, id, utility.FromStringPtr(res.Name))
+	})
+	t.Run("SetSecrets", func(t *testing.T) {
+		s := NewContainerSecret().SetName("name").SetValue("value")
+		res := NewECSContainerResources().SetSecrets([]ContainerSecret{*s})
+		require.Len(t, res.Secrets, 1)
+		assert.Equal(t, *s, res.Secrets[0])
+	})
+	t.Run("AddSecrets", func(t *testing.T) {
+		s0 := NewContainerSecret().SetName("name0").SetValue("value0")
+		s1 := NewContainerSecret().SetName("name1").SetValue("value1")
+		res := NewECSContainerResources().AddSecrets(*s0, *s1)
+		require.Len(t, res.Secrets, 2)
+		assert.Equal(t, *s0, res.Secrets[0])
+		assert.Equal(t, *s1, res.Secrets[1])
+	})
+}
+
+func TestECSStatusInfo(t *testing.T) {
+	t.Run("NewECSPodStatusInfo", func(t *testing.T) {
+		stat := NewECSPodStatusInfo()
+		require.NotZero(t, stat)
+		assert.Zero(t, *stat)
+	})
+	t.Run("SetStatus", func(t *testing.T) {
+		stat := NewECSPodStatusInfo().SetStatus(StatusRunning)
+		assert.Equal(t, StatusRunning, stat.Status)
+	})
+	t.Run("SetContainers", func(t *testing.T) {
+		containerStat0 := NewECSContainerStatusInfo().
+			SetContainerID("container_id0").
+			SetName("container_name0").
+			SetStatus(StatusRunning)
+		containerStat1 := NewECSContainerStatusInfo().
+			SetContainerID("container_id1").
+			SetName("container_name1").
+			SetStatus(StatusRunning)
+		stat := NewECSPodStatusInfo().SetContainers([]ECSContainerStatusInfo{
+			*containerStat0, *containerStat1,
+		})
+		require.Len(t, stat.Containers, 2)
+		assert.Equal(t, *containerStat0, stat.Containers[0])
+		assert.Equal(t, *containerStat1, stat.Containers[1])
+	})
+	t.Run("AddContainers", func(t *testing.T) {
+		containerStat := NewECSContainerStatusInfo().
+			SetContainerID("container_id0").
+			SetName("container_name0").
+			SetStatus(StatusRunning)
+
+		stat := NewECSPodStatusInfo().AddContainers(*containerStat)
+		require.Len(t, stat.Containers, 1)
+		assert.Equal(t, *containerStat, stat.Containers[0])
+
+		stat.AddContainers()
+		require.Len(t, stat.Containers, 1)
+		assert.Equal(t, *containerStat, stat.Containers[0])
+	})
+}
+
+func TestECSContainerStatusInfo(t *testing.T) {
+	t.Run("NewECSContainerStatusInfo", func(t *testing.T) {
+		stat := NewECSContainerStatusInfo()
+		require.NotZero(t, stat)
+		assert.Zero(t, *stat)
+	})
+	t.Run("SetContainerID", func(t *testing.T) {
+		id := "container_id"
+		stat := NewECSContainerStatusInfo().SetContainerID(id)
+		assert.Equal(t, id, utility.FromStringPtr(stat.ContainerID))
+	})
+	t.Run("SetName", func(t *testing.T) {
+		name := "name"
+		stat := NewECSContainerStatusInfo().SetName(name)
+		assert.Equal(t, name, utility.FromStringPtr(stat.Name))
+	})
+	t.Run("SetStatus", func(t *testing.T) {
+		status := StatusRunning
+		stat := NewECSContainerStatusInfo().SetStatus(status)
+		assert.Equal(t, status, stat.Status)
+	})
+}
+
+func TestECSStatus(t *testing.T) {
 	t.Run("Validate", func(t *testing.T) {
-		for _, s := range []ECSPodStatus{
+		for _, s := range []ECSStatus{
 			StatusStarting,
 			StatusRunning,
 			StatusStopped,
@@ -83,10 +182,10 @@ func TestECSPodStatus(t *testing.T) {
 			})
 		}
 		t.Run("FailsForEmptyStatus", func(t *testing.T) {
-			assert.Error(t, ECSPodStatus("").Validate())
+			assert.Error(t, ECSStatus("").Validate())
 		})
 		t.Run("FailsForInvalidStatus", func(t *testing.T) {
-			assert.Error(t, ECSPodStatus("invalid").Validate())
+			assert.Error(t, ECSStatus("invalid").Validate())
 		})
 	})
 }

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -105,8 +105,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				require.NoError(t, p.Delete(ctx))
 			}()
 
-			stat := p.Status()
-			assert.Equal(t, cocoa.StatusStarting, stat.Status)
+			checkPodStatus(t, p, cocoa.StatusStarting)
 		},
 		"CreatePodSucceeds": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
 			containerDef := cocoa.NewECSContainerDefinition().
@@ -134,8 +133,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				require.NoError(t, p.Delete(ctx))
 			}()
 
-			stat := p.Status()
-			assert.Equal(t, cocoa.StatusStarting, stat.Status)
+			checkPodStatus(t, p, cocoa.StatusStarting)
 		},
 	}
 }
@@ -207,9 +205,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				require.NoError(t, p.Delete(ctx))
 			}()
 
-			stat := p.Status()
-			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusStarting, stat.Status)
+			checkPodStatus(t, p, cocoa.StatusStarting)
 		},
 		"CreatePodSucceedsWithNewlyCreatedRepoCreds": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
 			storedCreds := cocoa.NewStoredRepositoryCredentials().
@@ -248,9 +244,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				require.NoError(t, p.Delete(ctx))
 			}()
 
-			stat := p.Status()
-			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusStarting, stat.Status)
+			checkPodStatus(t, p, cocoa.StatusStarting)
 		},
 	}
 }

--- a/mock/ecs_pod.go
+++ b/mock/ecs_pod.go
@@ -27,15 +27,15 @@ func NewECSPod(p cocoa.ECSPod) *ECSPod {
 	}
 }
 
-// Status returns mock cached status information about the pod. The mock output
-// can be customized. By default, it will return the result of the backing ECS
-// pod.
-func (p *ECSPod) Status() cocoa.ECSPodStatusInfo {
+// StatusInfo returns mock cached status information about the pod. The mock
+// output can be customized. By default, it will return the result of the
+// backing ECS pod.
+func (p *ECSPod) StatusInfo() cocoa.ECSPodStatusInfo {
 	if p.StatusOutput != nil {
 		return *p.StatusOutput
 	}
 
-	return p.ECSPod.Status()
+	return p.ECSPod.StatusInfo()
 }
 
 // Resources returns mock resource information about the pod. The mock output


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15104

* Expose container-level information about pods. Container ARNs is available in the resource information and container-level statuses are availabe in the status information, which are associated with the container names that users can provide as input. Secrets are now tied to individual containers rather than the pod as a whole.
* Refactors some structs to reflect new assumptions that secrets are per-container and containers have their own statuses.
* Test new container-level information.
* Clean up some copy-pasting within tests.