### PR TITLE
EVG-15139: include secret IDs in ECS pod after creation

### DIFF
--- a/ecs/pod.go
+++ b/ecs/pod.go
@@ -178,12 +178,7 @@ func (p *BasicECSPod) Delete(ctx context.Context) error {
 				continue
 			}
 
-			var id string
-			if s.ID != nil {
-				id = utility.FromStringPtr(s.ID)
-			} else {
-				id = utility.FromStringPtr(s.Name)
-			}
+			id := utility.FromStringPtr(s.ID)
 			catcher.Wrapf(p.vault.DeleteSecret(ctx, id), "deleting secret '%s' for container '%s'", id, utility.FromStringPtr(c.Name))
 		}
 	}

--- a/ecs/pod.go
+++ b/ecs/pod.go
@@ -61,15 +61,9 @@ func (o *BasicECSPodOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(o.Client == nil, "must specify a client")
 	if o.Resources != nil {
-		catcher.NewWhen(o.Resources.TaskID == nil, "must specify task ID of the pod")
-		if o.Resources.TaskDefinition != nil {
-			catcher.Wrapf(o.Resources.TaskDefinition.Validate(), "invalid task definition")
-		}
-		for _, c := range o.Resources.Containers {
-			catcher.Wrapf(c.Validate(), "container '%s'", utility.FromStringPtr(c.Name))
-		}
+		catcher.Wrap(o.Resources.Validate(), "invalid resources")
 	} else {
-		catcher.New("must specify at least task ID of the pod")
+		catcher.New("missing pod resources")
 	}
 	if o.StatusInfo != nil {
 		catcher.Add(o.StatusInfo.Validate())

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -176,11 +176,11 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetCredentials(credentials.NewEnvCredentials()).
 				SetRegion("us-east-1")
 		}
-		t.Run("EmptyIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithEmpty", func(t *testing.T) {
 			opts := NewBasicECSPodOptions()
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("AllFieldsPopulatedIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
 			ecsClient, err := NewBasicECSClient(validAWSOpts())
 			require.NoError(t, err)
 			smClient, err := secret.NewBasicSecretsManagerClient(validAWSOpts())
@@ -193,7 +193,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetStatusInfo(validStatusInfo())
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("MissingClientIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithoutClient", func(t *testing.T) {
 			smClient, err := secret.NewBasicSecretsManagerClient(validAWSOpts())
 			require.NoError(t, err)
 			v := secret.NewBasicSecretsManager(smClient)
@@ -203,7 +203,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetStatusInfo(validStatusInfo())
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("MissingVaultIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithoutVault", func(t *testing.T) {
 			ecsClient, err := NewBasicECSClient(validAWSOpts())
 			require.NoError(t, err)
 			opts := NewBasicECSPodOptions().
@@ -212,7 +212,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetStatusInfo(validStatusInfo())
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("MissingResourcesIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithoutResources", func(t *testing.T) {
 			ecsClient, err := NewBasicECSClient(validAWSOpts())
 			require.NoError(t, err)
 			opts := NewBasicECSPodOptions().
@@ -220,7 +220,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetStatusInfo(validStatusInfo())
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("BadResourcesIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadResources", func(t *testing.T) {
 			ecsClient, err := NewBasicECSClient(validAWSOpts())
 			require.NoError(t, err)
 			opts := NewBasicECSPodOptions().
@@ -229,7 +229,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetStatusInfo(validStatusInfo())
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("MissingStatusIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithoutStatus", func(t *testing.T) {
 			ecsClient, err := NewBasicECSClient(validAWSOpts())
 			require.NoError(t, err)
 			opts := NewBasicECSPodOptions().
@@ -237,7 +237,7 @@ func TestBasicECSPodOptions(t *testing.T) {
 				SetResources(validResources())
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("BadStatusIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadStatus", func(t *testing.T) {
 			ecsClient, err := NewBasicECSClient(validAWSOpts())
 			require.NoError(t, err)
 			opts := NewBasicECSPodOptions().

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -34,20 +34,20 @@ func TestBasicECSPod(t *testing.T) {
 		},
 		"InfoIsPopulated": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			res := cocoa.NewECSPodResources().SetTaskID("task_id")
-			stat := cocoa.NewECSPodStatusInfo().
+			ps := cocoa.NewECSPodStatusInfo().
 				SetStatus(cocoa.StatusRunning).
 				AddContainers(*cocoa.NewECSContainerStatusInfo().
 					SetContainerID("container_id").
 					SetName("name").
 					SetStatus(cocoa.StatusRunning))
-			opts := NewBasicECSPodOptions().SetClient(c).SetResources(*res).SetStatusInfo(*stat)
+			opts := NewBasicECSPodOptions().SetClient(c).SetResources(*res).SetStatusInfo(*ps)
 
 			p, err := NewBasicECSPod(opts)
 			require.NoError(t, err)
 
 			podRes := p.Resources()
 			assert.Equal(t, *res, podRes)
-			assert.Equal(t, *stat, p.StatusInfo())
+			assert.Equal(t, *ps, p.StatusInfo())
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
@@ -149,10 +149,10 @@ func TestBasicECSPodOptions(t *testing.T) {
 		assert.Equal(t, *res, *opts.Resources)
 	})
 	t.Run("SetStatusInfo", func(t *testing.T) {
-		stat := cocoa.NewECSPodStatusInfo().SetStatus(cocoa.StatusRunning)
-		opts := NewBasicECSPodOptions().SetStatusInfo(*stat)
+		ps := cocoa.NewECSPodStatusInfo().SetStatus(cocoa.StatusRunning)
+		opts := NewBasicECSPodOptions().SetStatusInfo(*ps)
 		require.NotNil(t, opts.StatusInfo)
-		assert.Equal(t, *stat, *opts.StatusInfo)
+		assert.Equal(t, *ps, *opts.StatusInfo)
 	})
 	t.Run("Validate", func(t *testing.T) {
 		validResources := func() cocoa.ECSPodResources {

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -212,7 +212,6 @@ func (r *ECSContainerResources) AddSecrets(secrets ...ContainerSecret) *ECSConta
 
 // Validate checks that the container ID is given and that all given container
 // secrets are valid.
-// kim: TODO: test
 func (r *ECSContainerResources) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(r.ContainerID == nil, "must specify a container ID")
@@ -258,10 +257,9 @@ func (s *ContainerSecret) SetOwned(owned bool) *ContainerSecret {
 }
 
 // Validate checks that the secret has either a name or ID
-// kim: TODO: test
 func (s *ContainerSecret) Validate() error {
 	catcher := grip.NewBasicCatcher()
-	catcher.NewWhen(s.ID == nil && s.Name == nil, "cannot have a secret with neither an ID nor a name")
+	catcher.NewWhen(s.ID == nil, "missing ID")
 	catcher.NewWhen(s.ID != nil && utility.FromStringPtr(s.ID) == "", "cannot have an empty ID")
 	catcher.NewWhen(s.Name != nil && utility.FromStringPtr(s.Name) == "", "cannot have an empty name")
 	return catcher.Resolve()

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -212,6 +212,7 @@ func (r *ECSContainerResources) AddSecrets(secrets ...ContainerSecret) *ECSConta
 
 // ContainerSecret is a named secret that may or may not be owned by its container.
 type ContainerSecret struct {
+	// kim: TODO: convert this into just Name and ID. Either can be set.
 	NamedSecret
 	// Owned determines whether or not the secret is owned by its container or
 	// not.

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -168,6 +168,20 @@ func (r *ECSPodResources) AddContainers(containers ...ECSContainerResources) *EC
 	return r
 }
 
+// Validate checks that the task ID is set, the task definition is valid, and
+// all container resources are valid.
+func (r *ECSPodResources) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(r.TaskID == nil, "must specify task ID of the pod")
+	if r.TaskDefinition != nil {
+		catcher.Wrapf(r.TaskDefinition.Validate(), "invalid task definition")
+	}
+	for _, c := range r.Containers {
+		catcher.Wrapf(c.Validate(), "container '%s'", utility.FromStringPtr(c.Name))
+	}
+	return catcher.Resolve()
+}
+
 // ECSContainerResources are ECS-specific resources associated with a container.
 type ECSContainerResources struct {
 	// ContainerID is the resource identifier for the container.

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -478,8 +478,11 @@ func (e *EnvironmentVariable) Validate() error {
 // SecretOptions represents a secret with a name and value that may or may not
 // be owned by its container.
 type SecretOptions struct {
-	// kim: TODO: determine if the secret name is the name or ID based on
-	// Exists.
+	// NamedSecret includes the name of the existing secret or secret to create
+	// and the value if the secret must be created. If the secret does not
+	// exist, it will be created with the given friendly name. Otherwise, if the
+	// secret exists already, the name should be the secret's unique resource
+	// identifier.
 	NamedSecret
 	// Owned determines whether or not the secret is owned by its container or
 	// not.
@@ -1030,7 +1033,6 @@ func (d *ECSTaskDefinition) SetOwned(owned bool) *ECSTaskDefinition {
 }
 
 // Validate checsk that the task definition ID is given.
-// kim: TODO: test
 func (d *ECSTaskDefinition) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(d.ID == nil, "must specify a task definition ID")

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -617,7 +617,7 @@ func (c *StoredRepositoryCredentials) SetPassword(pwd string) *StoredRepositoryC
 	return c
 }
 
-// Validate checks that the secret name, username, and password are set.
+// Validate checks that the username and password are set.
 func (c *StoredRepositoryCredentials) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(utility.FromStringPtr(c.Username) == "", "must specify a username")

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -15,10 +15,10 @@ type ECSPodCreator interface {
 	// CreatePod creates a new pod backed by ECS with the given options. Options
 	// are applied in the order they're specified and conflicting options are
 	// overwritten.
-	CreatePod(ctx context.Context, opts ...*ECSPodCreationOptions) (ECSPod, error)
+	CreatePod(ctx context.Context, opts ...ECSPodCreationOptions) (ECSPod, error)
 	// CreatePodFromExistingDefinition creates a new pod backed by ECS from an
 	// existing task definition.
-	CreatePodFromExistingDefinition(ctx context.Context, def ECSTaskDefinition, opts ...*ECSPodExecutionOptions) (ECSPod, error)
+	CreatePodFromExistingDefinition(ctx context.Context, def ECSTaskDefinition, opts ...ECSPodExecutionOptions) (ECSPod, error)
 }
 
 // ECSPodCreationOptions provide options to create a pod backed by ECS.
@@ -242,14 +242,10 @@ func (o *ECSPodCreationOptions) getNetworkMode() ECSNetworkMode {
 // MergeECSPodCreationOptions merges all the given options to create an ECS pod.
 // Options are applied in the order that they're specified and conflicting
 // options are overwritten.
-func MergeECSPodCreationOptions(opts ...*ECSPodCreationOptions) ECSPodCreationOptions {
+func MergeECSPodCreationOptions(opts ...ECSPodCreationOptions) ECSPodCreationOptions {
 	merged := ECSPodCreationOptions{}
 
 	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-
 		if opt.Name != nil {
 			merged.Name = opt.Name
 		}
@@ -482,6 +478,8 @@ func (e *EnvironmentVariable) Validate() error {
 // SecretOptions represents a secret with a name and value that may or may not
 // be owned by its container.
 type SecretOptions struct {
+	// kim: TODO: convert this into NamedSecret + Owned. When translating the
+	// pod, determine if the name is a friendly name or an ID based on Exists.
 	ContainerSecret
 	// Exists determines whether or not the secret already exists or must be
 	// created before it can be used.
@@ -759,14 +757,10 @@ func (o *ECSPodExecutionOptions) Validate() error {
 // MergeECSPodExecutionOptions merges all the given options to execute an ECS pod.
 // Options are applied in the order that they're specified and conflicting
 // options are overwritten.
-func MergeECSPodExecutionOptions(opts ...*ECSPodExecutionOptions) ECSPodExecutionOptions {
+func MergeECSPodExecutionOptions(opts ...ECSPodExecutionOptions) ECSPodExecutionOptions {
 	merged := ECSPodExecutionOptions{}
 
 	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-
 		if opt.Cluster != nil {
 			merged.Cluster = opt.Cluster
 		}

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -86,10 +86,10 @@ func TestECSPodCreationOptions(t *testing.T) {
 		assert.Equal(t, tags, opts.Tags)
 	})
 	t.Run("Validate", func(t *testing.T) {
-		t.Run("EmptyIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
 			assert.Error(t, NewECSPodCreationOptions().Validate())
 		})
-		t.Run("MemoryCPUAndContainerDefinitionIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithMemoryCPUAndContainerDefinition", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
@@ -97,7 +97,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetCPU(128)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("MissingContainerDefinitionsIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithoutContainerDefinition", func(t *testing.T) {
 			opts := NewECSPodCreationOptions().
 				SetMemoryMB(128).
 				SetCPU(128)
@@ -112,14 +112,14 @@ func TestECSPodCreationOptions(t *testing.T) {
 			assert.NoError(t, opts.Validate())
 			assert.NotZero(t, utility.FromStringPtr(opts.Name))
 		})
-		t.Run("BadContainerDefinitionIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadContainerDefinition", func(t *testing.T) {
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*NewECSContainerDefinition()).
 				SetMemoryMB(128).
 				SetCPU(128)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("AllFieldsPopulatedIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			opts := NewECSPodCreationOptions().
 				SetName("name").
@@ -131,21 +131,21 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetExecutionOptions(*NewECSPodExecutionOptions())
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("MissingCPUIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithMissingCPU", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("MissingPodCPUWithContainerCPUIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithoutPodCPUWhenContainerCPUIsGiven", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image").SetCPU(128)
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("TotalContainerCPUCannotExceedPodCPU", func(t *testing.T) {
+		t.Run("FailsWhenTotalContainerCPUExceedsPodCPU", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image").SetCPU(256)
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
@@ -153,7 +153,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetCPU(128)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("ZeroCPUIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithZeroCPU", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
@@ -161,21 +161,21 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetCPU(0)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("MissingMemoryIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithoutMemory", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetCPU(128)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("MissingPodMemoryWithContainerMemoryIsValid", func(t *testing.T) {
+		t.Run("SucceedWithoutPodMemoryWhenContainerMemoryIsGiven", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image").SetMemoryMB(128)
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
 				SetCPU(128)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("TotalContainerMemoryCannotExceedPodMemory", func(t *testing.T) {
+		t.Run("FailsWithTotalContainerMemoryExceedingPodMemory", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image").SetMemoryMB(256)
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
@@ -183,7 +183,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetCPU(1024)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("ZeroMemoryIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithZeroMemory", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
@@ -191,7 +191,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetCPU(128)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("BadExecutionOptionsIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadExecutionOptions", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			placementOpts := NewECSPodPlacementOptions().SetStrategy("foo")
 			execOpts := NewECSPodExecutionOptions().SetPlacementOptions(*placementOpts)
@@ -202,7 +202,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetExecutionOptions(*execOpts)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("SecretEnvironmentVariablesWithoutExecutionRoleIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithSecretEnvironmentVariablesWithoutExecutionRole", func(t *testing.T) {
 			secretOpts := NewSecretOptions().SetName("name").SetValue("value")
 			ev := NewEnvironmentVariable().SetName("name").SetSecretOptions(*secretOpts)
 			containerDef := NewECSContainerDefinition().SetImage("image").AddEnvironmentVariables(*ev)
@@ -212,7 +212,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetCPU(128)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("BadNetworkModeIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadNetworkMode", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
@@ -221,7 +221,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetNetworkMode("invalid")
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("NoPortMappingsWithNetworkModeNoneIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNetworkModeNoneAndNoPortMappings", func(t *testing.T) {
 			containerDef := NewECSContainerDefinition().SetImage("image")
 			opts := NewECSPodCreationOptions().
 				AddContainerDefinitions(*containerDef).
@@ -230,7 +230,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetNetworkMode(NetworkModeNone)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("PortMappingsWithNetworkModeNoneIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithNetworkModeNoneAndPortMappings", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(1337)
 			containerDef := NewECSContainerDefinition().
 				SetImage("image").
@@ -284,7 +284,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetExecutionOptions(*execOpts)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("PortMappingToIdenticalPortAndAWSVPCOptionsWithNetworkModeAWSVPCIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNetworkModeAWSVPCAndPortMappingToIdenticalPortAndAWSVPCOptions", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(1337).SetHostPort(1337)
 			containerDef := NewECSContainerDefinition().
 				SetImage("image").
@@ -299,7 +299,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("PortMappingToUnspecifiedHostPortAndAWSVPCOptionsWithNetworkModeAWSVPCIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNetworkModeAWSVPCAndPortMappingToUnspecifiedHostPortAndAWSVPCOptions", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(1337)
 			containerDef := NewECSContainerDefinition().
 				SetImage("image").
@@ -314,10 +314,10 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("PortMappingsToMismatchedPortWithNetworkModeAWSVPCIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithNetworkModeAWSVPCANdPortMappingsToDifferentHostPort", func(t *testing.T) {
 			pm := NewPortMapping().
 				SetContainerPort(1337).
-				SetHostPort(13337)
+				SetHostPort(9001)
 			containerDef := NewECSContainerDefinition().
 				SetImage("image").
 				AddPortMappings(*pm)
@@ -331,7 +331,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetExecutionOptions(*execOpts)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("PortMappingToIdenticalPortWithNetworkModeHostIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNetworkModeHostAndPortMappingToIdenticalHostPort", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(1337).SetHostPort(1337)
 			containerDef := NewECSContainerDefinition().
 				SetImage("image").
@@ -343,7 +343,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetNetworkMode(NetworkModeHost)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("PortMappingToUnspecifiedHostPortWithNetworkModeHostIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNetworkModeHostAndPortMappingToUnspecifiedHostPort", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(1337)
 			containerDef := NewECSContainerDefinition().
 				SetImage("image").
@@ -355,10 +355,10 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetNetworkMode(NetworkModeHost)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("PortMappingsToMismatchedPortWithNetworkModeHostIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithNetworkModeHostAndPortMappingsToDifferentHostPort", func(t *testing.T) {
 			pm := NewPortMapping().
 				SetContainerPort(1337).
-				SetHostPort(13337)
+				SetHostPort(9001)
 			containerDef := NewECSContainerDefinition().
 				SetImage("image").
 				AddPortMappings(*pm)
@@ -369,7 +369,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetNetworkMode(NetworkModeBridge)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("PortMappingToIdenticalPortWithNetworkModeBridgeIsValid", func(t *testing.T) {
+		t.Run("FailsWithNetworkModeBridgeAndPortMappingToIdenticalHostPort", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(1337).SetHostPort(1337)
 			containerDef := NewECSContainerDefinition().
 				SetImage("image").
@@ -381,7 +381,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetNetworkMode(NetworkModeHost)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("PortMappingToUnspecifiedHostPortWithNetworkModeBridgeIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNetworkModeBridgeAndPortMappingToUnspecifiedHostPort", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(1337)
 			containerDef := NewECSContainerDefinition().
 				SetImage("image").
@@ -393,7 +393,7 @@ func TestECSPodCreationOptions(t *testing.T) {
 				SetNetworkMode(NetworkModeBridge)
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("PortMappingsToMismatchedPortWithNetworkModeBridgeIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNetworkModeBridgeAndPortMappingsToDifferentHostPort", func(t *testing.T) {
 			pm := NewPortMapping().
 				SetContainerPort(1337).
 				SetHostPort(13337)
@@ -515,14 +515,14 @@ func TestECSContainerDefinition(t *testing.T) {
 		assert.ElementsMatch(t, pms, def.PortMappings)
 	})
 	t.Run("Validate", func(t *testing.T) {
-		t.Run("EmptyIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
 			assert.Error(t, NewECSContainerDefinition().Validate())
 		})
-		t.Run("JustImageIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithJustImage", func(t *testing.T) {
 			def := NewECSContainerDefinition().SetImage("image")
 			assert.NoError(t, def.Validate())
 		})
-		t.Run("MissingImageIsInvalid", func(t *testing.T) {
+		t.Run("FailsWIthoutImage", func(t *testing.T) {
 			def := NewECSContainerDefinition().
 				SetMemoryMB(128).
 				SetCPU(128)
@@ -533,7 +533,7 @@ func TestECSContainerDefinition(t *testing.T) {
 			assert.NoError(t, def.Validate())
 			assert.NotZero(t, utility.FromStringPtr(def.Name))
 		})
-		t.Run("AllFieldsPopulatedIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
 			ev := NewEnvironmentVariable().SetName("name").SetValue("value")
 			def := NewECSContainerDefinition().
 				SetImage("image").
@@ -543,31 +543,31 @@ func TestECSContainerDefinition(t *testing.T) {
 				AddEnvironmentVariables(*ev)
 			assert.NoError(t, def.Validate())
 		})
-		t.Run("ZeroCPUIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithZeroCPU", func(t *testing.T) {
 			def := NewECSContainerDefinition().
 				SetImage("image").
 				SetCPU(0)
 			assert.Error(t, def.Validate())
 		})
-		t.Run("ZeroMemoryIsInvalid", func(t *testing.T) {
+		t.Run("FailsWIthZeroMemory", func(t *testing.T) {
 			def := NewECSContainerDefinition().
 				SetImage("image").
 				SetMemoryMB(0)
 			assert.Error(t, def.Validate())
 		})
-		t.Run("BadEnvironmentVariablesIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadEnvironmentVariables", func(t *testing.T) {
 			def := NewECSContainerDefinition().
 				SetImage("image").
 				AddEnvironmentVariables(*NewEnvironmentVariable())
 			assert.Error(t, def.Validate())
 		})
-		t.Run("BadRepositoryCredentialsIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadRepositoryCredentials", func(t *testing.T) {
 			def := NewECSContainerDefinition().
 				SetImage("image").
 				SetRepositoryCredentials(*NewRepositoryCredentials())
 			assert.Error(t, def.Validate())
 		})
-		t.Run("BadPortMappingIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadPortMapping", func(t *testing.T) {
 			def := NewECSContainerDefinition().
 				SetImage("image").
 				AddPortMappings(*NewPortMapping())
@@ -600,56 +600,44 @@ func TestEnvironmentVariable(t *testing.T) {
 		assert.Equal(t, utility.FromStringPtr(opts.Value), utility.FromStringPtr(ev.SecretOpts.Value))
 	})
 	t.Run("Validate", func(t *testing.T) {
-		t.Run("EmptyIsInvalid", func(t *testing.T) {
-			var ev EnvironmentVariable
-			assert.Error(t, ev.Validate())
-		})
-		t.Run("NameAndValueIsValid", func(t *testing.T) {
-			ev := EnvironmentVariable{
-				Name:  utility.ToStringPtr("name"),
-				Value: utility.ToStringPtr("value"),
-			}
+		t.Run("SucceedsWithNameAndValue", func(t *testing.T) {
+			ev := NewEnvironmentVariable().SetName("name").SetValue("value")
 			assert.NoError(t, ev.Validate())
 		})
-		t.Run("NameAndSecretIsValid", func(t *testing.T) {
-			ev := EnvironmentVariable{
-				Name:       utility.ToStringPtr("name"),
-				SecretOpts: NewSecretOptions().SetName("secret_name").SetValue("secret_value"),
-			}
+		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
+			assert.Error(t, NewEnvironmentVariable().Validate())
+		})
+		t.Run("SucceedsWithNameAndNewSecretOptions", func(t *testing.T) {
+			ev := NewEnvironmentVariable().
+				SetName("name").
+				SetSecretOptions(*NewSecretOptions().
+					SetName("secret_name").
+					SetValue("secret_value"))
 			assert.NoError(t, ev.Validate())
 		})
-		t.Run("NameAndInvalidSecretIsInvalid", func(t *testing.T) {
-			ev := EnvironmentVariable{
-				Name:       utility.ToStringPtr("name"),
-				SecretOpts: NewSecretOptions(),
-			}
+		t.Run("FailsWithNameAndBadNewSecretOptions", func(t *testing.T) {
+			ev := NewEnvironmentVariable().SetName("name").SetSecretOptions(*NewSecretOptions())
 			assert.Error(t, ev.Validate())
 		})
-		t.Run("MissingNameIsInvalid", func(t *testing.T) {
-			ev := EnvironmentVariable{
-				Value: utility.ToStringPtr("value"),
-			}
+		t.Run("FailsWithoutName", func(t *testing.T) {
+			ev := NewEnvironmentVariable().SetValue("value")
 			assert.Error(t, ev.Validate())
 		})
-		t.Run("EmptyNameIsInvalid", func(t *testing.T) {
-			ev := EnvironmentVariable{
-				Name:  utility.ToStringPtr(""),
-				Value: utility.ToStringPtr("value"),
-			}
+		t.Run("FailsWithEmptyName", func(t *testing.T) {
+			ev := NewEnvironmentVariable().SetName("").SetValue("value")
 			assert.Error(t, ev.Validate())
 		})
-		t.Run("SettingValueAndSecretIsInvalid", func(t *testing.T) {
-			ev := EnvironmentVariable{
-				Name:       utility.ToStringPtr("name"),
-				Value:      utility.ToStringPtr("value"),
-				SecretOpts: NewSecretOptions().SetName("secret_name").SetValue("secret_value"),
-			}
+		t.Run("FailsWithValueAndSecretOptions", func(t *testing.T) {
+			ev := NewEnvironmentVariable().
+				SetName("name").
+				SetValue("value").
+				SetSecretOptions(*NewSecretOptions().
+					SetName("secret_name").
+					SetValue("secret_value"))
 			assert.Error(t, ev.Validate())
 		})
-		t.Run("MissingValueAndSecretIsInvalid", func(t *testing.T) {
-			ev := EnvironmentVariable{
-				Name: utility.ToStringPtr("name"),
-			}
+		t.Run("FailsWithoutValueOrSecretOptions", func(t *testing.T) {
+			ev := NewEnvironmentVariable().SetName("name")
 			assert.Error(t, ev.Validate())
 		})
 	})
@@ -692,18 +680,18 @@ func TestRepositoryCredentials(t *testing.T) {
 			creds := NewRepositoryCredentials().SetSecretName("name")
 			assert.NoError(t, creds.Validate())
 		})
-		t.Run("EmptyIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
 			creds := NewRepositoryCredentials()
 			assert.Error(t, creds.Validate())
 		})
-		t.Run("MissingSecretNameIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithoutSecretName", func(t *testing.T) {
 			storedCreds := NewStoredRepositoryCredentials().
 				SetUsername("username").
 				SetPassword("password")
 			creds := NewRepositoryCredentials().SetNewCredentials(*storedCreds)
 			assert.Error(t, creds.Validate())
 		})
-		t.Run("BadNewCredentialsIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadNewCredentials", func(t *testing.T) {
 			storedCreds := NewStoredRepositoryCredentials()
 			creds := NewRepositoryCredentials().SetNewCredentials(*storedCreds)
 			assert.Error(t, creds.Validate())
@@ -765,23 +753,23 @@ func TestSecretOptions(t *testing.T) {
 		assert.True(t, utility.FromBoolPtr(opts.Owned))
 	})
 	t.Run("Validate", func(t *testing.T) {
-		t.Run("NameAndNewValueIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNameAndNewValue", func(t *testing.T) {
 			s := NewSecretOptions().SetName("name").SetValue("value")
 			assert.NoError(t, s.Validate())
 		})
-		t.Run("EmptyIsInvalid", func(t *testing.T) {
-			s := NewSecretOptions()
-			assert.Error(t, s.Validate())
-		})
-		t.Run("ExistingSecretWithNameIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNameAndExistingSecret", func(t *testing.T) {
 			s := NewSecretOptions().SetName("name").SetExists(true)
 			assert.NoError(t, s.Validate())
 		})
-		t.Run("MissingNameIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
+			s := NewSecretOptions()
+			assert.Error(t, s.Validate())
+		})
+		t.Run("FailsWithoutName", func(t *testing.T) {
 			s := NewSecretOptions().SetValue("value")
 			assert.Error(t, s.Validate())
 		})
-		t.Run("ExistingSecretWithNewValueIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithExistingSecretAndNewValue", func(t *testing.T) {
 			s := NewSecretOptions().SetName("name").SetExists(true).SetValue("value")
 			assert.Error(t, s.Validate())
 		})
@@ -805,33 +793,33 @@ func TestPortMappings(t *testing.T) {
 		assert.Equal(t, port, utility.FromIntPtr(pm.HostPort))
 	})
 	t.Run("Validate", func(t *testing.T) {
-		t.Run("EmptyIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
 			pm := NewPortMapping()
 			assert.Error(t, pm.Validate())
 		})
-		t.Run("JustContainerPortIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithJustContainerPort", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(1337)
 			assert.NoError(t, pm.Validate())
 		})
-		t.Run("ContainerAndHostPortIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithContainerAndHostPort", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(1337).SetHostPort(1337)
 			assert.NoError(t, pm.Validate())
 		})
-		t.Run("NegativeContainerPortIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithNegativeContainerPort", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(-100)
 			assert.Error(t, pm.Validate())
 		})
-		t.Run("ContainerPortAboveMaxIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithContainerPortAboveMax", func(t *testing.T) {
 			pm := NewPortMapping().SetContainerPort(100000)
 			assert.Error(t, pm.Validate())
 		})
-		t.Run("NegativeHostPortIsInvalid", func(t *testing.T) {
+		t.Run("FailsWIthNegativeHostPort", func(t *testing.T) {
 			pm := NewPortMapping().
 				SetContainerPort(1337).
 				SetHostPort(-100)
 			assert.Error(t, pm.Validate())
 		})
-		t.Run("HostPortAboveMaxIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithHostPortAboveMax", func(t *testing.T) {
 			pm := NewPortMapping().
 				SetContainerPort(1337).
 				SetHostPort(100000)
@@ -870,11 +858,14 @@ func TestECSPodExecutionOptions(t *testing.T) {
 		assert.True(t, utility.FromBoolPtr(opts.SupportsDebugMode))
 	})
 	t.Run("SetTags", func(t *testing.T) {
-		key := "tkey"
-		value := "tvalue"
-		opts := NewECSPodExecutionOptions().SetTags(map[string]string{key: value})
-		require.Len(t, opts.Tags, 1)
-		assert.Equal(t, value, opts.Tags[key])
+		tags := map[string]string{
+			"key0": "val0",
+			"key1": "val1",
+		}
+		opts := NewECSPodExecutionOptions().SetTags(tags)
+		assert.Equal(t, tags, opts.Tags)
+		opts.SetTags(nil)
+		assert.Empty(t, opts.Tags)
 	})
 	t.Run("AddTags", func(t *testing.T) {
 		tags := map[string]string{
@@ -887,8 +878,15 @@ func TestECSPodExecutionOptions(t *testing.T) {
 		assert.Equal(t, tags, opts.Tags)
 	})
 	t.Run("Validate", func(t *testing.T) {
-		t.Run("EmptyIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithNoFieldsPopulated", func(t *testing.T) {
 			opts := NewECSPodExecutionOptions()
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
+			awsvpcOpts := NewAWSVPCOptions().AddSubnets("subnet-12345")
+			opts := NewECSPodExecutionOptions().
+				SetCluster("cluster").
+				SetAWSVPCOptions(*awsvpcOpts)
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("NoPlacementOptionsAreDefaultedToBinpackMemory", func(t *testing.T) {
@@ -899,17 +897,12 @@ func TestECSPodExecutionOptions(t *testing.T) {
 			assert.Equal(t, StrategyBinpack, *opts.PlacementOpts.Strategy)
 			assert.Equal(t, StrategyParamBinpackMemory, utility.FromStringPtr(opts.PlacementOpts.StrategyParameter))
 		})
-		t.Run("BadPlacementOptionsAreInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadPlacementOptions", func(t *testing.T) {
 			placementOpts := NewECSPodPlacementOptions().SetStrategy("foo")
 			opts := NewECSPodExecutionOptions().SetPlacementOptions(*placementOpts)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("GoodAWSVPCOptionsIsValid", func(t *testing.T) {
-			awsvpcOpts := NewAWSVPCOptions().AddSubnets("subnet-12345")
-			opts := NewECSPodExecutionOptions().SetAWSVPCOptions(*awsvpcOpts)
-			assert.NoError(t, opts.Validate())
-		})
-		t.Run("BadAWSVPCOptionsIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBadAWSVPCOptions", func(t *testing.T) {
 			opts := NewECSPodExecutionOptions().SetAWSVPCOptions(*NewAWSVPCOptions())
 			assert.Error(t, opts.Validate())
 		})
@@ -949,9 +942,8 @@ func TestECSPodPlacementOptions(t *testing.T) {
 		assert.Equal(t, filter, opts.InstanceFilters[0])
 	})
 	t.Run("Validate", func(t *testing.T) {
-		t.Run("EmptyIsValid", func(t *testing.T) {
-			var opts ECSPodPlacementOptions
-			assert.NoError(t, opts.Validate())
+		t.Run("SucceedsWithNoFieldsPopulated", func(t *testing.T) {
+			assert.NoError(t, NewECSPodPlacementOptions().Validate())
 		})
 		t.Run("EmptyDefaultsToBinpackMemory", func(t *testing.T) {
 			var opts ECSPodPlacementOptions
@@ -968,25 +960,25 @@ func TestECSPodPlacementOptions(t *testing.T) {
 			assert.Equal(t, StrategyBinpack, *opts.Strategy)
 			assert.Equal(t, StrategyParamBinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("BinpackWithMemoryBinpackingIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithBinpackByMemory", func(t *testing.T) {
 			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackMemory)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
 			assert.Equal(t, StrategyBinpack, *opts.Strategy)
 			assert.Equal(t, StrategyParamBinpackMemory, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("BinpackWithCPUBinpackingIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithBinpackByCPU", func(t *testing.T) {
 			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamBinpackCPU)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
 			assert.Equal(t, StrategyBinpack, *opts.Strategy)
 			assert.Equal(t, StrategyParamBinpackCPU, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("BinpackWithSpreadHostIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBinpackAndSpreadHostParameter", func(t *testing.T) {
 			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter(StrategyParamSpreadHost)
 			assert.Error(t, opts.Validate())
 		})
-		t.Run("BinpackWithInvalidParameterIsInvalid", func(t *testing.T) {
+		t.Run("FailsWithBinpackAndInvalidParameter", func(t *testing.T) {
 			opts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack).SetStrategyParameter("foo")
 			assert.Error(t, opts.Validate())
 		})
@@ -997,14 +989,14 @@ func TestECSPodPlacementOptions(t *testing.T) {
 			assert.Equal(t, StrategySpread, *opts.Strategy)
 			assert.Equal(t, StrategyParamSpreadHost, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("SpreadWithHostSpreadIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithSpreadingByHost", func(t *testing.T) {
 			opts := NewECSPodPlacementOptions().SetStrategy(StrategySpread).SetStrategyParameter(StrategyParamSpreadHost)
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
 			assert.Equal(t, StrategySpread, *opts.Strategy)
 			assert.Equal(t, StrategyParamSpreadHost, utility.FromStringPtr(opts.StrategyParameter))
 		})
-		t.Run("SpreadWithCustomParameterIsValid", func(t *testing.T) {
+		t.Run("SucceedsWithSpreadingByCustomParameter", func(t *testing.T) {
 			opts := NewECSPodPlacementOptions().SetStrategy(StrategySpread).SetStrategyParameter("custom")
 			require.NoError(t, opts.Validate())
 			require.NotZero(t, opts.Strategy)
@@ -1049,7 +1041,7 @@ func TestAWSVPCOptions(t *testing.T) {
 		assert.ElementsMatch(t, groups, opts.SecurityGroups)
 	})
 	t.Run("Validate", func(t *testing.T) {
-		t.Run("Succeeds", func(t *testing.T) {
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
 			opts := NewAWSVPCOptions().
 				AddSubnets("subnet-12345").
 				AddSecurityGroups("sg-12345")
@@ -1059,7 +1051,7 @@ func TestAWSVPCOptions(t *testing.T) {
 			opts := NewAWSVPCOptions().AddSubnets("subnet-12345")
 			assert.NoError(t, opts.Validate())
 		})
-		t.Run("FailsWithEmpty", func(t *testing.T) {
+		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
 			opts := NewAWSVPCOptions()
 			assert.Error(t, opts.Validate())
 		})
@@ -1084,5 +1076,22 @@ func TestECSTaskDefinition(t *testing.T) {
 	t.Run("SetOwned", func(t *testing.T) {
 		def := NewECSTaskDefinition().SetOwned(true)
 		assert.True(t, utility.FromBoolPtr(def.Owned))
+	})
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
+			def := NewECSTaskDefinition().SetID("id").SetOwned(true)
+			assert.NoError(t, def.Validate())
+		})
+		t.Run("SucceedsWithJustTaskDefinitionID", func(t *testing.T) {
+			def := NewECSTaskDefinition().SetID("id")
+			assert.NoError(t, def.Validate())
+		})
+		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
+			assert.Error(t, NewECSTaskDefinition().Validate())
+		})
+		t.Run("FailsWithoutTaskDefinitionID", func(t *testing.T) {
+			def := NewECSTaskDefinition().SetOwned(true)
+			assert.Error(t, def.Validate())
+		})
 	})
 }

--- a/ecs_pod_test.go
+++ b/ecs_pod_test.go
@@ -93,6 +93,35 @@ func TestECSPodResources(t *testing.T) {
 		assert.Equal(t, *containerRes0, res.Containers[0])
 		assert.Equal(t, *containerRes1, res.Containers[1])
 	})
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
+			opts := NewECSPodResources().
+				SetTaskID("task_id").
+				SetCluster("cluster").
+				SetTaskDefinition(*NewECSTaskDefinition().SetID("task_definition_id")).
+				AddContainers(*NewECSContainerResources().SetContainerID("container_id"))
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("SucceedsWithJustTaskID", func(t *testing.T) {
+			opts := NewECSPodResources().SetTaskID("task_id")
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("FailsWithEmpty", func(t *testing.T) {
+			assert.Error(t, NewECSPodResources().Validate())
+		})
+		t.Run("FailsWithInvalidTaskDefinition", func(t *testing.T) {
+			opts := NewECSPodResources().
+				SetTaskID("task_id").
+				SetTaskDefinition(*NewECSTaskDefinition())
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("FailsWithInvalidContainer", func(t *testing.T) {
+			opts := NewECSPodResources().
+				SetTaskID("task_id").
+				AddContainers(*NewECSContainerResources())
+			assert.Error(t, opts.Validate())
+		})
+	})
 }
 
 func TestECSContainerResources(t *testing.T) {

--- a/ecs_pod_test.go
+++ b/ecs_pod_test.go
@@ -29,6 +29,31 @@ func TestContainerSecret(t *testing.T) {
 		s := NewContainerSecret().SetOwned(true)
 		assert.True(t, utility.FromBoolPtr(s.Owned))
 	})
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
+			s := NewContainerSecret().
+				SetID("id").
+				SetName("name").
+				SetOwned(true)
+			assert.NoError(t, s.Validate())
+		})
+		t.Run("SucceedsWithJustID", func(t *testing.T) {
+			s := NewContainerSecret().SetID("id")
+			assert.NoError(t, s.Validate())
+		})
+		t.Run("FailsWithEmpty", func(t *testing.T) {
+			s := NewContainerSecret()
+			assert.Error(t, s.Validate())
+		})
+		t.Run("FailsWithoutID", func(t *testing.T) {
+			s := NewContainerSecret().SetName("name").SetOwned(true)
+			assert.Error(t, s.Validate())
+		})
+		t.Run("FailsWithEmptyID", func(t *testing.T) {
+			s := NewContainerSecret().SetID("")
+			assert.Error(t, s.Validate())
+		})
+	})
 }
 
 func TestECSPodResources(t *testing.T) {
@@ -107,6 +132,33 @@ func TestECSContainerResources(t *testing.T) {
 		assert.ElementsMatch(t, secrets, res.Secrets)
 		res.AddSecrets()
 		assert.ElementsMatch(t, secrets, res.Secrets)
+	})
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
+			r := NewECSContainerResources().
+				SetContainerID("container_id").
+				SetName("name").
+				AddSecrets(*NewContainerSecret().SetID("id"))
+			assert.NoError(t, r.Validate())
+		})
+		t.Run("FailsWithEmpty", func(t *testing.T) {
+			r := NewECSContainerResources()
+			assert.Error(t, r.Validate())
+		})
+		t.Run("SucceedsWithJustContainerID", func(t *testing.T) {
+			r := NewECSContainerResources().SetContainerID("container_id")
+			assert.NoError(t, r.Validate())
+		})
+		t.Run("FailsWithBadContainerID", func(t *testing.T) {
+			r := NewECSContainerResources().SetContainerID("")
+			assert.Error(t, r.Validate())
+		})
+		t.Run("FailsWithBadSecret", func(t *testing.T) {
+			r := NewECSContainerResources().
+				SetContainerID("container_id").
+				AddSecrets(*NewContainerSecret())
+			assert.Error(t, r.Validate())
+		})
 	})
 }
 

--- a/ecs_pod_test.go
+++ b/ecs_pod_test.go
@@ -15,15 +15,15 @@ func TestContainerSecret(t *testing.T) {
 		require.NotZero(t, s)
 		assert.Zero(t, *s)
 	})
+	t.Run("SetID", func(t *testing.T) {
+		id := "id"
+		s := NewContainerSecret().SetID(id)
+		assert.Equal(t, id, utility.FromStringPtr(s.ID))
+	})
 	t.Run("SetName", func(t *testing.T) {
 		name := "name"
 		s := NewContainerSecret().SetName(name)
 		assert.Equal(t, name, utility.FromStringPtr(s.Name))
-	})
-	t.Run("SetValue", func(t *testing.T) {
-		val := "val"
-		s := NewContainerSecret().SetValue(val)
-		assert.Equal(t, val, utility.FromStringPtr(s.Value))
 	})
 	t.Run("SetOwned", func(t *testing.T) {
 		s := NewContainerSecret().SetOwned(true)
@@ -89,83 +89,92 @@ func TestECSContainerResources(t *testing.T) {
 		assert.Equal(t, id, utility.FromStringPtr(res.Name))
 	})
 	t.Run("SetSecrets", func(t *testing.T) {
-		s := NewContainerSecret().SetName("name").SetValue("value")
-		res := NewECSContainerResources().SetSecrets([]ContainerSecret{*s})
-		require.Len(t, res.Secrets, 1)
-		assert.Equal(t, *s, res.Secrets[0])
+		secrets := []ContainerSecret{
+			*NewContainerSecret().SetID("id0").SetName("name0"),
+			*NewContainerSecret().SetID("id1").SetName("name1"),
+		}
+		res := NewECSContainerResources().SetSecrets(secrets)
+		assert.ElementsMatch(t, secrets, res.Secrets)
+		res.SetSecrets(nil)
+		assert.Empty(t, res.Secrets)
 	})
 	t.Run("AddSecrets", func(t *testing.T) {
-		s0 := NewContainerSecret().SetName("name0").SetValue("value0")
-		s1 := NewContainerSecret().SetName("name1").SetValue("value1")
-		res := NewECSContainerResources().AddSecrets(*s0, *s1)
-		require.Len(t, res.Secrets, 2)
-		assert.Equal(t, *s0, res.Secrets[0])
-		assert.Equal(t, *s1, res.Secrets[1])
+		secrets := []ContainerSecret{
+			*NewContainerSecret().SetID("id0").SetName("name0"),
+			*NewContainerSecret().SetID("id1").SetName("name1"),
+		}
+		res := NewECSContainerResources().AddSecrets(secrets...)
+		assert.ElementsMatch(t, secrets, res.Secrets)
+		res.AddSecrets()
+		assert.ElementsMatch(t, secrets, res.Secrets)
 	})
 }
 
 func TestECSStatusInfo(t *testing.T) {
 	t.Run("NewECSPodStatusInfo", func(t *testing.T) {
-		stat := NewECSPodStatusInfo()
-		require.NotZero(t, stat)
-		assert.Zero(t, *stat)
+		ps := NewECSPodStatusInfo()
+		require.NotZero(t, ps)
+		assert.Zero(t, *ps)
 	})
 	t.Run("SetStatus", func(t *testing.T) {
-		stat := NewECSPodStatusInfo().SetStatus(StatusRunning)
-		assert.Equal(t, StatusRunning, stat.Status)
+		ps := NewECSPodStatusInfo().SetStatus(StatusRunning)
+		assert.Equal(t, StatusRunning, ps.Status)
 	})
 	t.Run("SetContainers", func(t *testing.T) {
-		containerStat0 := NewECSContainerStatusInfo().
-			SetContainerID("container_id0").
-			SetName("container_name0").
-			SetStatus(StatusRunning)
-		containerStat1 := NewECSContainerStatusInfo().
-			SetContainerID("container_id1").
-			SetName("container_name1").
-			SetStatus(StatusRunning)
-		stat := NewECSPodStatusInfo().SetContainers([]ECSContainerStatusInfo{
-			*containerStat0, *containerStat1,
-		})
-		require.Len(t, stat.Containers, 2)
-		assert.Equal(t, *containerStat0, stat.Containers[0])
-		assert.Equal(t, *containerStat1, stat.Containers[1])
+		cs := []ECSContainerStatusInfo{
+			*NewECSContainerStatusInfo().
+				SetContainerID("container_id0").
+				SetName("container_name0").
+				SetStatus(StatusRunning),
+			*NewECSContainerStatusInfo().
+				SetContainerID("container_id1").
+				SetName("container_name1").
+				SetStatus(StatusStopped),
+		}
+		ps := NewECSPodStatusInfo().SetContainers(cs)
+		assert.ElementsMatch(t, ps.Containers, cs)
+		ps.SetContainers(nil)
+		assert.Empty(t, ps.Containers)
 	})
 	t.Run("AddContainers", func(t *testing.T) {
-		containerStat := NewECSContainerStatusInfo().
-			SetContainerID("container_id0").
-			SetName("container_name0").
-			SetStatus(StatusRunning)
+		cs := []ECSContainerStatusInfo{
+			*NewECSContainerStatusInfo().
+				SetContainerID("container_id0").
+				SetName("container_name0").
+				SetStatus(StatusRunning),
+			*NewECSContainerStatusInfo().
+				SetContainerID("container_id1").
+				SetName("container_name1").
+				SetStatus(StatusStopped),
+		}
 
-		stat := NewECSPodStatusInfo().AddContainers(*containerStat)
-		require.Len(t, stat.Containers, 1)
-		assert.Equal(t, *containerStat, stat.Containers[0])
-
-		stat.AddContainers()
-		require.Len(t, stat.Containers, 1)
-		assert.Equal(t, *containerStat, stat.Containers[0])
+		ps := NewECSPodStatusInfo().AddContainers(cs...)
+		assert.ElementsMatch(t, cs, ps.Containers)
+		ps.AddContainers()
+		assert.ElementsMatch(t, cs, ps.Containers)
 	})
 }
 
 func TestECSContainerStatusInfo(t *testing.T) {
 	t.Run("NewECSContainerStatusInfo", func(t *testing.T) {
-		stat := NewECSContainerStatusInfo()
-		require.NotZero(t, stat)
-		assert.Zero(t, *stat)
+		cs := NewECSContainerStatusInfo()
+		require.NotZero(t, cs)
+		assert.Zero(t, *cs)
 	})
 	t.Run("SetContainerID", func(t *testing.T) {
 		id := "container_id"
-		stat := NewECSContainerStatusInfo().SetContainerID(id)
-		assert.Equal(t, id, utility.FromStringPtr(stat.ContainerID))
+		cs := NewECSContainerStatusInfo().SetContainerID(id)
+		assert.Equal(t, id, utility.FromStringPtr(cs.ContainerID))
 	})
 	t.Run("SetName", func(t *testing.T) {
 		name := "name"
-		stat := NewECSContainerStatusInfo().SetName(name)
-		assert.Equal(t, name, utility.FromStringPtr(stat.Name))
+		cs := NewECSContainerStatusInfo().SetName(name)
+		assert.Equal(t, name, utility.FromStringPtr(cs.Name))
 	})
 	t.Run("SetStatus", func(t *testing.T) {
 		status := StatusRunning
-		stat := NewECSContainerStatusInfo().SetStatus(status)
-		assert.Equal(t, status, stat.Status)
+		cs := NewECSContainerStatusInfo().SetStatus(status)
+		assert.Equal(t, status, cs.Status)
 	})
 }
 

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -118,8 +118,6 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			checkPodStatus(t, p, cocoa.StatusStopped)
 		},
 		"StopSucceedsWithSecrets": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
-			// kim: TODO: deal with the fact that the secrets might be out of
-			// order.
 			secret := cocoa.NewEnvironmentVariable().
 				SetName("secret").
 				SetSecretOptions(*cocoa.NewSecretOptions().

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -46,8 +46,8 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				require.NoError(t, p.Delete(ctx))
 			}()
 
-			stat := p.StatusInfo()
-			assert.Equal(t, cocoa.StatusStarting, stat.Status)
+			ps := p.StatusInfo()
+			assert.Equal(t, cocoa.StatusStarting, ps.Status)
 		},
 		"CreatePodFailsWithInvalidCreationOpts": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
 			opts := cocoa.NewECSPodCreationOptions()

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -61,7 +61,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetName("envVar").
 				SetSecretOptions(*cocoa.NewSecretOptions().
 					SetName(testutil.NewSecretName("name")).
-					SetValue("value"))
+					SetNewValue("value"))
 			containerDef := cocoa.NewECSContainerDefinition().
 				SetImage("image").
 				AddEnvironmentVariables(*envVar).
@@ -88,7 +88,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetUsername("username").
 				SetPassword("password")
 			creds := cocoa.NewRepositoryCredentials().
-				SetSecretName(testutil.NewSecretName(t.Name())).
+				SetName(testutil.NewSecretName(t.Name())).
 				SetNewCredentials(*storedCreds)
 			containerDef := cocoa.NewECSContainerDefinition().
 				SetImage("image").
@@ -121,7 +121,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 			envVar := cocoa.NewEnvironmentVariable().SetName("envVar").
 				SetSecretOptions(*cocoa.NewSecretOptions().
 					SetName(testutil.NewSecretName("name")).
-					SetValue("value"))
+					SetNewValue("value"))
 			containerDef := cocoa.NewECSContainerDefinition().SetImage("image").
 				AddEnvironmentVariables(*envVar).
 				SetMemoryMB(128).
@@ -149,9 +149,8 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetName("envVar").
 				SetSecretOptions(*cocoa.NewSecretOptions().
 					SetName(testutil.NewSecretName("name")).
-					SetValue("value").
-					SetExists(false))
-			envVar.SecretOpts.SetOwned(true)
+					SetNewValue("value").
+					SetOwned(true))
 
 			containerDef := cocoa.NewECSContainerDefinition().
 				SetImage("image").
@@ -188,7 +187,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetUsername("username").
 				SetPassword("password")
 			creds := cocoa.NewRepositoryCredentials().
-				SetSecretName(testutil.NewSecretName(t.Name())).
+				SetName(testutil.NewSecretName(t.Name())).
 				SetNewCredentials(*storedCreds).
 				SetOwned(true)
 

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -38,7 +38,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
-			p, err := c.CreatePod(ctx, opts)
+			p, err := c.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 			require.NotNil(t, p)
 
@@ -52,7 +52,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 		"CreatePodFailsWithInvalidCreationOpts": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
 			opts := cocoa.NewECSPodCreationOptions()
 
-			p, err := c.CreatePod(ctx, opts)
+			p, err := c.CreatePod(ctx, *opts)
 			require.Error(t, err)
 			require.Zero(t, p)
 		},
@@ -79,7 +79,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
-			p, err := c.CreatePod(ctx, opts)
+			p, err := c.CreatePod(ctx, *opts)
 			require.Error(t, err)
 			require.Zero(t, p)
 		},
@@ -107,7 +107,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
-			p, err := c.CreatePod(ctx, opts)
+			p, err := c.CreatePod(ctx, *opts)
 			require.Error(t, err)
 			require.Zero(t, p)
 		},
@@ -140,7 +140,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetName(testutil.NewTaskDefinitionFamily(t.Name()))
 			assert.Error(t, opts.Validate())
 
-			p, err := c.CreatePod(ctx, opts)
+			p, err := c.CreatePod(ctx, *opts)
 			require.Error(t, err)
 			require.Zero(t, p)
 		},
@@ -173,7 +173,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
-			p, err := c.CreatePod(ctx, opts)
+			p, err := c.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 			require.NotNil(t, p)
 
@@ -212,7 +212,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
-			p, err := c.CreatePod(ctx, opts)
+			p, err := c.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 			require.NotNil(t, p)
 

--- a/mock/ecs_pod_creator.go
+++ b/mock/ecs_pod_creator.go
@@ -13,7 +13,7 @@ import (
 type ECSPodCreator struct {
 	cocoa.ECSPodCreator
 
-	CreatePodInput  []*cocoa.ECSPodCreationOptions
+	CreatePodInput  []cocoa.ECSPodCreationOptions
 	CreatePodOutput *cocoa.ECSPod
 	CreatePodError  error
 }
@@ -28,7 +28,7 @@ func NewECSPodCreator(c cocoa.ECSPodCreator) *ECSPodCreator {
 // CreatePod saves the input and returns a new mock pod. The mock output can be
 // customized. By default, it will create a new pod based on the input that is
 // backed by a mock ECSClient.
-func (m *ECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPodCreationOptions) (cocoa.ECSPod, error) {
+func (m *ECSPodCreator) CreatePod(ctx context.Context, opts ...cocoa.ECSPodCreationOptions) (cocoa.ECSPod, error) {
 	m.CreatePodInput = opts
 
 	if m.CreatePodOutput != nil {
@@ -43,6 +43,6 @@ func (m *ECSPodCreator) CreatePod(ctx context.Context, opts ...*cocoa.ECSPodCrea
 // CreatePodFromExistingDefinition saves the input and returns a new mock pod.
 // The mock output can be customized. By default, it will create a new pod from
 // the existing task definition that is backed by a mock ECSClient.
-func (m *ECSPodCreator) CreatePodFromExistingDefinition(ctx context.Context, def cocoa.ECSTaskDefinition, opts ...*cocoa.ECSPodExecutionOptions) (cocoa.ECSPod, error) {
+func (m *ECSPodCreator) CreatePodFromExistingDefinition(ctx context.Context, def cocoa.ECSTaskDefinition, opts ...cocoa.ECSPodExecutionOptions) (cocoa.ECSPod, error) {
 	return nil, errors.New("TODO: implement")
 }

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -290,7 +290,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			require.Len(t, p.Resources().Containers, 1)
 			require.Len(t, p.Resources().Containers[0].Secrets, 1)
 
-			getSecretOut, err := sm.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{SecretId: p.Resources().Containers[0].Secrets[0].Name})
+			getSecretOut, err := sm.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{SecretId: p.Resources().Containers[0].Secrets[0].ID})
 			require.NoError(t, err)
 			require.NotZero(t, getSecretOut)
 			assert.Equal(t, utility.FromStringPtr(secretOpts.Value), utility.FromStringPtr(getSecretOut.SecretString))

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -146,7 +146,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 				AddContainerDefinitions(*containerDef).
 				SetExecutionOptions(*execOpts)
 
-			_, err := pc.CreatePod(ctx, opts)
+			_, err := pc.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 
 			require.NotZero(t, c.RegisterTaskDefinitionInput)
@@ -217,7 +217,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 				AddContainerDefinitions(*containerDef).
 				SetExecutionOptions(*execOpts)
 
-			_, err := pc.CreatePod(ctx, opts)
+			_, err := pc.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 
 			require.NotZero(t, c.RegisterTaskDefinitionInput)
@@ -274,7 +274,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			c.RegisterTaskDefinitionError = errors.New("fake error")
 			c.RunTaskError = errors.New("fake error")
 
-			_, err := pc.CreatePod(ctx, opts)
+			_, err := pc.CreatePod(ctx, *opts)
 			require.Error(t, err)
 
 			secret, ok := GlobalSecretCache[utility.FromStringPtr(secretOpts.Name)]
@@ -284,7 +284,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			c.RegisterTaskDefinitionError = nil
 			c.RunTaskError = nil
 
-			p, err := pc.CreatePod(ctx, opts)
+			p, err := pc.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 
 			require.Len(t, p.Resources().Containers, 1)

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"testing"
 	"time"
@@ -165,9 +166,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			assert.Equal(t, "creation_tag", utility.FromStringPtr(c.RegisterTaskDefinitionInput.Tags[0].Key))
 			assert.Equal(t, opts.Tags["creation_tag"], utility.FromStringPtr(c.RegisterTaskDefinitionInput.Tags[0].Value))
 			require.Len(t, c.RegisterTaskDefinitionInput.ContainerDefinitions, 1)
-			left, right := utility.StringSliceSymmetricDifference(containerDef.Command, utility.FromStringPtrSlice(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Command))
-			assert.Empty(t, left)
-			assert.Empty(t, right)
+			assert.Equal(t, containerDef.Command, utility.FromStringPtrSlice(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Command))
 			assert.Equal(t, utility.FromStringPtr(containerDef.WorkingDir), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].WorkingDirectory))
 			assert.EqualValues(t, utility.FromIntPtr(containerDef.MemoryMB), utility.FromInt64Ptr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Memory))
 			assert.EqualValues(t, utility.FromIntPtr(containerDef.CPU), utility.FromInt64Ptr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Cpu))
@@ -204,12 +203,8 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 				SetImage("image").
 				SetCommand([]string{"echo", "foo"}).
 				AddEnvironmentVariables(*envVar)
-			placementOpts := cocoa.NewECSPodPlacementOptions().
-				SetStrategy(cocoa.StrategyBinpack).
-				SetStrategyParameter(cocoa.StrategyParamBinpackMemory)
 			execOpts := cocoa.NewECSPodExecutionOptions().
-				SetCluster(testutil.ECSClusterName()).
-				SetPlacementOptions(*placementOpts)
+				SetCluster(testutil.ECSClusterName())
 			opts := cocoa.NewECSPodCreationOptions().
 				SetMemoryMB(512).
 				SetCPU(1024).
@@ -228,23 +223,60 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			cpu, err := strconv.Atoi(utility.FromStringPtr(c.RegisterTaskDefinitionInput.Cpu))
 			require.NoError(t, err)
 			assert.Equal(t, utility.FromIntPtr(opts.CPU), cpu)
-			assert.Equal(t, utility.FromStringPtr(opts.TaskRole), utility.FromStringPtr(c.RegisterTaskDefinitionInput.TaskRoleArn))
 			assert.Equal(t, utility.FromStringPtr(opts.ExecutionRole), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ExecutionRoleArn))
 			require.Len(t, c.RegisterTaskDefinitionInput.ContainerDefinitions, 1)
-			left, right := utility.StringSliceSymmetricDifference(containerDef.Command, utility.FromStringPtrSlice(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Command))
-			assert.Empty(t, left)
-			assert.Empty(t, right)
+			assert.Equal(t, containerDef.Command, utility.FromStringPtrSlice(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Command))
 			require.Len(t, c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Secrets, 1)
 			assert.Equal(t, utility.FromStringPtr(envVar.Name), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Secrets[0].Name))
 			assert.Equal(t, utility.FromStringPtr(secretOpts.Name), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Secrets[0].ValueFrom))
 
 			assert.Equal(t, utility.FromStringPtr(secretOpts.Name), utility.FromStringPtr(sm.CreateSecretInput.Name))
 			assert.Equal(t, utility.FromStringPtr(secretOpts.Value), utility.FromStringPtr(sm.CreateSecretInput.SecretString))
+		},
+		"RegistersTaskDefinitionAndRunsTaskWithCreatedRepositoryCredentials": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
+			repoCreds := cocoa.NewRepositoryCredentials().
+				SetSecretName("repo_creds_secret_name").
+				SetNewCredentials(*cocoa.NewStoredRepositoryCredentials().
+					SetUsername("username").
+					SetPassword("password"))
+			containerDef := cocoa.NewECSContainerDefinition().
+				SetName("name").
+				SetImage("image").
+				SetCommand([]string{"echo", "foo"}).
+				SetRepositoryCredentials(*repoCreds)
+			execOpts := cocoa.NewECSPodExecutionOptions().
+				SetCluster(testutil.ECSClusterName())
+			opts := cocoa.NewECSPodCreationOptions().
+				SetMemoryMB(512).
+				SetCPU(1024).
+				SetExecutionRole("execution_role").
+				AddContainerDefinitions(*containerDef).
+				SetExecutionOptions(*execOpts)
 
-			require.NotZero(t, c.RunTaskInput)
-			require.Len(t, c.RunTaskInput.PlacementStrategy, 1)
-			assert.EqualValues(t, *placementOpts.Strategy, utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Type))
-			assert.Equal(t, utility.FromStringPtr(placementOpts.StrategyParameter), utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Field))
+			p, err := pc.CreatePod(ctx, *opts)
+			require.NoError(t, err)
+
+			require.NotZero(t, c.RegisterTaskDefinitionInput)
+
+			mem, err := strconv.Atoi(utility.FromStringPtr(c.RegisterTaskDefinitionInput.Memory))
+			require.NoError(t, err)
+			assert.Equal(t, utility.FromIntPtr(opts.MemoryMB), mem)
+			cpu, err := strconv.Atoi(utility.FromStringPtr(c.RegisterTaskDefinitionInput.Cpu))
+			require.NoError(t, err)
+			assert.Equal(t, utility.FromIntPtr(opts.CPU), cpu)
+			assert.Equal(t, utility.FromStringPtr(opts.ExecutionRole), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ExecutionRoleArn))
+			require.Len(t, c.RegisterTaskDefinitionInput.ContainerDefinitions, 1)
+			assert.Equal(t, containerDef.Command, utility.FromStringPtrSlice(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Command))
+			res := p.Resources()
+			require.Len(t, res.Containers, 1)
+			require.Len(t, res.Containers[0].Secrets, 1)
+			require.NotZero(t, c.RegisterTaskDefinitionInput.ContainerDefinitions[0].RepositoryCredentials, 1)
+			assert.Equal(t, utility.FromStringPtr(res.Containers[0].Secrets[0].ID), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].RepositoryCredentials.CredentialsParameter))
+
+			assert.Equal(t, utility.FromStringPtr(repoCreds.SecretName), utility.FromStringPtr(sm.CreateSecretInput.Name))
+			storedCreds, err := json.Marshal(repoCreds.NewCreds)
+			require.NoError(t, err)
+			assert.Equal(t, string(storedCreds), utility.FromStringPtr(sm.CreateSecretInput.SecretString))
 		},
 		"CreatingNewSecretsIsRetryable": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
 			secretOpts := cocoa.NewSecretOptions().

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -85,7 +85,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			SetName(t.Name()).
 			SetSecretOptions(*cocoa.NewSecretOptions().
 				SetName(t.Name()).
-				SetValue(utility.RandomString()).
+				SetNewValue(utility.RandomString()).
 				SetOwned(true))
 	}
 	makeContainerDef := func(t *testing.T) *cocoa.ECSContainerDefinition {

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -108,8 +108,8 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 	}
 
 	checkPodDeleted := func(ctx context.Context, t *testing.T, p cocoa.ECSPod, c cocoa.ECSClient, smc cocoa.SecretsManagerClient, opts cocoa.ECSPodCreationOptions) {
-		stat := p.StatusInfo()
-		assert.Equal(t, cocoa.StatusDeleted, stat.Status)
+		ps := p.StatusInfo()
+		assert.Equal(t, cocoa.StatusDeleted, ps.Status)
 
 		res := p.Resources()
 
@@ -132,11 +132,11 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 		for _, containerRes := range res.Containers {
 			for _, s := range containerRes.Secrets {
 				_, err := smc.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{
-					SecretId: s.Name,
+					SecretId: s.ID,
 				})
 				assert.NoError(t, err)
 				_, err = smc.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
-					SecretId: s.Name,
+					SecretId: s.ID,
 				})
 				assert.Error(t, err)
 			}
@@ -153,14 +153,14 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			require.Error(t, p.Stop(ctx))
 
-			stat := p.StatusInfo()
-			assert.Equal(t, cocoa.StatusStarting, stat.Status)
+			ps := p.StatusInfo()
+			assert.Equal(t, cocoa.StatusStarting, ps.Status)
 
 			c.StopTaskError = nil
 
 			require.NoError(t, p.Stop(ctx))
-			stat = p.StatusInfo()
-			assert.Equal(t, cocoa.StatusStopped, stat.Status)
+			ps = p.StatusInfo()
+			assert.Equal(t, cocoa.StatusStopped, ps.Status)
 		},
 		"DeleteIsIdempotentWhenStoppingTaskFails": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
 			opts := makePodCreationOpts(t).AddContainerDefinitions(
@@ -175,9 +175,9 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			require.Error(t, p.Delete(ctx))
 
-			stat := p.StatusInfo()
+			ps := p.StatusInfo()
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusStarting, stat.Status)
+			assert.Equal(t, cocoa.StatusStarting, ps.Status)
 
 			c.StopTaskError = nil
 
@@ -198,9 +198,9 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			require.Error(t, p.Delete(ctx))
 
-			stat := p.StatusInfo()
+			ps := p.StatusInfo()
 			require.NoError(t, err)
-			assert.Equal(t, cocoa.StatusStopped, stat.Status)
+			assert.Equal(t, cocoa.StatusStopped, ps.Status)
 
 			c.DeregisterTaskDefinitionError = nil
 
@@ -221,8 +221,8 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			require.Error(t, p.Delete(ctx))
 
-			stat := p.StatusInfo()
-			assert.Equal(t, cocoa.StatusStopped, stat.Status)
+			ps := p.StatusInfo()
+			assert.Equal(t, cocoa.StatusStopped, ps.Status)
 
 			smc.DeleteSecretError = nil
 

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -146,7 +146,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 	return map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient){
 		"StopIsIdempotentWhenItFails": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
 			opts := makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t))
-			p, err := pc.CreatePod(ctx, opts)
+			p, err := pc.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 
 			c.StopTaskError = errors.New("fake error")
@@ -168,7 +168,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 					*makeSecretEnvVar(t),
 				),
 			)
-			p, err := pc.CreatePod(ctx, opts)
+			p, err := pc.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 
 			c.StopTaskError = errors.New("fake error")
@@ -191,7 +191,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 					*makeSecretEnvVar(t),
 				),
 			)
-			p, err := pc.CreatePod(ctx, opts)
+			p, err := pc.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 
 			c.DeregisterTaskDefinitionError = errors.New("fake error")
@@ -214,7 +214,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 					*makeSecretEnvVar(t),
 				),
 			)
-			p, err := pc.CreatePod(ctx, opts)
+			p, err := pc.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 
 			smc.DeleteSecretError = errors.New("fake error")


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15139

* Make a field to distinguish between the secret's friendly name and the unique ARN assigned after the secret is created in Secrets Manager. ECS pods should always perform Secrets Manager operations with the unique ID. The name is just a useful piece of information to associate the friendly secret names that the user gave with the final ARN associated with the created secret. That way, if the user passes a friendly secret name and asks it to be created, they can map the secret name they requested to the unique ARN.
* Propagate the secret name and secret ID (after the secret is created) to the ECS pod's resources during pod creation. I had to make some intermediate structs to hold temporary information until all the secrets were created in Secrets Manager, after which point we know all the secret IDs associated with each pod.
    * If the secret already exists when the pod is created, the secret name and ID will be identical. However, this isn't a real issue because as I said, keeping the friendly secret name in the ECS pod is only really necessary if the secret was just created during pod creation.
* Fix an issue where Docker repository credentials (also a secret, but treated separately from the secret environment variables) were not propagated to the ECS pod resources during pod creation.
* Rename some tests and variables for consistency.
* Pass options as values instead of pointers to the pod creator. There's no real reason the input options have to be pointers, so I would prefer them to be values instead of pointers.
* Add more validation for ECS pod input to better account for container secrets.