### PR TITLE
EVG-15378: add support for pod placement groups

### DIFF
--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -426,6 +426,9 @@ func (pc *BasicECSPodCreator) exportTaskExecutionOptions(opts cocoa.ECSPodExecut
 		SetPlacementStrategy(pc.exportStrategy(opts.PlacementOpts)).
 		SetPlacementConstraints(pc.exportPlacementConstraints(opts.PlacementOpts)).
 		SetNetworkConfiguration(pc.exportAWSVPCOptions(opts.AWSVPCOpts))
+	if opts.PlacementOpts != nil && opts.PlacementOpts.Group != nil {
+		runTask.SetGroup(utility.FromStringPtr(opts.PlacementOpts.Group))
+	}
 	return &runTask
 }
 

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -943,6 +943,11 @@ func TestECSPodPlacementOptions(t *testing.T) {
 		require.NotZero(t, opts)
 		assert.Zero(t, *opts)
 	})
+	t.Run("SetGroup", func(t *testing.T) {
+		group := "group"
+		opts := NewECSPodPlacementOptions().SetGroup(group)
+		assert.Equal(t, group, utility.FromStringPtr(opts.Group))
+	})
 	t.Run("SetStrategy", func(t *testing.T) {
 		strategy := StrategyBinpack
 		opts := NewECSPodPlacementOptions().SetStrategy(strategy)
@@ -1030,6 +1035,14 @@ func TestECSPodPlacementOptions(t *testing.T) {
 			require.NotZero(t, opts.Strategy)
 			assert.Equal(t, StrategySpread, *opts.Strategy)
 			assert.Equal(t, "custom", utility.FromStringPtr(opts.StrategyParameter))
+		})
+		t.Run("SucceedsWithNonemptyGroupName", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetGroup("group")
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("FailsWithEmptyGroupName", func(t *testing.T) {
+			opts := NewECSPodPlacementOptions().SetGroup("")
+			assert.Error(t, opts.Validate())
 		})
 	})
 }

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -126,6 +126,7 @@ type ECSTask struct {
 	TaskDef     ECSTaskDefinition
 	Cluster     *string
 	Containers  []ECSContainer
+	Group       *string
 	ExecEnabled *bool
 	Status      *string
 	GoalStatus  *string
@@ -147,6 +148,7 @@ func newECSTask(in *ecs.RunTaskInput, taskDef ECSTaskDefinition) ECSTask {
 		ARN:         utility.ToStringPtr(id.String()),
 		Cluster:     in.Cluster,
 		ExecEnabled: in.EnableExecuteCommand,
+		Group:       in.Group,
 		Status:      utility.ToStringPtr(ecs.DesiredStatusPending),
 		GoalStatus:  utility.ToStringPtr(ecs.DesiredStatusRunning),
 		Created:     utility.ToTimePtr(time.Now()),
@@ -166,6 +168,7 @@ func (t *ECSTask) export() *ecs.Task {
 		TaskArn:              t.ARN,
 		ClusterArn:           t.Cluster,
 		EnableExecuteCommand: t.ExecEnabled,
+		Group:                t.Group,
 		Tags:                 exportTags(t.Tags),
 		TaskDefinitionArn:    t.TaskDef.ARN,
 		Cpu:                  t.TaskDef.CPU,

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -125,6 +125,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 				SetCPU(256).
 				AddEnvironmentVariables(*envVar)
 			placementOpts := cocoa.NewECSPodPlacementOptions().
+				SetGroup("group").
 				SetStrategy(cocoa.StrategyBinpack).
 				SetStrategyParameter(cocoa.StrategyParamBinpackMemory).
 				AddInstanceFilters("runningTaskCount == 0")
@@ -176,6 +177,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 
 			require.NotZero(t, c.RunTaskInput)
 			assert.Equal(t, utility.FromStringPtr(execOpts.Cluster), utility.FromStringPtr(c.RunTaskInput.Cluster))
+			assert.Equal(t, utility.FromStringPtr(placementOpts.Group), utility.FromStringPtr(c.RunTaskInput.Group))
 			require.Len(t, c.RunTaskInput.PlacementStrategy, 1)
 			assert.EqualValues(t, *placementOpts.Strategy, utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Type))
 			assert.Equal(t, utility.FromStringPtr(placementOpts.StrategyParameter), utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Field))


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15378

Add support for ECS task groups. By default, ECS tasks are assigned to hosts independently of one another. Task groups are a feature that lets the user have more control over how tasks in the task group are assigned to hosts.