### PR TITLE
EVG-14979: clean up ECS and Secrets Manager resources during test teardown

### DIFF
--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -42,7 +42,6 @@ func TestECSClient(t *testing.T) {
 
 	defer func() {
 		testutil.CleanupTaskDefinitions(ctx, t, c)
-
 		testutil.CleanupTasks(ctx, t, c)
 
 		assert.NoError(t, c.Close(ctx))

--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -69,7 +69,7 @@ func TestECSClient(t *testing.T) {
 		},
 		Cpu:    aws.String("128"),
 		Memory: aws.String("4"),
-		Family: aws.String(testutil.NewTaskDefinitionFamily(t.Name())),
+		Family: aws.String(testutil.NewTaskDefinitionFamily(t)),
 	}
 
 	registerOut, err := c.RegisterTaskDefinition(ctx, registerIn)

--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -2,8 +2,6 @@ package ecs
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,8 +13,6 @@ import (
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +39,14 @@ func TestECSClient(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, c)
+
+	defer func() {
+		testutil.CleanupTaskDefinitions(ctx, t, c)
+
+		testutil.CleanupTasks(ctx, t, c)
+
+		assert.NoError(t, c.Close(ctx))
+	}()
 
 	for tName, tCase := range testcase.ECSClientTaskDefinitionTests() {
 		t.Run(tName, func(t *testing.T) {
@@ -72,21 +76,11 @@ func TestECSClient(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, registerOut)
 	require.NotZero(t, registerOut.TaskDefinition)
-
 	defer func() {
-		taskDefs := cleanupTaskDefinitions(ctx, t, c)
-		grip.InfoWhen(len(taskDefs) > 0, message.Fields{
-			"message":          "cleaned up leftover task definitions",
-			"task_definitions": taskDefs,
-			"test":             t.Name(),
+		_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
+			TaskDefinition: registerOut.TaskDefinition.TaskDefinitionArn,
 		})
-		tasks := cleanupTasks(ctx, t, c, taskDefs)
-		grip.InfoWhen(len(tasks) > 0, message.Fields{
-			"message": "cleaned up leftover running tasks",
-			"tasks":   tasks,
-			"test":    t.Name(),
-		})
-		require.NoError(t, c.Close(ctx))
+		assert.NoError(t, err)
 	}()
 
 	for tName, tCase := range testcase.ECSClientRegisteredTaskDefinitionTests(*registerIn, *registerOut) {
@@ -97,130 +91,4 @@ func TestECSClient(t *testing.T) {
 			tCase(tctx, t, c)
 		})
 	}
-}
-
-// cleanupTaskDefinitions cleans up all existing task definitions for testing
-// teardown.
-func cleanupTaskDefinitions(ctx context.Context, t *testing.T, c cocoa.ECSClient) []string {
-	out, err := c.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
-		Status: aws.String(ecs.TaskDefinitionStatusActive),
-	})
-	require.NoError(t, err)
-	require.NotZero(t, out)
-
-	var taskDefs []string
-
-	for _, arn := range out.TaskDefinitionArns {
-		if arn == nil {
-			continue
-		}
-		taskDefArn := *arn
-		// Ignore task definitions that were not generated with testutil.NewTaskDefinitionFamily.
-		name := strings.Join([]string{testutil.TaskDefinitionPrefix(), "cocoa", t.Name()}, "-")
-		if !strings.Contains(taskDefArn, name) {
-			continue
-		}
-		taskDefs = append(taskDefs, *arn)
-		_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
-			TaskDefinition: arn,
-		})
-		assert.NoError(t, err)
-	}
-
-	return taskDefs
-}
-
-// cleanupTasks cleans up all tasks for testing teardown. It only cleans up
-// tasks if they are running and are created from one of the given task
-// definitions.
-func cleanupTasks(ctx context.Context, t *testing.T, c cocoa.ECSClient, taskDefs []string) []string {
-	out, err := c.ListTasks(ctx, &ecs.ListTasksInput{
-		Cluster: aws.String(testutil.ECSClusterName()),
-	})
-	require.NoError(t, err)
-	require.NotZero(t, out)
-
-	if len(out.TaskArns) == 0 {
-		return nil
-	}
-
-	describeOut, err := c.DescribeTasks(ctx, &ecs.DescribeTasksInput{
-		Cluster: aws.String(testutil.ECSClusterName()),
-		Tasks:   out.TaskArns,
-	})
-	require.NoError(t, err)
-
-	var tasks []string
-	for _, task := range describeOut.Tasks {
-		if task == nil {
-			continue
-		}
-
-		if task.TaskDefinitionArn == nil {
-			grip.Notice(message.Fields{
-				"message": "cannot check task for test teardown because it does not have a task definition ARN",
-				"context": "cocoa test teardown",
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		}
-		// Ignore tasks started by task definitions outside of the cocoa testing
-		// environment.
-		if taskDef := *task.TaskDefinitionArn; !utility.StringSliceContains(taskDefs, taskDef) {
-			continue
-		}
-
-		if task.LastStatus == nil {
-			grip.Notice(message.Fields{
-				"message": "cannot check task for test teardown because it does not have a status",
-				"context": "cocoa test teardown",
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		}
-
-		status := *task.LastStatus
-		switch status {
-		case "PROVISIONING", "PENDING", "ACTIVATING":
-			grip.Notice(message.Fields{
-				"message": "cannot stop the task because it is in an unstoppable state",
-				"context": "cocoa test teardown",
-				"status":  status,
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		case "RUNNING":
-			if task.DesiredStatus != nil && *task.DesiredStatus == "STOPPED" {
-				continue
-			}
-			if task.TaskArn == nil {
-				grip.Notice(message.Fields{
-					"message": "cannot stop the task because it is missing a task ARN",
-					"context": "cocoa test teardown",
-					"status":  status,
-					"task":    *task,
-					"test":    t.Name(),
-				})
-				continue
-			}
-			_, err := c.StopTask(ctx, &ecs.StopTaskInput{
-				Cluster: aws.String(testutil.ECSClusterName()),
-				Reason:  aws.String(fmt.Sprintf("cocoa test teardown for test '%s'", t.Name())),
-				Task:    task.TaskArn,
-			})
-			if assert.NoError(t, err) {
-				tasks = append(tasks, *task.TaskArn)
-			}
-		case "DEACTIVATING", "STOPPING", "DEPROVISIONING", "STOPPED":
-			continue
-		default:
-			assert.Fail(t, "unrecognized task status '%s'", status)
-		}
-
-	}
-
-	return tasks
 }

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/awsutil"
@@ -66,15 +65,7 @@ func TestBasicECSPodCreator(t *testing.T) {
 				assert.NoError(t, c.Close(ctx))
 			}()
 
-			smc, err := secret.NewBasicSecretsManagerClient(awsutil.ClientOptions{
-				Creds:  credentials.NewEnvCredentials(),
-				Region: aws.String(testutil.AWSRegion()),
-				Role:   aws.String(testutil.AWSRole()),
-				RetryOpts: &utility.RetryOptions{
-					MaxAttempts: 5,
-				},
-				HTTPClient: hc,
-			})
+			smc, err := secret.NewBasicSecretsManagerClient(*awsOpts)
 			require.NoError(t, err)
 			require.NotNil(t, c)
 			defer func() {
@@ -95,72 +86,57 @@ func TestECSPodCreator(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	hc := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(hc)
+
+	awsOpts := awsutil.NewClientOptions().
+		SetHTTPClient(hc).
+		SetCredentials(credentials.NewEnvCredentials()).
+		SetRole(testutil.AWSRole()).
+		SetRegion(testutil.AWSRegion())
+
+	c, err := NewBasicECSClient(*awsOpts)
+	require.NoError(t, err)
+	defer func() {
+		testutil.CleanupTaskDefinitions(ctx, t, c)
+
+		testutil.CleanupTasks(ctx, t, c)
+
+		assert.NoError(t, c.Close(ctx))
+	}()
+
 	for tName, tCase := range testcase.ECSPodCreatorTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
 			defer tcancel()
 
-			hc := utility.GetHTTPClient()
-			defer utility.PutHTTPClient(hc)
-
-			awsOpts := awsutil.NewClientOptions().
-				SetHTTPClient(hc).
-				SetCredentials(credentials.NewEnvCredentials()).
-				SetRole(testutil.AWSRole()).
-				SetRegion(testutil.AWSRegion())
-
-			c, err := NewBasicECSClient(*awsOpts)
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
-			podCreator, err := NewBasicECSPodCreator(c, nil)
+			pc, err := NewBasicECSPodCreator(c, nil)
 			require.NoError(t, err)
 
-			tCase(tctx, t, podCreator)
+			tCase(tctx, t, pc)
 		})
 	}
+
+	smc, err := secret.NewBasicSecretsManagerClient(*awsOpts)
+	require.NoError(t, err)
+	defer func() {
+		testutil.CleanupSecrets(ctx, t, smc)
+
+		assert.NoError(t, smc.Close(ctx))
+	}()
 
 	for tName, tCase := range testcase.ECSPodCreatorWithVaultTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
 			defer tcancel()
 
-			hc := utility.GetHTTPClient()
-			defer utility.PutHTTPClient(hc)
-
-			awsOpts := awsutil.NewClientOptions().
-				SetHTTPClient(hc).
-				SetCredentials(credentials.NewEnvCredentials()).
-				SetRole(testutil.AWSRole()).
-				SetRegion(testutil.AWSRegion())
-
-			c, err := NewBasicECSClient(*awsOpts)
-			require.NoError(t, err)
-			defer c.Close(tctx)
-
-			smc, err := secret.NewBasicSecretsManagerClient(awsutil.ClientOptions{
-				Creds:  credentials.NewEnvCredentials(),
-				Region: aws.String(testutil.AWSRegion()),
-				Role:   aws.String(testutil.AWSRole()),
-				RetryOpts: &utility.RetryOptions{
-					MaxAttempts: 5,
-				},
-				HTTPClient: hc,
-			})
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, smc.Close(tctx))
-			}()
-
 			m := secret.NewBasicSecretsManager(smc)
 			require.NotNil(t, m)
 
-			podCreator, err := NewBasicECSPodCreator(c, m)
+			pc, err := NewBasicECSPodCreator(c, m)
 			require.NoError(t, err)
 
-			tCase(tctx, t, podCreator)
+			tCase(tctx, t, pc)
 		})
 	}
 }

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -99,7 +99,6 @@ func TestECSPodCreator(t *testing.T) {
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupTaskDefinitions(ctx, t, c)
-
 		testutil.CleanupTasks(ctx, t, c)
 
 		assert.NoError(t, c.Close(ctx))

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/awsutil"
@@ -96,15 +95,7 @@ func TestECSPod(t *testing.T) {
 		assert.NoError(t, c.Close(ctx))
 	}()
 
-	smc, err := secret.NewBasicSecretsManagerClient(awsutil.ClientOptions{
-		Creds:  credentials.NewEnvCredentials(),
-		Region: aws.String(testutil.AWSRegion()),
-		Role:   aws.String(testutil.AWSRole()),
-		RetryOpts: &utility.RetryOptions{
-			MaxAttempts: 5,
-		},
-		HTTPClient: hc,
-	})
+	smc, err := secret.NewBasicSecretsManagerClient(*awsOpts)
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupSecrets(ctx, t, smc)

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -72,7 +72,6 @@ func TestBasicECSPod(t *testing.T) {
 	}
 }
 
-// TODO (EVG-14979): clean up resources in ECS tests more thoroughly
 func TestECSPod(t *testing.T) {
 	testutil.CheckAWSEnvVarsForECSAndSecretsManager(t)
 

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -91,7 +91,6 @@ func TestECSPod(t *testing.T) {
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupTaskDefinitions(ctx, t, c)
-
 		testutil.CleanupTasks(ctx, t, c)
 
 		assert.NoError(t, c.Close(ctx))

--- a/internal/testcase/ecs_client.go
+++ b/internal/testcase/ecs_client.go
@@ -41,7 +41,7 @@ func ECSClientTaskDefinitionTests() map[string]ECSClientTestCase {
 				},
 				Cpu:    aws.String("128"),
 				Memory: aws.String("4"),
-				Family: aws.String(testutil.NewTaskDefinitionFamily(t.Name())),
+				Family: aws.String(testutil.NewTaskDefinitionFamily(t)),
 			})
 			require.NoError(t, err)
 			require.NotNil(t, registerOut)
@@ -68,7 +68,7 @@ func ECSClientRegisteredTaskDefinitionTests(registerIn ecs.RegisterTaskDefinitio
 		"RunTaskFailsWithValidButNonexistentInput": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			out, err := c.RunTask(ctx, &ecs.RunTaskInput{
 				Cluster:        aws.String(testutil.ECSClusterName()),
-				TaskDefinition: aws.String(testutil.NewTaskDefinitionFamily(t.Name()) + ":1"),
+				TaskDefinition: aws.String(testutil.NewTaskDefinitionFamily(t) + ":1"),
 			})
 			assert.Error(t, err)
 			assert.Zero(t, out)
@@ -184,7 +184,7 @@ func ECSClientRegisteredTaskDefinitionTests(registerIn ecs.RegisterTaskDefinitio
 		},
 		"DescribeTaskDefinitionFailsWithNonexistentTaskDefinition": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			out, err := c.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
-				TaskDefinition: aws.String(testutil.NewTaskDefinitionFamily(t.Name())),
+				TaskDefinition: aws.String(testutil.NewTaskDefinitionFamily(t)),
 			})
 			assert.Error(t, err)
 			assert.Zero(t, out)

--- a/internal/testcase/ecs_client.go
+++ b/internal/testcase/ecs_client.go
@@ -153,8 +153,8 @@ func ECSClientRegisteredTaskDefinitionTests(registerIn ecs.RegisterTaskDefinitio
 				Cluster: aws.String(testutil.ECSClusterName()),
 				Tasks:   []*string{aws.String(utility.RandomString())},
 			})
-			assert.NoError(t, err)
-			assert.NotZero(t, out)
+			require.NoError(t, err)
+			require.NotZero(t, out)
 			assert.NotZero(t, out.Failures)
 			assert.Empty(t, out.Tasks)
 		},

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -34,7 +34,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 		return cocoa.NewEnvironmentVariable().
 			SetName(t.Name()).
 			SetSecretOptions(*cocoa.NewSecretOptions().
-				SetName(testutil.NewSecretName(t.Name())).
+				SetName(testutil.NewSecretName(t)).
 				SetNewValue(utility.RandomString()).
 				SetOwned(true))
 	}
@@ -49,7 +49,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 
 	makePodCreationOpts := func(t *testing.T) *cocoa.ECSPodCreationOptions {
 		return cocoa.NewECSPodCreationOptions().
-			SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+			SetName(testutil.NewTaskDefinitionFamily(t)).
 			SetMemoryMB(128).
 			SetCPU(128).
 			SetTaskRole(testutil.ECSTaskRole()).
@@ -120,7 +120,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 		},
 		"StopSucceedsWithRepoCreds": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
 			creds := cocoa.NewRepositoryCredentials().
-				SetName(testutil.NewSecretName(t.Name())).
+				SetName(testutil.NewSecretName(t)).
 				SetNewCredentials(*cocoa.NewStoredRepositoryCredentials().SetUsername("user").SetPassword("such_secure_password_wow")).
 				SetOwned(true)
 			opts := makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t).SetRepositoryCredentials(*creds))
@@ -153,7 +153,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			secret := cocoa.NewEnvironmentVariable().
 				SetName("secret").
 				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName(t.Name())).
+					SetName(testutil.NewSecretName(t)).
 					SetNewValue(utility.RandomString()))
 			ownedSecret := makeSecretEnvVar(t)
 
@@ -232,7 +232,7 @@ func ECSPodTests() map[string]ECSPodTestCase {
 		},
 		"DeleteSucceedsWithRepoCreds": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
 			creds := cocoa.NewRepositoryCredentials().
-				SetName(testutil.NewSecretName(t.Name())).
+				SetName(testutil.NewSecretName(t)).
 				SetNewCredentials(*cocoa.NewStoredRepositoryCredentials().SetUsername("user").SetPassword("such_secure_password_wow")).
 				SetOwned(true)
 			opts := makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t).SetRepositoryCredentials(*creds))
@@ -263,11 +263,11 @@ func ECSPodTests() map[string]ECSPodTestCase {
 		"DeleteSucceedsWithSecrets": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
 			secret := cocoa.NewEnvironmentVariable().SetName(t.Name()).
 				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName(t.Name())).
+					SetName(testutil.NewSecretName(t)).
 					SetNewValue("value1"))
 			ownedSecret := cocoa.NewEnvironmentVariable().SetName(t.Name() + "-owned").
 				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName(t.Name())).
+					SetName(testutil.NewSecretName(t)).
 					SetNewValue("value2").
 					SetOwned(true))
 

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -52,8 +52,8 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			SetName(testutil.NewTaskDefinitionFamily(t.Name())).
 			SetMemoryMB(128).
 			SetCPU(128).
-			SetTaskRole(testutil.TaskRole()).
-			SetExecutionRole(testutil.ExecutionRole()).
+			SetTaskRole(testutil.ECSTaskRole()).
+			SetExecutionRole(testutil.ECSExecutionRole()).
 			SetExecutionOptions(*cocoa.NewECSPodExecutionOptions().
 				SetCluster(testutil.ECSClusterName()))
 	}

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -30,7 +30,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
@@ -60,7 +60,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			envVar := cocoa.NewEnvironmentVariable().
 				SetName("envVar").
 				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName("name")).
+					SetName(testutil.NewSecretName(t)).
 					SetNewValue("value"))
 			containerDef := cocoa.NewECSContainerDefinition().
 				SetImage("image").
@@ -70,7 +70,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
@@ -88,7 +88,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetUsername("username").
 				SetPassword("password")
 			creds := cocoa.NewRepositoryCredentials().
-				SetName(testutil.NewSecretName(t.Name())).
+				SetName(testutil.NewSecretName(t)).
 				SetNewCredentials(*storedCreds)
 			containerDef := cocoa.NewECSContainerDefinition().
 				SetImage("image").
@@ -98,7 +98,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
@@ -120,7 +120,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 		"CreatePodFailsWithSecretsButNoExecutionRole": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
 			envVar := cocoa.NewEnvironmentVariable().SetName("envVar").
 				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName("name")).
+					SetName(testutil.NewSecretName(t)).
 					SetNewValue("value"))
 			containerDef := cocoa.NewECSContainerDefinition().SetImage("image").
 				AddEnvironmentVariables(*envVar).
@@ -137,7 +137,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetCPU(128).
 				SetTaskRole(testutil.ECSTaskRole()).
 				SetExecutionOptions(*execOpts).
-				SetName(testutil.NewTaskDefinitionFamily(t.Name()))
+				SetName(testutil.NewTaskDefinitionFamily(t))
 			assert.Error(t, opts.Validate())
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -148,7 +148,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 			envVar := cocoa.NewEnvironmentVariable().
 				SetName("envVar").
 				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName("name")).
+					SetName(testutil.NewSecretName(t)).
 					SetNewValue("value").
 					SetOwned(true))
 
@@ -163,7 +163,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
@@ -187,7 +187,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetUsername("username").
 				SetPassword("password")
 			creds := cocoa.NewRepositoryCredentials().
-				SetName(testutil.NewSecretName(t.Name())).
+				SetName(testutil.NewSecretName(t)).
 				SetNewCredentials(*storedCreds).
 				SetOwned(true)
 
@@ -202,7 +202,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				SetCluster(testutil.ECSClusterName())
 
 			opts := cocoa.NewECSPodCreationOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -74,8 +74,8 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
-				SetExecutionRole(testutil.ExecutionRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
+				SetExecutionRole(testutil.ECSExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -102,8 +102,8 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
-				SetExecutionRole(testutil.ExecutionRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
+				SetExecutionRole(testutil.ECSExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -135,7 +135,7 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
 				SetExecutionOptions(*execOpts).
 				SetName(testutil.NewTaskDefinitionFamily(t.Name()))
 			assert.Error(t, opts.Validate())
@@ -167,8 +167,8 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
-				SetExecutionRole(testutil.ExecutionRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
+				SetExecutionRole(testutil.ECSExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -206,8 +206,8 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.TaskRole()).
-				SetExecutionRole(testutil.ExecutionRole()).
+				SetTaskRole(testutil.ECSTaskRole()).
+				SetExecutionRole(testutil.ECSExecutionRole()).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 

--- a/internal/testcase/secrets_manager_client.go
+++ b/internal/testcase/secrets_manager_client.go
@@ -23,7 +23,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 	return map[string]SecretsManagerClientTestCase{
 		"CreateSecretSucceeds": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			out, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-				Name:         aws.String(testutil.NewSecretName(t.Name())),
+				Name:         aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String(utility.RandomString()),
 			})
 			require.NoError(t, err)
@@ -37,7 +37,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 			assert.Zero(t, out)
 		},
 		"GetSecretValueSucceedsWithExistingSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
-			secretName := testutil.NewSecretName(t.Name())
+			secretName := testutil.NewSecretName(t)
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
 				Name:         aws.String(secretName),
 				SecretString: aws.String("foo"),
@@ -64,13 +64,13 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"GetSecretValueFailsWithValidNonexistentSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			out, err := c.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
-				SecretId: aws.String(testutil.NewSecretName(t.Name())),
+				SecretId: aws.String(testutil.NewSecretName(t)),
 			})
 			assert.Error(t, err)
 			assert.Zero(t, out)
 		},
 		"UpdateSecretValueSucceedsWithExistingSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
-			secretName := testutil.NewSecretName(t.Name())
+			secretName := testutil.NewSecretName(t)
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
 				Name:         aws.String(secretName),
 				SecretString: aws.String("bar"),
@@ -104,7 +104,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"UpdateSecretValueFailsWithValidNonexistentSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			out, err := c.UpdateSecretValue(ctx, &secretsmanager.UpdateSecretInput{
-				SecretId:     aws.String(testutil.NewSecretName(t.Name())),
+				SecretId:     aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String("hello"),
 			})
 			assert.Error(t, err)
@@ -112,7 +112,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"DescribeSecretSucceeds": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-				Name:         aws.String(testutil.NewSecretName(t.Name())),
+				Name:         aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String("bar"),
 			})
 			require.NoError(t, err)
@@ -131,7 +131,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"DescribeSecretSucceedsAfterDeletion": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-				Name:         aws.String(testutil.NewSecretName(t.Name())),
+				Name:         aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String("bar"),
 			})
 			require.NoError(t, err)
@@ -157,7 +157,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"DescribeSecretFailsWithValidNonexistentSecret": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			out, err := c.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
-				SecretId: aws.String(testutil.NewSecretName(t.Name())),
+				SecretId: aws.String(testutil.NewSecretName(t)),
 			})
 			assert.Error(t, err)
 			assert.Zero(t, out)
@@ -169,7 +169,7 @@ func SecretsManagerClientTests() map[string]SecretsManagerClientTestCase {
 		},
 		"DeleteSecretSucceeds": func(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
 			createOut, err := c.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-				Name:         aws.String(testutil.NewSecretName(t.Name())),
+				Name:         aws.String(testutil.NewSecretName(t)),
 				SecretString: aws.String("hello"),
 			})
 			require.NoError(t, err)

--- a/internal/testcase/vault.go
+++ b/internal/testcase/vault.go
@@ -17,7 +17,7 @@ type VaultTestCase func(ctx context.Context, t *testing.T, v cocoa.Vault)
 func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Vault, id string)) map[string]VaultTestCase {
 	return map[string]VaultTestCase{
 		"CreateSecretSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue("hello"))
+			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue("hello"))
 			require.NoError(t, err)
 			require.NotZero(t, id)
 
@@ -29,7 +29,7 @@ func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Va
 			assert.Zero(t, id)
 		},
 		"DeleteSecretWithExistingSecretSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue("hello"))
+			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue("hello"))
 			require.NoError(t, err)
 			require.NotZero(t, id)
 
@@ -39,11 +39,11 @@ func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Va
 			assert.Error(t, v.DeleteSecret(ctx, ""))
 		},
 		"DeleteSecretWithValidNonexistentInputNoops": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			assert.NoError(t, v.DeleteSecret(ctx, testutil.NewSecretName(t.Name())))
+			assert.NoError(t, v.DeleteSecret(ctx, testutil.NewSecretName(t)))
 		},
 		"GetValueWithExistingSecretSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
 			val := "eggs"
-			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue(val))
+			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue(val))
 			require.NoError(t, err)
 			require.NotZero(t, id)
 
@@ -60,12 +60,12 @@ func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Va
 			assert.Zero(t, id)
 		},
 		"GetValueWithValidNonexistentInputFails": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			id, err := v.GetValue(ctx, testutil.NewSecretName(t.Name()))
+			id, err := v.GetValue(ctx, testutil.NewSecretName(t))
 			assert.Error(t, err)
 			assert.Zero(t, id)
 		},
 		"UpdateValueSucceeds": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue("eggs"))
+			id, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue("eggs"))
 			require.NoError(t, err)
 			require.NotZero(t, id)
 
@@ -83,7 +83,7 @@ func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Va
 			assert.Error(t, v.UpdateValue(ctx, *cocoa.NewNamedSecret()))
 		},
 		"UpdateValueWithValidNonexistentInputFails": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
-			assert.Error(t, v.UpdateValue(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t.Name())).SetValue("leaf")))
+			assert.Error(t, v.UpdateValue(ctx, *cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue("leaf")))
 		},
 	}
 }

--- a/internal/testutil/aws.go
+++ b/internal/testutil/aws.go
@@ -1,0 +1,15 @@
+package testutil
+
+import (
+	"os"
+)
+
+// AWSRegion returns the AWS region from the environment variable.
+func AWSRegion() string {
+	return os.Getenv("AWS_REGION")
+}
+
+// AWSRole returns the AWS IAM role from the environment variable.
+func AWSRole() string {
+	return os.Getenv("AWS_ROLE")
+}

--- a/internal/testutil/aws.go
+++ b/internal/testutil/aws.go
@@ -2,7 +2,19 @@ package testutil
 
 import (
 	"os"
+
+	"github.com/evergreen-ci/utility"
 )
+
+// runtimeNamespace is a random string generated during testing runtime that
+// acts as a namespace for this particular runtime's tests. It is used to
+// namespace AWS resources (e.g. secrets, task definitions). This avoids an
+// issue where the tests can be running concurrently on different machines and
+// may interfere with each other due to the way AWS resources are cleaned up at
+// the end of tests. For example, if one machine is running the ECS tests and at
+// the same time, another machine is cleaning up the resources for the same ECS
+// tests, they should not affect one another.
+var runtimeNamespace = utility.RandomString()
 
 // AWSRegion returns the AWS region from the environment variable.
 func AWSRegion() string {

--- a/internal/testutil/ecs.go
+++ b/internal/testutil/ecs.go
@@ -51,7 +51,7 @@ func ECSExecutionRole() string {
 // CleanupTaskDefinitions cleans up all existing task definitions used in a
 // test.
 func CleanupTaskDefinitions(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
-	for token := cleanupTaskDefinitionsWithToken(ctx, t, c, nil); token != nil; cleanupTaskDefinitionsWithToken(ctx, t, c, token) {
+	for token := cleanupTaskDefinitionsWithToken(ctx, t, c, nil); token != nil; token = cleanupTaskDefinitionsWithToken(ctx, t, c, token) {
 	}
 }
 

--- a/internal/testutil/ecs.go
+++ b/internal/testutil/ecs.go
@@ -55,8 +55,8 @@ func CleanupTaskDefinitions(ctx context.Context, t *testing.T, c cocoa.ECSClient
 	}
 }
 
-// cleanupTaskDefinitionsWithToken cleans up all existing task definitions used
-// in Cocoa tests based on the results from the pagination token.
+// cleanupTaskDefinitionsWithToken cleans up active task definitions used in
+// Cocoa tests based on the results from the pagination token.
 func cleanupTaskDefinitionsWithToken(ctx context.Context, t *testing.T, c cocoa.ECSClient, token *string) (nextToken *string) {
 	out, err := c.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
 		Status:    aws.String(ecs.TaskDefinitionStatusActive),
@@ -103,7 +103,7 @@ func CleanupTasks(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 	}
 }
 
-// cleanupTasksWithToken cleans up all existing tasks used in Cocoa tests based
+// cleanupTasksWithToken cleans up running tasks used in the Cocoa cluster based
 // on the results from the pagination token.
 func cleanupTasksWithToken(ctx context.Context, t *testing.T, c cocoa.ECSClient, token *string) (nextToken *string) {
 	out, err := c.ListTasks(ctx, &ecs.ListTasksInput{
@@ -122,11 +122,6 @@ func cleanupTasksWithToken(ctx context.Context, t *testing.T, c cocoa.ECSClient,
 		}
 
 		taskARN := *arn
-
-		name := taskDefinitionFamily(t)
-		if !strings.Contains(taskARN, name) {
-			continue
-		}
 
 		_, err := c.StopTask(ctx, &ecs.StopTaskInput{
 			Cluster: aws.String(ECSClusterName()),

--- a/internal/testutil/secret.go
+++ b/internal/testutil/secret.go
@@ -39,8 +39,8 @@ func CleanupSecrets(ctx context.Context, t *testing.T, c cocoa.SecretsManagerCli
 	}
 }
 
-// cleanupSecretsWithToken cleans up all existing secrets used in Cocoa tests
-// based on the results from the pagination token.
+// cleanupSecretsWithToken cleans up existing secrets used in Cocoa tests based
+// on the results from the pagination token.
 func cleanupSecretsWithToken(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient, token *string) (nextToken *string) {
 	out, err := c.ListSecrets(ctx, &secretsmanager.ListSecretsInput{
 		NextToken: token,

--- a/internal/testutil/secret.go
+++ b/internal/testutil/secret.go
@@ -1,11 +1,19 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
+	"strings"
+	"testing"
 
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/stretchr/testify/assert"
 )
 
 const projectName = "cocoa"
@@ -13,11 +21,62 @@ const projectName = "cocoa"
 // NewSecretName creates a new test secret name with a common prefix, the given
 // name, and a random string.
 func NewSecretName(name string) string {
-	return fmt.Sprint(path.Join(SecretPrefix(), projectName, name, utility.RandomString()))
+	return fmt.Sprint(path.Join(strings.TrimSuffix(SecretPrefix(), "/"), projectName, name, utility.RandomString()))
 }
 
 // SecretPrefix returns the prefix name for secrets from the environment
 // variable.
 func SecretPrefix() string {
 	return os.Getenv("AWS_SECRET_PREFIX")
+}
+
+// CleanupSecrets cleans up all existing secrets used in Cocoa tests.
+func CleanupSecrets(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) {
+	for token := cleanupSecretsWithToken(ctx, t, c, nil); token != nil; token = cleanupSecretsWithToken(ctx, t, c, token) {
+	}
+}
+
+// cleanupSecretsWithToken cleans up all existing secrets used in Cocoa tests
+// based on the results from the pagination token.
+func cleanupSecretsWithToken(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient, token *string) (nextToken *string) {
+	out, err := c.ListSecrets(ctx, &secretsmanager.ListSecretsInput{
+		NextToken: token,
+	})
+	if !assert.NoError(t, err) {
+		return nil
+	}
+	if !assert.NotZero(t, out) {
+		return nil
+	}
+
+	for _, secret := range out.SecretList {
+		if secret == nil {
+			continue
+		}
+		if secret.ARN == nil {
+			continue
+		}
+
+		arn := *secret.ARN
+
+		// Ignore secrets that were not generated within Cocoa.
+		name := path.Join(strings.TrimSuffix(SecretPrefix(), "/"), "cocoa")
+		if !strings.Contains(arn, name) {
+			continue
+		}
+
+		_, err := c.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
+			ForceDeleteWithoutRecovery: utility.TruePtr(),
+			SecretId:                   &arn,
+		})
+		if assert.NoError(t, err) {
+			grip.Info(message.Fields{
+				"message": "cleaned up leftover secret",
+				"arn":     arn,
+				"test":    t.Name(),
+			})
+		}
+	}
+
+	return out.NextToken
 }

--- a/mock/ecs_client_test.go
+++ b/mock/ecs_client_test.go
@@ -2,8 +2,6 @@ package mock
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -12,9 +10,6 @@ import (
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
-	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +46,7 @@ func TestECSClient(t *testing.T) {
 		},
 		Cpu:    aws.String("128"),
 		Memory: aws.String("4"),
-		Family: aws.String(testutil.NewTaskDefinitionFamily(t.Name())),
+		Family: aws.String(testutil.NewTaskDefinitionFamily(t)),
 	}
 
 	registerOut, err := c.RegisterTaskDefinition(ctx, registerIn)
@@ -60,18 +55,10 @@ func TestECSClient(t *testing.T) {
 	require.NotZero(t, registerOut.TaskDefinition)
 
 	defer func() {
-		taskDefs := cleanupTaskDefinitions(ctx, t, c)
-		grip.InfoWhen(len(taskDefs) > 0, message.Fields{
-			"message":          "cleaned up leftover task definitions",
-			"task_definitions": taskDefs,
-			"test":             t.Name(),
-		})
-		tasks := cleanupTasks(ctx, t, c, taskDefs)
-		grip.InfoWhen(len(tasks) > 0, message.Fields{
-			"message": "cleaned up leftover running tasks",
-			"tasks":   tasks,
-			"test":    t.Name(),
-		})
+		testutil.CleanupTaskDefinitions(ctx, t, c)
+
+		testutil.CleanupTasks(ctx, t, c)
+
 		require.NoError(t, c.Close(ctx))
 	}()
 
@@ -83,130 +70,4 @@ func TestECSClient(t *testing.T) {
 			tCase(tctx, t, c)
 		})
 	}
-}
-
-// cleanupTaskDefinitions cleans up all existing task definitions for testing
-// teardown.
-func cleanupTaskDefinitions(ctx context.Context, t *testing.T, c cocoa.ECSClient) []string {
-	out, err := c.ListTaskDefinitions(ctx, &ecs.ListTaskDefinitionsInput{
-		Status: aws.String(ecs.TaskDefinitionStatusActive),
-	})
-	require.NoError(t, err)
-	require.NotZero(t, out)
-
-	var taskDefs []string
-
-	for _, arn := range out.TaskDefinitionArns {
-		if arn == nil {
-			continue
-		}
-		taskDefArn := *arn
-		// Ignore task definitions that were not generated with testutil.NewTaskDefinitionFamily.
-		name := strings.Join([]string{testutil.TaskDefinitionPrefix(), "cocoa", t.Name()}, "-")
-		if !strings.Contains(taskDefArn, name) {
-			continue
-		}
-		taskDefs = append(taskDefs, *arn)
-		_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
-			TaskDefinition: arn,
-		})
-		assert.NoError(t, err)
-	}
-
-	return taskDefs
-}
-
-// cleanupTasks cleans up all tasks for testing teardown. It only cleans up
-// tasks if they are running and are created from one of the given task
-// definitions.
-func cleanupTasks(ctx context.Context, t *testing.T, c cocoa.ECSClient, taskDefs []string) []string {
-	out, err := c.ListTasks(ctx, &ecs.ListTasksInput{
-		Cluster: aws.String(testutil.ECSClusterName()),
-	})
-	require.NoError(t, err)
-	require.NotZero(t, out)
-
-	if len(out.TaskArns) == 0 {
-		return nil
-	}
-
-	describeOut, err := c.DescribeTasks(ctx, &ecs.DescribeTasksInput{
-		Cluster: aws.String(testutil.ECSClusterName()),
-		Tasks:   out.TaskArns,
-	})
-	require.NoError(t, err)
-
-	var tasks []string
-	for _, task := range describeOut.Tasks {
-		if task == nil {
-			continue
-		}
-
-		if task.TaskDefinitionArn == nil {
-			grip.Notice(message.Fields{
-				"message": "cannot check task for test teardown because it does not have a task definition ARN",
-				"context": "cocoa test teardown",
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		}
-		// Ignore tasks started by task definitions outside of the cocoa testing
-		// environment.
-		if taskDef := *task.TaskDefinitionArn; !utility.StringSliceContains(taskDefs, taskDef) {
-			continue
-		}
-
-		if task.LastStatus == nil {
-			grip.Notice(message.Fields{
-				"message": "cannot check task for test teardown because it does not have a status",
-				"context": "cocoa test teardown",
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		}
-
-		status := *task.LastStatus
-		switch status {
-		case "PROVISIONING", "PENDING", "ACTIVATING":
-			grip.Notice(message.Fields{
-				"message": "cannot stop the task because it is in an unstoppable state",
-				"context": "cocoa test teardown",
-				"status":  status,
-				"task":    *task,
-				"test":    t.Name(),
-			})
-			continue
-		case "RUNNING":
-			if task.DesiredStatus != nil && *task.DesiredStatus == "STOPPED" {
-				continue
-			}
-			if task.TaskArn == nil {
-				grip.Notice(message.Fields{
-					"message": "cannot stop the task because it is missing a task ARN",
-					"context": "cocoa test teardown",
-					"status":  status,
-					"task":    *task,
-					"test":    t.Name(),
-				})
-				continue
-			}
-			_, err := c.StopTask(ctx, &ecs.StopTaskInput{
-				Cluster: aws.String(testutil.ECSClusterName()),
-				Reason:  aws.String(fmt.Sprintf("cocoa test teardown for test '%s'", t.Name())),
-				Task:    task.TaskArn,
-			})
-			if assert.NoError(t, err) {
-				tasks = append(tasks, *task.TaskArn)
-			}
-		case "DEACTIVATING", "STOPPING", "DEPROVISIONING", "STOPPED":
-			continue
-		default:
-			assert.Fail(t, "unrecognized task status '%s'", status)
-		}
-
-	}
-
-	return tasks
 }

--- a/mock/ecs_client_test.go
+++ b/mock/ecs_client_test.go
@@ -22,6 +22,8 @@ func TestECSClient(t *testing.T) {
 
 	c := &ECSClient{}
 	defer func() {
+		cleanupECSAndSecretsManagerCache()
+
 		assert.NoError(t, c.Close(ctx))
 	}()
 
@@ -54,18 +56,12 @@ func TestECSClient(t *testing.T) {
 	require.NotZero(t, registerOut)
 	require.NotZero(t, registerOut.TaskDefinition)
 
-	defer func() {
-		testutil.CleanupTaskDefinitions(ctx, t, c)
-
-		testutil.CleanupTasks(ctx, t, c)
-
-		require.NoError(t, c.Close(ctx))
-	}()
-
 	for tName, tCase := range testcase.ECSClientRegisteredTaskDefinitionTests(*registerIn, *registerOut) {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, time.Second)
 			defer tcancel()
+
+			cleanupECSAndSecretsManagerCache()
 
 			tCase(tctx, t, c)
 		})

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -101,8 +101,8 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			SetName(testutil.NewTaskDefinitionFamily(t.Name())).
 			SetMemoryMB(128).
 			SetCPU(128).
-			SetTaskRole(testutil.TaskRole()).
-			SetExecutionRole(testutil.ExecutionRole()).
+			SetTaskRole(testutil.ECSTaskRole()).
+			SetExecutionRole(testutil.ECSExecutionRole()).
 			SetExecutionOptions(*cocoa.NewECSPodExecutionOptions().
 				SetCluster(testutil.ECSClusterName()))
 	}

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -98,7 +98,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 	makePodCreationOpts := func(t *testing.T) *cocoa.ECSPodCreationOptions {
 		return cocoa.NewECSPodCreationOptions().
-			SetName(testutil.NewTaskDefinitionFamily(t.Name())).
+			SetName(testutil.NewTaskDefinitionFamily(t)).
 			SetMemoryMB(128).
 			SetCPU(128).
 			SetTaskRole(testutil.ECSTaskRole()).

--- a/mock/secrets_manager_client.go
+++ b/mock/secrets_manager_client.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,6 +49,11 @@ type SecretsManagerClient struct {
 
 	DescribeSecretInput  *secretsmanager.DescribeSecretInput
 	DescribeSecretOutput *secretsmanager.DescribeSecretOutput
+	DescribeSecretError  error
+
+	ListSecretsInput  *secretsmanager.ListSecretsInput
+	ListSecretsOutput *secretsmanager.ListSecretsOutput
+	ListSecretsError  error
 
 	UpdateSecretInput  *secretsmanager.UpdateSecretInput
 	UpdateSecretOutput *secretsmanager.UpdateSecretOutput
@@ -85,10 +91,11 @@ func (c *SecretsManagerClient) CreateSecret(ctx context.Context, in *secretsmana
 
 	ts := time.Now()
 	GlobalSecretCache[name] = StoredSecret{
+		ARN:         utility.FromStringPtr(in.Name),
+		Value:       utility.FromStringPtr(in.SecretString),
 		BinaryValue: in.SecretBinary,
 		Created:     ts,
 		Accessed:    ts,
-		Value:       utility.FromStringPtr(in.SecretString),
 	}
 
 	return &secretsmanager.CreateSecretOutput{
@@ -139,8 +146,8 @@ func (c *SecretsManagerClient) GetSecretValue(ctx context.Context, in *secretsma
 func (c *SecretsManagerClient) DescribeSecret(ctx context.Context, in *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
 	c.DescribeSecretInput = in
 
-	if c.DescribeSecretOutput != nil {
-		return c.DescribeSecretOutput, nil
+	if c.DescribeSecretOutput != nil || c.DescribeSecretError != nil {
+		return c.DescribeSecretOutput, c.DescribeSecretError
 	}
 
 	if in.SecretId == nil {
@@ -159,6 +166,63 @@ func (c *SecretsManagerClient) DescribeSecret(ctx context.Context, in *secretsma
 		LastAccessedDate: utility.ToTimePtr(s.Accessed),
 		LastChangedDate:  utility.ToTimePtr(s.Updated),
 		DeletedDate:      utility.ToTimePtr(s.Deleted),
+	}, nil
+}
+
+// ListSecrets saves the input options and returns all matching mock secrets'
+// metadata information. The mock output can be customized. By default, it will
+// return any matching cached mock secrets in the global secret cache.
+func (c *SecretsManagerClient) ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error) {
+	c.ListSecretsInput = in
+
+	if c.ListSecretsOutput != nil || c.ListSecretsError != nil {
+		return c.ListSecretsOutput, c.ListSecretsError
+	}
+
+	matched := map[string]StoredSecret{}
+	for _, filter := range in.Filters {
+		if filter == nil {
+			continue
+		}
+		if filter.Key != nil {
+			name := utility.FromStringPtr(filter.Key)
+			s, ok := GlobalSecretCache[name]
+			if !ok {
+				continue
+			}
+			matched[name] = s
+		}
+		for _, v := range filter.Values {
+			if v == nil {
+				continue
+			}
+			val := utility.FromStringPtr(v)
+
+			for name, s := range GlobalSecretCache {
+				if strings.HasPrefix(val, "!") && s.Value != val[1:] {
+					matched[name] = s
+				}
+				if !strings.HasPrefix(val, "!") && s.Value == val {
+					matched[name] = s
+				}
+			}
+		}
+	}
+
+	var converted []*secretsmanager.SecretListEntry
+	for name, s := range matched {
+		converted = append(converted, &secretsmanager.SecretListEntry{
+			ARN:              utility.ToStringPtr(s.ARN),
+			Name:             utility.ToStringPtr(name),
+			CreatedDate:      utility.ToTimePtr(s.Created),
+			LastAccessedDate: utility.ToTimePtr(s.Accessed),
+			LastChangedDate:  utility.ToTimePtr(s.Updated),
+			DeletedDate:      utility.ToTimePtr(s.Deleted),
+		})
+	}
+
+	return &secretsmanager.ListSecretsOutput{
+		SecretList: converted,
 	}, nil
 }
 

--- a/secret/secrets_manager_client.go
+++ b/secret/secrets_manager_client.go
@@ -158,6 +158,7 @@ func (c *BasicSecretsManagerClient) DescribeSecret(ctx context.Context, in *secr
 	return out, nil
 }
 
+// ListSecrets lists the metadata information for secrets matching the filters.
 func (c *BasicSecretsManagerClient) ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")

--- a/secret/secrets_manager_client.go
+++ b/secret/secrets_manager_client.go
@@ -154,6 +154,33 @@ func (c *BasicSecretsManagerClient) DescribeSecret(ctx context.Context, in *secr
 		}, *c.opts.RetryOpts); err != nil {
 		return nil, err
 	}
+
+	return out, nil
+}
+
+func (c *BasicSecretsManagerClient) ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error) {
+	if err := c.setup(); err != nil {
+		return nil, errors.Wrap(err, "setting up client")
+	}
+
+	var out *secretsmanager.ListSecretsOutput
+	var err error
+	msg := awsutil.MakeAPILogMessage("ListSecrets", in)
+	if err := utility.Retry(
+		ctx,
+		func() (bool, error) {
+			out, err = c.sm.ListSecretsWithContext(ctx, in)
+			if awsErr, ok := err.(awserr.Error); ok {
+				grip.Debug(message.WrapError(awsErr, msg))
+				if c.isNonRetryableErrorCode(awsErr.Code()) {
+					return false, err
+				}
+			}
+			return true, err
+		}, *c.opts.RetryOpts); err != nil {
+		return nil, err
+	}
+
 	return out, nil
 }
 

--- a/secret/secrets_manager_client_test.go
+++ b/secret/secrets_manager_client_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/awsutil"
@@ -24,27 +23,25 @@ func TestSecretsManagerClient(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	hc := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(hc)
+
+	c, err := NewBasicSecretsManagerClient(*awsutil.NewClientOptions().
+		SetHTTPClient(hc).
+		SetCredentials(credentials.NewEnvCredentials()).
+		SetRole(testutil.AWSRole()).
+		SetRegion(testutil.AWSRegion()))
+	require.NoError(t, err)
+	defer func() {
+		testutil.CleanupSecrets(ctx, t, c)
+
+		assert.NoError(t, c.Close(ctx))
+	}()
+
 	for tName, tCase := range testcase.SecretsManagerClientTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
 			defer tcancel()
-
-			hc := utility.GetHTTPClient()
-			defer utility.PutHTTPClient(hc)
-
-			c, err := NewBasicSecretsManagerClient(awsutil.ClientOptions{
-				Creds:  credentials.NewEnvCredentials(),
-				Region: aws.String(testutil.AWSRegion()),
-				Role:   aws.String(testutil.AWSRole()),
-				RetryOpts: &utility.RetryOptions{
-					MaxAttempts: 5,
-				},
-				HTTPClient: hc,
-			})
-			require.NoError(t, err)
-			require.NotNil(t, c)
-
-			defer c.Close(tctx)
 
 			tCase(tctx, t, c)
 		})

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -2,16 +2,20 @@ package secret
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/awsutil"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,13 +34,37 @@ func TestSecretsManager(t *testing.T) {
 		}
 	}
 
+	hc := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(hc)
+
+	defer func() {
+		c, err := NewBasicSecretsManagerClient(awsutil.ClientOptions{
+			Creds:  credentials.NewEnvCredentials(),
+			Region: aws.String(testutil.AWSRegion()),
+			Role:   aws.String(testutil.AWSRole()),
+			RetryOpts: &utility.RetryOptions{
+				MaxAttempts: 5,
+			},
+			HTTPClient: hc,
+		})
+		require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, c.Close(ctx))
+		}()
+
+		secrets := cleanupSecrets(ctx, t, c)
+		grip.InfoWhen(len(secrets) > 0, message.Fields{
+			"message": "cleaned up leftover secrets",
+			"secrets": secrets,
+			"test":    t.Name(),
+		})
+
+	}()
+
 	for tName, tCase := range testcase.VaultTests(cleanupSecret) {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
 			defer tcancel()
-
-			hc := utility.GetHTTPClient()
-			defer utility.PutHTTPClient(hc)
 
 			c, err := NewBasicSecretsManagerClient(awsutil.ClientOptions{
 				Creds:  credentials.NewEnvCredentials(),
@@ -56,4 +84,49 @@ func TestSecretsManager(t *testing.T) {
 			tCase(tctx, t, m)
 		})
 	}
+}
+
+func cleanupSecrets(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) []string {
+	var secrets []string
+	var nextToken *string
+
+	secrets, nextToken = cleanupSecretsWithToken(ctx, t, c, nextToken)
+
+	for nextToken != nil {
+		var nextSecrets []string
+		nextSecrets, nextToken = cleanupSecretsWithToken(ctx, t, c, nextToken)
+		secrets = append(secrets, nextSecrets...)
+	}
+
+	return secrets
+}
+
+func cleanupSecretsWithToken(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient, nextToken *string) (secrets []string, followingToken *string) {
+	out, err := c.ListSecrets(ctx, &secretsmanager.ListSecretsInput{
+		NextToken: nextToken,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, out)
+
+	for _, secret := range out.SecretList {
+		if secret == nil {
+			continue
+		}
+		if secret.ARN == nil {
+			continue
+		}
+		name := strings.Join([]string{strings.TrimSuffix(testutil.SecretPrefix(), "/"), "cocoa"}, "/")
+		arn := *secret.ARN
+		if !strings.Contains(arn, name) {
+			continue
+		}
+		_, err := c.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
+			ForceDeleteWithoutRecovery: utility.TruePtr(),
+			SecretId:                   &arn,
+		})
+		assert.NoError(t, err)
+		secrets = append(secrets, arn)
+	}
+
+	return secrets, out.NextToken
 }

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -2,20 +2,15 @@ package secret
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/awsutil"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,28 +32,16 @@ func TestSecretsManager(t *testing.T) {
 	hc := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(hc)
 
+	c, err := NewBasicSecretsManagerClient(*awsutil.NewClientOptions().
+		SetHTTPClient(hc).
+		SetCredentials(credentials.NewEnvCredentials()).
+		SetRole(testutil.AWSRole()).
+		SetRegion(testutil.AWSRegion()))
+	require.NoError(t, err)
 	defer func() {
-		c, err := NewBasicSecretsManagerClient(awsutil.ClientOptions{
-			Creds:  credentials.NewEnvCredentials(),
-			Region: aws.String(testutil.AWSRegion()),
-			Role:   aws.String(testutil.AWSRole()),
-			RetryOpts: &utility.RetryOptions{
-				MaxAttempts: 5,
-			},
-			HTTPClient: hc,
-		})
-		require.NoError(t, err)
-		defer func() {
-			assert.NoError(t, c.Close(ctx))
-		}()
+		testutil.CleanupSecrets(ctx, t, c)
 
-		secrets := cleanupSecrets(ctx, t, c)
-		grip.InfoWhen(len(secrets) > 0, message.Fields{
-			"message": "cleaned up leftover secrets",
-			"secrets": secrets,
-			"test":    t.Name(),
-		})
-
+		assert.NoError(t, c.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.VaultTests(cleanupSecret) {
@@ -66,67 +49,10 @@ func TestSecretsManager(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
 			defer tcancel()
 
-			c, err := NewBasicSecretsManagerClient(awsutil.ClientOptions{
-				Creds:  credentials.NewEnvCredentials(),
-				Region: aws.String(testutil.AWSRegion()),
-				Role:   aws.String(testutil.AWSRole()),
-				RetryOpts: &utility.RetryOptions{
-					MaxAttempts: 5,
-				},
-				HTTPClient: hc,
-			})
-			require.NoError(t, err)
-			require.NotNil(t, c)
-
 			m := NewBasicSecretsManager(c)
 			require.NotNil(t, m)
 
 			tCase(tctx, t, m)
 		})
 	}
-}
-
-func cleanupSecrets(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient) []string {
-	var secrets []string
-	var nextToken *string
-
-	secrets, nextToken = cleanupSecretsWithToken(ctx, t, c, nextToken)
-
-	for nextToken != nil {
-		var nextSecrets []string
-		nextSecrets, nextToken = cleanupSecretsWithToken(ctx, t, c, nextToken)
-		secrets = append(secrets, nextSecrets...)
-	}
-
-	return secrets
-}
-
-func cleanupSecretsWithToken(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient, nextToken *string) (secrets []string, followingToken *string) {
-	out, err := c.ListSecrets(ctx, &secretsmanager.ListSecretsInput{
-		NextToken: nextToken,
-	})
-	require.NoError(t, err)
-	require.NotZero(t, out)
-
-	for _, secret := range out.SecretList {
-		if secret == nil {
-			continue
-		}
-		if secret.ARN == nil {
-			continue
-		}
-		name := strings.Join([]string{strings.TrimSuffix(testutil.SecretPrefix(), "/"), "cocoa"}, "/")
-		arn := *secret.ARN
-		if !strings.Contains(arn, name) {
-			continue
-		}
-		_, err := c.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
-			ForceDeleteWithoutRecovery: utility.TruePtr(),
-			SecretId:                   &arn,
-		})
-		assert.NoError(t, err)
-		secrets = append(secrets, arn)
-	}
-
-	return secrets, out.NextToken
 }

--- a/secrets_manager_client.go
+++ b/secrets_manager_client.go
@@ -16,7 +16,8 @@ type SecretsManagerClient interface {
 	GetSecretValue(ctx context.Context, in *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
 	// DescribeSecret gets metadata information about a secret.
 	DescribeSecret(ctx context.Context, in *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error)
-	// ListSecrets lists all secrets matching a filter.
+	// ListSecrets lists all metadata information for secrets matching the
+	// filters.
 	ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error)
 	// UpdateSecret updates the value of an existing secret.
 	UpdateSecretValue(ctx context.Context, in *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error)

--- a/secrets_manager_client.go
+++ b/secrets_manager_client.go
@@ -16,6 +16,8 @@ type SecretsManagerClient interface {
 	GetSecretValue(ctx context.Context, in *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
 	// DescribeSecret gets metadata information about a secret.
 	DescribeSecret(ctx context.Context, in *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error)
+	// ListSecrets lists all secrets matching a filter.
+	ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error)
 	// UpdateSecret updates the value of an existing secret.
 	UpdateSecretValue(ctx context.Context, in *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error)
 	// DeleteSecret deletes an existing secret.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14979

* During teardown, clean up all task definitions, tasks, and secrets that were created during that test.
    * Cleaning up the resources are tricky because we have to avoid the possibility that the cleanup interferes with another running instance of that test. For example, if cleanup is happening on your local machine for `TestECSClient` and at the same time, a CI machine is running `TestECSClient`, the cleanup mechanism should not affect the CI test at all. I resolved this by adding a random string generated at runtime to distinguish between test runtime instances. The resources will only be cleaned up if the runtime random string appears in the ARN.
    * Cleaning up tasks is also tricky because we have no control over the task's ARN. Both task definitions and secrets include a friendly name as part of the ARN (which we use to identify which ones need to be cleaned up), but the task ARN seems to just be a random string. Therefore, the cleanup helper has to compare against the task definition ARN that was used to run the task to determine if it should clean up a task.
* Implement `ListSecrets` API call to help with cleaning up.
* Rename a couple testutil methods.