### PR TITLE
EVG-15104: validate unknown ECS status

### DIFF
--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -266,7 +266,7 @@ const (
 // Validate checks that the ECS status is one of the recognized statuses.
 func (s ECSStatus) Validate() error {
 	switch s {
-	case StatusStarting, StatusRunning, StatusStopped, StatusDeleted:
+	case StatusStarting, StatusRunning, StatusStopped, StatusDeleted, StatusUnknown:
 		return nil
 	default:
 		return errors.Errorf("unrecognized status '%s'", s)

--- a/ecs_pod_test.go
+++ b/ecs_pod_test.go
@@ -176,6 +176,7 @@ func TestECSStatus(t *testing.T) {
 			StatusRunning,
 			StatusStopped,
 			StatusDeleted,
+			StatusUnknown,
 		} {
 			t.Run(fmt.Sprintf("SucceedsForStatus=%s", s), func(t *testing.T) {
 				assert.NoError(t, s.Validate())


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15104

I forgot to add the unknown status as a valid status. This is considered a valid state because we might legitimately not know or keep track of the current state of a container (e.g. the network is down, so we can't verify what state it's in). Statuses for containers are also optional, for which unknown is the valid indeterminate state.