### PR TITLE
EVG-15174: add pod network settings

### DIFF
--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -31,7 +31,7 @@ func NewBasicECSPodCreator(c cocoa.ECSClient, v cocoa.Vault) (*BasicECSPodCreato
 }
 
 // CreatePod creates a new pod backed by AWS ECS.
-func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPodCreationOptions) (cocoa.ECSPod, error) {
+func (pc *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPodCreationOptions) (cocoa.ECSPod, error) {
 	mergedPodCreationOpts := cocoa.MergeECSPodCreationOptions(opts...)
 	mergedPodExecutionOpts := cocoa.MergeECSPodExecutionOptions(mergedPodCreationOpts.ExecutionOpts)
 
@@ -43,21 +43,21 @@ func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPo
 		return nil, errors.Wrap(err, "invalid pod execution options")
 	}
 
-	secrets := m.getSecrets(mergedPodCreationOpts)
+	secrets := pc.getSecrets(mergedPodCreationOpts)
 
-	repoCreds, err := m.getRepoCreds(mergedPodCreationOpts)
+	repoCreds, err := pc.getRepoCreds(mergedPodCreationOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting secret repository credentials")
 	}
 
-	resolvedSecrets, err := m.createSecrets(ctx, m.mergeSecrets(secrets, repoCreds))
+	resolvedSecrets, err := pc.createSecrets(ctx, pc.mergeSecrets(secrets, repoCreds))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating secret repository credentials")
 	}
 
-	taskDefinition := m.exportPodCreationOptions(mergedPodCreationOpts)
+	taskDefinition := pc.exportPodCreationOptions(mergedPodCreationOpts)
 
-	registerOut, err := m.client.RegisterTaskDefinition(ctx, taskDefinition)
+	registerOut, err := pc.client.RegisterTaskDefinition(ctx, taskDefinition)
 	if err != nil {
 		return nil, errors.Wrap(err, "registering task definition")
 	}
@@ -70,9 +70,9 @@ func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPo
 		SetID(utility.FromStringPtr(registerOut.TaskDefinition.TaskDefinitionArn)).
 		SetOwned(true)
 
-	runTask := m.exportTaskExecutionOptions(mergedPodExecutionOpts, *taskDef)
+	runTask := pc.exportTaskExecutionOptions(mergedPodExecutionOpts, *taskDef)
 
-	runOut, err := m.client.RunTask(ctx, runTask)
+	runOut, err := pc.client.RunTask(ctx, runTask)
 	if err != nil {
 		return nil, errors.Wrapf(err, "running task for definition '%s' in cluster '%s'", utility.FromStringPtr(runTask.TaskDefinition), utility.FromStringPtr(runTask.Cluster))
 	}
@@ -91,14 +91,14 @@ func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPo
 
 	resources := cocoa.NewECSPodResources().
 		SetCluster(utility.FromStringPtr(mergedPodExecutionOpts.Cluster)).
-		SetContainers(translateContainerResources(runOut.Tasks[0].Containers, resolvedSecrets)).
+		SetContainers(pc.translateContainerResources(runOut.Tasks[0].Containers, resolvedSecrets)).
 		SetTaskDefinition(*taskDef).
 		SetTaskID(utility.FromStringPtr(runOut.Tasks[0].TaskArn))
 
 	podOpts := NewBasicECSPodOptions().
-		SetClient(m.client).
-		SetVault(m.vault).
-		SetStatusInfo(translatePodStatusInfo(runOut.Tasks[0])).
+		SetClient(pc.client).
+		SetVault(pc.vault).
+		SetStatusInfo(pc.translatePodStatusInfo(runOut.Tasks[0])).
 		SetResources(*resources)
 
 	p, err := NewBasicECSPod(podOpts)
@@ -111,13 +111,13 @@ func (m *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPo
 
 // CreatePodFromExistingDefinition creates a new pod backed by AWS ECS from an
 // existing definition.
-func (m *BasicECSPodCreator) CreatePodFromExistingDefinition(ctx context.Context, def cocoa.ECSTaskDefinition, opts ...*cocoa.ECSPodExecutionOptions) (cocoa.ECSPod, error) {
+func (pc *BasicECSPodCreator) CreatePodFromExistingDefinition(ctx context.Context, def cocoa.ECSTaskDefinition, opts ...*cocoa.ECSPodExecutionOptions) (cocoa.ECSPod, error) {
 	return nil, errors.New("TODO: implement")
 }
 
 // getSecrets retrieves the secrets from the secret environment variables for
 // each container.
-func (m *BasicECSPodCreator) getSecrets(opts cocoa.ECSPodCreationOptions) map[string][]cocoa.SecretOptions {
+func (pc *BasicECSPodCreator) getSecrets(opts cocoa.ECSPodCreationOptions) map[string][]cocoa.SecretOptions {
 	containerSecrets := map[string][]cocoa.SecretOptions{}
 
 	for _, def := range opts.ContainerDefinitions {
@@ -133,12 +133,12 @@ func (m *BasicECSPodCreator) getSecrets(opts cocoa.ECSPodCreationOptions) map[st
 }
 
 // createSecrets creates secrets that do not already exist for each container.
-func (m *BasicECSPodCreator) createSecrets(ctx context.Context, containerSecrets map[string][]cocoa.SecretOptions) (map[string][]cocoa.SecretOptions, error) {
+func (pc *BasicECSPodCreator) createSecrets(ctx context.Context, containerSecrets map[string][]cocoa.SecretOptions) (map[string][]cocoa.SecretOptions, error) {
 	resolvedSecrets := map[string][]cocoa.SecretOptions{}
 
 	for containerName, secrets := range containerSecrets {
 		for _, opts := range secrets {
-			resolvedOpts, err := m.createSecret(ctx, opts)
+			resolvedOpts, err := pc.createSecret(ctx, opts)
 			if err != nil {
 				return nil, errors.Wrapf(err, "creating secret '%s' for container '%s'", utility.FromStringPtr(opts.ContainerSecret.Name), containerName)
 			}
@@ -151,14 +151,14 @@ func (m *BasicECSPodCreator) createSecrets(ctx context.Context, containerSecrets
 
 // createSecret creates a single secret for a container if it does not exist
 // yet.
-func (m *BasicECSPodCreator) createSecret(ctx context.Context, secret cocoa.SecretOptions) (*cocoa.SecretOptions, error) {
+func (pc *BasicECSPodCreator) createSecret(ctx context.Context, secret cocoa.SecretOptions) (*cocoa.SecretOptions, error) {
 	if utility.FromBoolPtr(secret.Exists) {
 		return &secret, nil
 	}
-	if m.vault == nil {
+	if pc.vault == nil {
 		return nil, errors.New("no vault was specified")
 	}
-	arn, err := m.vault.CreateSecret(ctx, secret.ContainerSecret.NamedSecret)
+	arn, err := pc.vault.CreateSecret(ctx, secret.ContainerSecret.NamedSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -210,8 +210,8 @@ func (m *BasicECSPodCreator) mergeSecrets(secrets map[string][]cocoa.SecretOptio
 	return merged
 }
 
-// exportTags converts a mapping of string-string into ECS tags.
-func exportTags(tags map[string]string) []*ecs.Tag {
+// exportTags converts a mapping of tag names to values into ECS tags.
+func (pc *BasicECSPodCreator) exportTags(tags map[string]string) []*ecs.Tag {
 	var ecsTags []*ecs.Tag
 	for k, v := range tags {
 		ecsTag := &ecs.Tag{}
@@ -223,15 +223,15 @@ func exportTags(tags map[string]string) []*ecs.Tag {
 
 // exportStrategy converts the strategy and parameter into an ECS placement
 // strategy.
-func exportStrategy(strategy *cocoa.ECSPlacementStrategy, param *cocoa.ECSStrategyParameter) []*ecs.PlacementStrategy {
+func (pc *BasicECSPodCreator) exportStrategy(opts *cocoa.ECSPodPlacementOptions) []*ecs.PlacementStrategy {
 	var placementStrat ecs.PlacementStrategy
-	placementStrat.SetType(string(*strategy)).SetField(utility.FromStringPtr(param))
+	placementStrat.SetType(string(*opts.Strategy)).SetField(utility.FromStringPtr(opts.StrategyParameter))
 	return []*ecs.PlacementStrategy{&placementStrat}
 }
 
-// exportPlacementConstraints converts the placement options into placement
+// exportPlacementConstraints converts the placement options into ECS placement
 // constraints.
-func exportPlacementConstraints(opts *cocoa.ECSPodPlacementOptions) []*ecs.PlacementConstraint {
+func (pc *BasicECSPodCreator) exportPlacementConstraints(opts *cocoa.ECSPodPlacementOptions) []*ecs.PlacementConstraint {
 	var constraints []*ecs.PlacementConstraint
 	for _, filter := range opts.InstanceFilters {
 		var constraint ecs.PlacementConstraint
@@ -243,8 +243,9 @@ func exportPlacementConstraints(opts *cocoa.ECSPodPlacementOptions) []*ecs.Place
 
 // exportEnvVars converts the non-secret environment variables into ECS
 // environment variables.
-func exportEnvVars(envVars []cocoa.EnvironmentVariable) []*ecs.KeyValuePair {
+func (pc *BasicECSPodCreator) exportEnvVars(envVars []cocoa.EnvironmentVariable) []*ecs.KeyValuePair {
 	var converted []*ecs.KeyValuePair
+
 	for _, envVar := range envVars {
 		if envVar.SecretOpts != nil {
 			continue
@@ -253,13 +254,15 @@ func exportEnvVars(envVars []cocoa.EnvironmentVariable) []*ecs.KeyValuePair {
 		pair.SetName(utility.FromStringPtr(envVar.Name)).SetValue(utility.FromStringPtr(envVar.Value))
 		converted = append(converted, &pair)
 	}
+
 	return converted
 }
 
 // exportSecrets converts environment variables backed by secrets into ECS
 // Secrets.
-func exportSecrets(envVars []cocoa.EnvironmentVariable) []*ecs.Secret {
+func (pc *BasicECSPodCreator) exportSecrets(envVars []cocoa.EnvironmentVariable) []*ecs.Secret {
 	var secrets []*ecs.Secret
+
 	for _, envVar := range envVars {
 		if envVar.SecretOpts != nil {
 			var secret ecs.Secret
@@ -268,12 +271,13 @@ func exportSecrets(envVars []cocoa.EnvironmentVariable) []*ecs.Secret {
 			secrets = append(secrets, &secret)
 		}
 	}
+
 	return secrets
 }
 
-// translateContainerResources translates the created containers and stored
-// secrets into the resources associated with each container.
-func translateContainerResources(containers []*ecs.Container, containerSecrets map[string][]cocoa.SecretOptions) []cocoa.ECSContainerResources {
+// translateContainerResources translates the stored secrets into the resources
+// associated with each container.
+func (pc *BasicECSPodCreator) translateContainerResources(containers []*ecs.Container, containerSecrets map[string][]cocoa.SecretOptions) []cocoa.ECSContainerResources {
 	containerResourcesSet := map[string]cocoa.ECSContainerResources{}
 
 	for _, container := range containers {
@@ -288,7 +292,7 @@ func translateContainerResources(containers []*ecs.Container, containerSecrets m
 
 	for name, opts := range containerSecrets {
 		res := containerResourcesSet[name]
-		res.SetSecrets(translateContainerSecrets(opts))
+		res.SetSecrets(pc.translateContainerSecrets(opts))
 		containerResourcesSet[name] = res
 	}
 
@@ -301,13 +305,13 @@ func translateContainerResources(containers []*ecs.Container, containerSecrets m
 	return containerResources
 }
 
-func translatePodStatusInfo(task *ecs.Task) cocoa.ECSPodStatusInfo {
+func (pc *BasicECSPodCreator) translatePodStatusInfo(task *ecs.Task) cocoa.ECSPodStatusInfo {
 	return *cocoa.NewECSPodStatusInfo().
-		SetStatus(translateECSStatus(task.LastStatus)).
-		SetContainers(translateContainerStatusInfo(task.Containers))
+		SetStatus(pc.translateECSStatus(task.LastStatus)).
+		SetContainers(pc.translateContainerStatusInfo(task.Containers))
 }
 
-func translateContainerStatusInfo(containers []*ecs.Container) []cocoa.ECSContainerStatusInfo {
+func (pc *BasicECSPodCreator) translateContainerStatusInfo(containers []*ecs.Container) []cocoa.ECSContainerStatusInfo {
 	var statuses []cocoa.ECSContainerStatusInfo
 
 	for _, container := range containers {
@@ -317,14 +321,16 @@ func translateContainerStatusInfo(containers []*ecs.Container) []cocoa.ECSContai
 		status := cocoa.NewECSContainerStatusInfo().
 			SetContainerID(utility.FromStringPtr(container.ContainerArn)).
 			SetName(utility.FromStringPtr(container.Name)).
-			SetStatus(translateECSStatus(container.LastStatus))
+			SetStatus(pc.translateECSStatus(container.LastStatus))
 		statuses = append(statuses, *status)
 	}
 
 	return statuses
 }
 
-func translateECSStatus(status *string) cocoa.ECSStatus {
+// translateECSStatus translate the ECS status into its equivalent cocoa
+// status.
+func (pc *BasicECSPodCreator) translateECSStatus(status *string) cocoa.ECSStatus {
 	if status == nil {
 		return cocoa.StatusUnknown
 	}
@@ -341,7 +347,7 @@ func translateECSStatus(status *string) cocoa.ECSStatus {
 }
 
 // translateContainerSecrets translates secret options into container secrets.
-func translateContainerSecrets(secrets []cocoa.SecretOptions) []cocoa.ContainerSecret {
+func (pc *BasicECSPodCreator) translateContainerSecrets(secrets []cocoa.SecretOptions) []cocoa.ContainerSecret {
 	var containerSecrets []cocoa.ContainerSecret
 
 	for _, secret := range secrets {
@@ -351,13 +357,14 @@ func translateContainerSecrets(secrets []cocoa.SecretOptions) []cocoa.ContainerS
 	return containerSecrets
 }
 
-// exportPodCreationOptions converts options to create a pod into its equivalent ECS task definition.
-func (m *BasicECSPodCreator) exportPodCreationOptions(opts cocoa.ECSPodCreationOptions) *ecs.RegisterTaskDefinitionInput {
+// exportPodCreationOptions converts options to create a pod into its equivalent
+// ECS task definition.
+func (pc *BasicECSPodCreator) exportPodCreationOptions(opts cocoa.ECSPodCreationOptions) *ecs.RegisterTaskDefinitionInput {
 	var taskDef ecs.RegisterTaskDefinitionInput
 
 	var containerDefs []*ecs.ContainerDefinition
 	for _, def := range opts.ContainerDefinitions {
-		containerDefs = append(containerDefs, exportContainerDefinition(def))
+		containerDefs = append(containerDefs, pc.exportContainerDefinition(def))
 	}
 	taskDef.SetContainerDefinitions(containerDefs)
 
@@ -369,17 +376,21 @@ func (m *BasicECSPodCreator) exportPodCreationOptions(opts cocoa.ECSPodCreationO
 		taskDef.SetCpu(strconv.Itoa(cpu))
 	}
 
+	if opts.NetworkMode != nil {
+		taskDef.SetNetworkMode(string(*opts.NetworkMode))
+	}
+
 	taskDef.SetFamily(utility.FromStringPtr(opts.Name)).
 		SetTaskRoleArn(utility.FromStringPtr(opts.TaskRole)).
 		SetExecutionRoleArn(utility.FromStringPtr(opts.ExecutionRole)).
-		SetTags(exportTags(opts.Tags))
+		SetTags(pc.exportTags(opts.Tags))
 
 	return &taskDef
 }
 
 // exportContainerDefinition converts a container definition into an ECS
 // container definition input.
-func exportContainerDefinition(def cocoa.ECSContainerDefinition) *ecs.ContainerDefinition {
+func (pc *BasicECSPodCreator) exportContainerDefinition(def cocoa.ECSContainerDefinition) *ecs.ContainerDefinition {
 	var containerDef ecs.ContainerDefinition
 	if mem := utility.FromIntPtr(def.MemoryMB); mem != 0 {
 		containerDef.SetMemory(int64(mem))
@@ -393,20 +404,33 @@ func exportContainerDefinition(def cocoa.ECSContainerDefinition) *ecs.ContainerD
 	containerDef.SetCommand(utility.ToStringPtrSlice(def.Command)).
 		SetImage(utility.FromStringPtr(def.Image)).
 		SetName(utility.FromStringPtr(def.Name)).
-		SetEnvironment(exportEnvVars(def.EnvVars)).
-		SetSecrets(exportSecrets(def.EnvVars))
+		SetEnvironment(pc.exportEnvVars(def.EnvVars)).
+		SetSecrets(pc.exportSecrets(def.EnvVars)).
+		SetPortMappings(pc.exportPortMappings(def.PortMappings))
 	return &containerDef
 }
 
 // exportTaskExecutionOptions converts execution options and a task definition
 // into an ECS task execution input.
-func (m *BasicECSPodCreator) exportTaskExecutionOptions(opts cocoa.ECSPodExecutionOptions, taskDef cocoa.ECSTaskDefinition) *ecs.RunTaskInput {
+func (pc *BasicECSPodCreator) exportTaskExecutionOptions(opts cocoa.ECSPodExecutionOptions, taskDef cocoa.ECSTaskDefinition) *ecs.RunTaskInput {
 	var runTask ecs.RunTaskInput
 	runTask.SetCluster(utility.FromStringPtr(opts.Cluster)).
 		SetTaskDefinition(utility.FromStringPtr(taskDef.ID)).
-		SetTags(exportTags(opts.Tags)).
+		SetTags(pc.exportTags(opts.Tags)).
 		SetEnableExecuteCommand(utility.FromBoolPtr(opts.SupportsDebugMode)).
-		SetPlacementStrategy(exportStrategy(opts.PlacementOpts.Strategy, opts.PlacementOpts.StrategyParameter)).
-		SetPlacementConstraints(exportPlacementConstraints(opts.PlacementOpts))
+		SetPlacementStrategy(pc.exportStrategy(opts.PlacementOpts)).
+		SetPlacementConstraints(pc.exportPlacementConstraints(opts.PlacementOpts))
 	return &runTask
+}
+
+// exportPortMappings converts port mappings into ECS port mappings.
+func (pc *BasicECSPodCreator) exportPortMappings(mappings []cocoa.PortMapping) []*ecs.PortMapping {
+	var converted []*ecs.PortMapping
+	for _, pm := range mappings {
+		mapping := &ecs.PortMapping{}
+		mapping.SetContainerPort(int64(utility.FromIntPtr(pm.ContainerPort))).
+			SetHostPort(int64(utility.FromIntPtr(pm.HostPort)))
+		converted = append(converted, mapping)
+	}
+	return converted
 }

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -39,7 +39,10 @@ type ECSPodCreationOptions struct {
 	// This is ignored for pods running Windows containers.
 	CPU *int
 	// NetworkMode describes the networking capabilities of the pod's
-	// containers. If unspecified, the default value is bridge.
+	// containers. If the NetworkMode is unspecified for a pod running Linux
+	// containers, the default value is NetworkModeBridge. If the NetworkMode is
+	// unspecified for a pod running Windows containers, the default network
+	// mode is to use the Windows NAT network.
 	NetworkMode *ECSNetworkMode
 	// TaskRole is the role that the pod can use. Depending on the
 	// configuration, this may be required if
@@ -305,7 +308,7 @@ type ECSContainerDefinition struct {
 	// require authentication.
 	RepoCreds *RepositoryCredentials
 	// PortMappings are mappings between the ports within the container to
-	// expose in the network interface for external traffic.
+	// allow network traffic.
 	PortMappings []PortMapping
 }
 
@@ -605,7 +608,8 @@ func (c *StoredRepositoryCredentials) Validate() error {
 // PortMapping represents a mapping from a container port to a port in the
 // container instance. The transport protocol is TCP.
 type PortMapping struct {
-	// ContainerPort is the port within the container to expose.
+	// ContainerPort is the port within the container to expose to network
+	// traffic.
 	ContainerPort *int
 	// HostPort is the port within the container instance to which the container
 	// port will be bound.
@@ -621,7 +625,8 @@ func NewPortMapping() *PortMapping {
 	return &PortMapping{}
 }
 
-// SetContainerPort sets the port within the container to expose.
+// SetContainerPort sets the port within the container to expose to network
+// traffic.
 func (m *PortMapping) SetContainerPort(port int) *PortMapping {
 	m.ContainerPort = &port
 	return m
@@ -896,18 +901,21 @@ const (
 type ECSNetworkMode string
 
 const (
-	// kim: TODO: continue documenting the different networking modes.
 	// NetworkModeNone indicates that networking is disabled entirely. The pod
-	// does not allow any external connectivity and container ports cannot be
-	// exposed.
+	// does not allow any external network connectivity and container ports
+	// cannot be mapped.
 	NetworkModeNone ECSNetworkMode = "none"
-	// NetworkModeAWSVPC. If this is set, container ports can be mapped This is supported for Linux and Window containers.
+	// NetworkModeAWSVPC indicates that the pod will be allocated its own
+	// virtual network interface and IPv4 address. This is supported for Linux
+	// and Window containers.
 	NetworkModeAWSVPC ECSNetworkMode = "awsvpc"
-	// NetworkModeBridge indicates that the . This is only supported for Linux
-	// containers.
+	// NetworkModeBridge indicates that the container will use Docker's built-in
+	// virtual network inside the container instance running the pod. This is
+	// only supported for Linux containers.
 	NetworkModeBridge ECSNetworkMode = "bridge"
-	// NetworkModeHost indicates that the container will use the underlying
-	// host's . This is only supported for Linux containers.
+	// NetworkModeHost indicates that the container will directly map its ports
+	// to the underlying container instance's network interface.
+	// This is only supported for Linux containers.
 	NetworkModeHost ECSNetworkMode = "host"
 )
 

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -1,6 +1,7 @@
 package cocoa
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/evergreen-ci/utility"
@@ -21,9 +22,13 @@ func TestECSPodCreationOptions(t *testing.T) {
 	})
 	t.Run("SetContainerDefinitions", func(t *testing.T) {
 		containerDef := NewECSContainerDefinition().SetImage("image")
-		def := NewECSPodCreationOptions().SetContainerDefinitions([]ECSContainerDefinition{*containerDef})
-		require.Len(t, def.ContainerDefinitions, 1)
-		assert.Equal(t, *containerDef, def.ContainerDefinitions[0])
+
+		opts := NewECSPodCreationOptions().SetContainerDefinitions([]ECSContainerDefinition{*containerDef})
+		require.Len(t, opts.ContainerDefinitions, 1)
+		assert.Equal(t, *containerDef, opts.ContainerDefinitions[0])
+
+		opts.SetContainerDefinitions(nil)
+		assert.Empty(t, opts.ContainerDefinitions)
 	})
 	t.Run("AddContainerDefinitions", func(t *testing.T) {
 		containerDef0 := NewECSContainerDefinition().SetImage("image0")
@@ -39,21 +44,19 @@ func TestECSPodCreationOptions(t *testing.T) {
 	})
 	t.Run("SetMemoryMB", func(t *testing.T) {
 		mem := 128
-		def := NewECSPodCreationOptions().SetMemoryMB(mem)
-		assert.Equal(t, mem, utility.FromIntPtr(def.MemoryMB))
+		opts := NewECSPodCreationOptions().SetMemoryMB(mem)
+		assert.Equal(t, mem, utility.FromIntPtr(opts.MemoryMB))
 	})
 	t.Run("SetCPU", func(t *testing.T) {
 		cpu := 128
-		def := NewECSPodCreationOptions().SetCPU(cpu)
-		assert.Equal(t, cpu, utility.FromIntPtr(def.CPU))
+		opts := NewECSPodCreationOptions().SetCPU(cpu)
+		assert.Equal(t, cpu, utility.FromIntPtr(opts.CPU))
 	})
-	t.Run("SetTags", func(t *testing.T) {
-		tags := map[string]string{"key": "value"}
-		opts := NewECSPodCreationOptions().SetTags(tags)
-		require.Len(t, opts.Tags, len(tags))
-		for k, v := range tags {
-			assert.Equal(t, v, opts.Tags[k])
-		}
+	t.Run("SetNetworkMode", func(t *testing.T) {
+		mode := NetworkModeAWSVPC
+		opts := NewECSPodCreationOptions().SetNetworkMode(mode)
+		require.NotZero(t, opts.NetworkMode)
+		assert.Equal(t, mode, *opts.NetworkMode)
 	})
 	t.Run("SetTaskRole", func(t *testing.T) {
 		r := "task_role"
@@ -64,6 +67,18 @@ func TestECSPodCreationOptions(t *testing.T) {
 		r := "execution_role"
 		opts := NewECSPodCreationOptions().SetExecutionRole(r)
 		assert.Equal(t, r, utility.FromStringPtr(opts.ExecutionRole))
+	})
+	t.Run("SetTags", func(t *testing.T) {
+		tags := map[string]string{"key": "value"}
+
+		opts := NewECSPodCreationOptions().SetTags(tags)
+		require.Len(t, opts.Tags, len(tags))
+		for k, v := range tags {
+			assert.Equal(t, v, opts.Tags[k])
+		}
+
+		opts.SetTags(nil)
+		assert.Empty(t, opts.Tags)
 	})
 	t.Run("AddTags", func(t *testing.T) {
 		tags := map[string]string{"key0": "val0", "key1": "val1"}
@@ -84,34 +99,37 @@ func TestECSPodCreationOptions(t *testing.T) {
 		})
 		t.Run("MemoryCPUAndContainerDefinitionIsValid", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128)
-			assert.NoError(t, def.Validate())
+			assert.NoError(t, opts.Validate())
 		})
 		t.Run("MissingContainerDefinitionsIsInvalid", func(t *testing.T) {
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				SetMemoryMB(128).
 				SetCPU(128)
-			assert.Error(t, def.Validate())
+			assert.Error(t, opts.Validate())
 		})
 		t.Run("NameIsGenerated", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128)
-			assert.NoError(t, def.Validate())
-			assert.NotZero(t, utility.FromStringPtr(def.Name))
+			assert.NoError(t, opts.Validate())
+			assert.NotZero(t, utility.FromStringPtr(opts.Name))
 		})
 		t.Run("BadContainerDefinitionIsInvalid", func(t *testing.T) {
-			def := NewECSPodCreationOptions().AddContainerDefinitions(*NewECSContainerDefinition()).SetMemoryMB(128).SetCPU(128)
-			assert.Error(t, def.Validate())
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*NewECSContainerDefinition()).
+				SetMemoryMB(128).
+				SetCPU(128)
+			assert.Error(t, opts.Validate())
 		})
 		t.Run("AllFieldsPopulatedIsValid", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				SetName("name").
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
@@ -119,88 +137,253 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetTaskRole("role").
 				AddTags(map[string]string{"key": "val"}).
 				SetExecutionOptions(*NewECSPodExecutionOptions())
-			assert.NoError(t, def.Validate())
+			assert.NoError(t, opts.Validate())
 		})
 		t.Run("MissingCPUIsInvalid", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128)
-			assert.Error(t, def.Validate())
+			assert.Error(t, opts.Validate())
 		})
 		t.Run("MissingPodCPUWithContainerCPUIsValid", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image").SetCPU(128)
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128)
-			assert.NoError(t, def.Validate())
+			assert.NoError(t, opts.Validate())
 		})
 		t.Run("TotalContainerCPUCannotExceedPodCPU", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image").SetCPU(256)
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(1024).
 				SetCPU(128)
-			assert.Error(t, def.Validate())
+			assert.Error(t, opts.Validate())
 		})
 		t.Run("ZeroCPUIsInvalid", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(0)
-			assert.Error(t, def.Validate())
+			assert.Error(t, opts.Validate())
 		})
 		t.Run("MissingMemoryIsInvalid", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetCPU(128)
-			assert.Error(t, def.Validate())
+			assert.Error(t, opts.Validate())
 		})
 		t.Run("MissingPodMemoryWithContainerMemoryIsValid", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image").SetMemoryMB(128)
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetCPU(128)
-			assert.NoError(t, def.Validate())
+			assert.NoError(t, opts.Validate())
 		})
 		t.Run("TotalContainerMemoryCannotExceedPodMemory", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image").SetMemoryMB(256)
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(1024)
-			assert.Error(t, def.Validate())
+			assert.Error(t, opts.Validate())
 		})
 		t.Run("ZeroMemoryIsInvalid", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(0).
 				SetCPU(128)
-			assert.Error(t, def.Validate())
+			assert.Error(t, opts.Validate())
 		})
 		t.Run("BadExecutionOptionsIsInvalid", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			placementOpts := NewECSPodPlacementOptions().SetStrategy("foo")
 			execOpts := NewECSPodExecutionOptions().SetPlacementOptions(*placementOpts)
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
 				SetExecutionOptions(*execOpts)
-			assert.Error(t, def.Validate())
+			assert.Error(t, opts.Validate())
 		})
 		t.Run("SecretEnvironmentVariablesWithoutExecutionRoleIsInvalid", func(t *testing.T) {
 			secretOpts := NewSecretOptions().SetName("name").SetValue("value")
 			ev := NewEnvironmentVariable().SetName("name").SetSecretOptions(*secretOpts)
 			containerDef := NewECSContainerDefinition().SetImage("image").AddEnvironmentVariables(*ev)
-			def := NewECSPodCreationOptions().
+			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128)
-			assert.Error(t, def.Validate())
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("BadNetworkModeIsInvalid", func(t *testing.T) {
+			containerDef := NewECSContainerDefinition().SetImage("image")
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode("invalid")
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("NoPortMappingsWithNetworkModeNoneIsValid", func(t *testing.T) {
+			containerDef := NewECSContainerDefinition().SetImage("image")
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeNone)
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("PortMappingsWithNetworkModeNoneIsInvalid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(1337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeNone)
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("PortMappingToIdenticalPortWithNetworkModeAWSVPCIsValid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(1337).SetHostPort(1337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeAWSVPC)
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("PortMappingToUnspecifiedHostPortWithNetworkModeAWSVPCIsValid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(1337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeAWSVPC)
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("PortMappingsToMismatchedPortWithNetworkModeAWSVPCIsInvalid", func(t *testing.T) {
+			pm := NewPortMapping().
+				SetContainerPort(1337).
+				SetHostPort(13337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeAWSVPC)
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("PortMappingToIdenticalPortWithNetworkModeHostIsValid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(1337).SetHostPort(1337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeHost)
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("PortMappingToUnspecifiedHostPortWithNetworkModeHostIsValid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(1337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeHost)
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("PortMappingsToMismatchedPortWithNetworkModeHostIsInvalid", func(t *testing.T) {
+			pm := NewPortMapping().
+				SetContainerPort(1337).
+				SetHostPort(13337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeBridge)
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("PortMappingToIdenticalPortWithNetworkModeBridgeIsValid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(1337).SetHostPort(1337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeHost)
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("PortMappingToUnspecifiedHostPortWithNetworkModeBridgeIsValid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(1337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeBridge)
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("PortMappingsToMismatchedPortWithNetworkModeBridgeIsValid", func(t *testing.T) {
+			pm := NewPortMapping().
+				SetContainerPort(1337).
+				SetHostPort(13337)
+			containerDef := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*pm)
+			opts := NewECSPodCreationOptions().
+				AddContainerDefinitions(*containerDef).
+				SetMemoryMB(128).
+				SetCPU(128).
+				SetNetworkMode(NetworkModeBridge)
+			assert.NoError(t, opts.Validate())
+		})
+	})
+}
+
+func TestECSNetworkMode(t *testing.T) {
+	t.Run("Validate", func(t *testing.T) {
+		for _, m := range []ECSNetworkMode{
+			NetworkModeNone,
+			NetworkModeAWSVPC,
+			NetworkModeBridge,
+			NetworkModeHost,
+		} {
+			t.Run(fmt.Sprintf("SucceedsForStatus=%s", m), func(t *testing.T) {
+				assert.NoError(t, m.Validate())
+			})
+		}
+		t.Run("FailsForEmptyStatus", func(t *testing.T) {
+			assert.Error(t, ECSNetworkMode("").Validate())
+		})
+		t.Run("FailsForInvalidStatus", func(t *testing.T) {
+			assert.Error(t, ECSNetworkMode("invalid").Validate())
 		})
 	})
 }
@@ -243,9 +426,13 @@ func TestECSContainerDefinition(t *testing.T) {
 	})
 	t.Run("SetEnvironmentVariables", func(t *testing.T) {
 		ev := NewEnvironmentVariable().SetName("name").SetValue("value")
+
 		def := NewECSContainerDefinition().SetEnvironmentVariables([]EnvironmentVariable{*ev})
 		require.Len(t, def.EnvVars, 1)
 		assert.Equal(t, *ev, def.EnvVars[0])
+
+		def.SetEnvironmentVariables(nil)
+		assert.Empty(t, def.EnvVars)
 	})
 	t.Run("AddEnvironmentVariables", func(t *testing.T) {
 		ev0 := NewEnvironmentVariable().SetName("name0").SetValue("value0")
@@ -264,6 +451,30 @@ func TestECSContainerDefinition(t *testing.T) {
 		def := NewECSContainerDefinition().SetRepositoryCredentials(*creds)
 		require.NotZero(t, def.RepoCreds)
 		assert.Equal(t, utility.FromStringPtr(creds.SecretName), utility.FromStringPtr(def.RepoCreds.SecretName))
+	})
+	t.Run("SetPortMappings", func(t *testing.T) {
+		pm := NewPortMapping().SetContainerPort(1337)
+
+		def := NewECSContainerDefinition().SetPortMappings([]PortMapping{*pm})
+		require.Len(t, def.PortMappings, 1)
+		assert.Equal(t, *pm, def.PortMappings[0])
+
+		def = NewECSContainerDefinition().SetPortMappings(nil)
+		assert.Empty(t, def.PortMappings)
+	})
+	t.Run("AddPortMappings", func(t *testing.T) {
+		pm0 := NewPortMapping().SetContainerPort(1337)
+		pm1 := NewPortMapping().SetContainerPort(23456)
+
+		def := NewECSContainerDefinition().AddPortMappings(*pm0, *pm1)
+		require.Len(t, def.PortMappings, 2)
+		assert.Equal(t, *pm0, def.PortMappings[0])
+		assert.Equal(t, *pm1, def.PortMappings[1])
+
+		def.AddPortMappings()
+		require.Len(t, def.PortMappings, 2)
+		assert.Equal(t, *pm0, def.PortMappings[0])
+		assert.Equal(t, *pm1, def.PortMappings[1])
 	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("EmptyIsInvalid", func(t *testing.T) {
@@ -316,6 +527,12 @@ func TestECSContainerDefinition(t *testing.T) {
 			def := NewECSContainerDefinition().
 				SetImage("image").
 				SetRepositoryCredentials(*NewRepositoryCredentials())
+			assert.Error(t, def.Validate())
+		})
+		t.Run("BadPortMappingIsInvalid", func(t *testing.T) {
+			def := NewECSContainerDefinition().
+				SetImage("image").
+				AddPortMappings(*NewPortMapping())
 			assert.Error(t, def.Validate())
 		})
 	})
@@ -529,6 +746,58 @@ func TestSecretOptions(t *testing.T) {
 		t.Run("ExistingSecretWithNewValueIsInvalid", func(t *testing.T) {
 			s := NewSecretOptions().SetName("name").SetExists(true).SetValue("value")
 			assert.Error(t, s.Validate())
+		})
+	})
+}
+
+func TestPortMappings(t *testing.T) {
+	t.Run("NewPortMapping", func(t *testing.T) {
+		pm := NewPortMapping()
+		require.NotZero(t, pm)
+		assert.Zero(t, *pm)
+	})
+	t.Run("SetContainerPort", func(t *testing.T) {
+		port := 1337
+		pm := NewPortMapping().SetContainerPort(1337)
+		assert.Equal(t, port, utility.FromIntPtr(pm.ContainerPort))
+	})
+	t.Run("SetHostPort", func(t *testing.T) {
+		port := 1337
+		pm := NewPortMapping().SetHostPort(1337)
+		assert.Equal(t, port, utility.FromIntPtr(pm.HostPort))
+	})
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("EmptyIsInvalid", func(t *testing.T) {
+			pm := NewPortMapping()
+			assert.Error(t, pm.Validate())
+		})
+		t.Run("JustContainerPortIsValid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(1337)
+			assert.NoError(t, pm.Validate())
+		})
+		t.Run("ContainerAndHostPortIsValid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(1337).SetHostPort(1337)
+			assert.NoError(t, pm.Validate())
+		})
+		t.Run("NegativeContainerPortIsInvalid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(-100)
+			assert.Error(t, pm.Validate())
+		})
+		t.Run("ContainerPortAboveMaxIsInvalid", func(t *testing.T) {
+			pm := NewPortMapping().SetContainerPort(100000)
+			assert.Error(t, pm.Validate())
+		})
+		t.Run("NegativeHostPortIsInvalid", func(t *testing.T) {
+			pm := NewPortMapping().
+				SetContainerPort(1337).
+				SetHostPort(-100)
+			assert.Error(t, pm.Validate())
+		})
+		t.Run("HostPortAboveMaxIsInvalid", func(t *testing.T) {
+			pm := NewPortMapping().
+				SetContainerPort(1337).
+				SetHostPort(100000)
+			assert.Error(t, pm.Validate())
 		})
 	})
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15174

* Add options to set pod networking mode and container port mappings.
* Refactor some ECS glue code conversion functions in the ECS package so that they're methods on the pod creator instead of plain functions.
* Slightly improve existing test coverage.