### PR TITLE
EVG-15378: support placing pods in the same group on distinct instances

### DIFF
--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -210,7 +210,11 @@ func (pc *BasicECSPodCreator) exportPlacementConstraints(opts *cocoa.ECSPodPlace
 
 	for _, filter := range opts.InstanceFilters {
 		var constraint ecs.PlacementConstraint
-		constraint.SetType("memberOf").SetExpression(filter)
+		if filter == cocoa.ConstraintDistinctInstance {
+			constraint.SetType(filter)
+		} else {
+			constraint.SetType("memberOf").SetExpression(filter)
+		}
 		constraints = append(constraints, &constraint)
 	}
 

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -815,8 +815,12 @@ type ECSPodPlacementOptions struct {
 
 	// InstanceFilter is a set of query expressions that restrict the placement
 	// of the pod to a set of container instances in the cluster that match the
-	// query filter.
-	// Docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html
+	// query filter. As a special case, if ConstraintDistinctInstance is the
+	// specified filter, it will place each pod in the pod's group on a
+	// different instance. Otherwise, all filters are assumed to use the ECS
+	// cluster query language to filter the candidate set of instances for a
+	// pod. Docs:
+	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html
 	InstanceFilters []string
 }
 
@@ -927,6 +931,13 @@ const (
 	// StrategyParamSpreadHost indicates the ECS should spread pods evenly
 	// across all container instances (i.e. hosts).
 	StrategyParamSpreadHost ECSStrategyParameter = "host"
+)
+
+const (
+	// ConstraintDistinctInstance is a container instance filter indicating that
+	// ECS should place all pods in the same group on different container
+	// instances.
+	ConstraintDistinctInstance = "distinctInstance"
 )
 
 // AWSVPCOptions represent options to configure networking when the network mode

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -127,7 +127,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			placementOpts := cocoa.NewECSPodPlacementOptions().
 				SetStrategy(cocoa.StrategyBinpack).
 				SetStrategyParameter(cocoa.StrategyParamBinpackMemory).
-				AddInstanceFilters("runningTaskCount == 0")
+				AddInstanceFilters("runningTaskCount == 0", cocoa.ConstraintDistinctInstance)
 			awsvpcOpts := cocoa.NewAWSVPCOptions().
 				AddSubnets("subnet-12345").
 				AddSecurityGroups("sg-12345")
@@ -179,9 +179,11 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			require.Len(t, c.RunTaskInput.PlacementStrategy, 1)
 			assert.EqualValues(t, *placementOpts.Strategy, utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Type))
 			assert.Equal(t, utility.FromStringPtr(placementOpts.StrategyParameter), utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Field))
-			require.Len(t, c.RunTaskInput.PlacementConstraints, 1)
-			assert.Equal(t, placementOpts.InstanceFilters[0], utility.FromStringPtr(c.RunTaskInput.PlacementConstraints[0].Expression))
+			require.Len(t, c.RunTaskInput.PlacementConstraints, 2)
 			assert.Equal(t, "memberOf", utility.FromStringPtr(c.RunTaskInput.PlacementConstraints[0].Type))
+			assert.Equal(t, placementOpts.InstanceFilters[0], utility.FromStringPtr(c.RunTaskInput.PlacementConstraints[0].Expression))
+			assert.Equal(t, cocoa.ConstraintDistinctInstance, utility.FromStringPtr(c.RunTaskInput.PlacementConstraints[1].Type))
+			assert.Zero(t, c.RunTaskInput.PlacementConstraints[1].Expression)
 			require.NotZero(t, c.RunTaskInput.NetworkConfiguration)
 			require.NotZero(t, c.RunTaskInput.NetworkConfiguration.AwsvpcConfiguration)
 			assert.ElementsMatch(t, execOpts.AWSVPCOpts.Subnets, utility.FromStringPtrSlice(c.RunTaskInput.NetworkConfiguration.AwsvpcConfiguration.Subnets))


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15378

This is a follow-on feature to #46. If ECS tasks are in the same ECS task group, they can be given a special placement constraint that ensures that they will be assigned to different instances. This can be used to enforce that ECS tasks in the same task group each get their own instance to run in.