### PR TITLE
EVG-15161: add method to get latest pod status

### DIFF
--- a/awsutil/client_options_test.go
+++ b/awsutil/client_options_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// defaultTestTimeout is the default test timeout for AWS utility tests.
+const defaultTestTimeout = time.Second
+
 func TestClientOptions(t *testing.T) {
 	t.Run("SetCredentials", func(t *testing.T) {
 		creds := credentials.NewEnvCredentials()
@@ -187,7 +190,7 @@ func TestClientOptionsGetCredentials(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, creds)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
 	resolved, err := creds.GetWithContext(ctx)

--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const defaultTestTimeout = time.Minute
+
 func TestECSClient(t *testing.T) {
 	assert.Implements(t, (*cocoa.ECSClient)(nil), &BasicECSClient{})
 
@@ -49,7 +51,7 @@ func TestECSClient(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSClientTaskDefinitionTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			defer c.Close(tctx)
@@ -84,7 +86,7 @@ func TestECSClient(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSClientRegisteredTaskDefinitionTests(*registerIn, *registerOut) {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			tCase(tctx, t, c)

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -92,7 +92,7 @@ func (pc *BasicECSPodCreator) CreatePod(ctx context.Context, opts ...cocoa.ECSPo
 	podOpts := NewBasicECSPodOptions().
 		SetClient(pc.client).
 		SetVault(pc.vault).
-		SetStatusInfo(pc.translatePodStatusInfo(runOut.Tasks[0])).
+		SetStatusInfo(translatePodStatusInfo(runOut.Tasks[0])).
 		SetResources(*resources)
 
 	p, err := NewBasicECSPod(podOpts)
@@ -313,13 +313,17 @@ func (pc *BasicECSPodCreator) translateContainerSecrets(defs []cocoa.ECSContaine
 	return translated
 }
 
-func (pc *BasicECSPodCreator) translatePodStatusInfo(task *ecs.Task) cocoa.ECSPodStatusInfo {
+// translatePodStatusInfo translates an ECS task to its equivalent cocoa
+// status information.
+func translatePodStatusInfo(task *ecs.Task) cocoa.ECSPodStatusInfo {
 	return *cocoa.NewECSPodStatusInfo().
-		SetStatus(pc.translateECSStatus(task.LastStatus)).
-		SetContainers(pc.translateContainerStatusInfo(task.Containers))
+		SetStatus(translateECSStatus(task.LastStatus)).
+		SetContainers(translateContainerStatusInfo(task.Containers))
 }
 
-func (pc *BasicECSPodCreator) translateContainerStatusInfo(containers []*ecs.Container) []cocoa.ECSContainerStatusInfo {
+// translateContainerStatusInfo translates an ECS container to its equivalent
+// cocoa container status information.
+func translateContainerStatusInfo(containers []*ecs.Container) []cocoa.ECSContainerStatusInfo {
 	var statuses []cocoa.ECSContainerStatusInfo
 
 	for _, container := range containers {
@@ -329,7 +333,7 @@ func (pc *BasicECSPodCreator) translateContainerStatusInfo(containers []*ecs.Con
 		status := cocoa.NewECSContainerStatusInfo().
 			SetContainerID(utility.FromStringPtr(container.ContainerArn)).
 			SetName(utility.FromStringPtr(container.Name)).
-			SetStatus(pc.translateECSStatus(container.LastStatus))
+			SetStatus(translateECSStatus(container.LastStatus))
 		statuses = append(statuses, *status)
 	}
 
@@ -338,7 +342,7 @@ func (pc *BasicECSPodCreator) translateContainerStatusInfo(containers []*ecs.Con
 
 // translateECSStatus translate the ECS status into its equivalent cocoa
 // status.
-func (pc *BasicECSPodCreator) translateECSStatus(status *string) cocoa.ECSStatus {
+func translateECSStatus(status *string) cocoa.ECSStatus {
 	if status == nil {
 		return cocoa.StatusUnknown
 	}

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -3,7 +3,6 @@ package ecs
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/cocoa"
@@ -47,7 +46,7 @@ func TestBasicECSPodCreator(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			hc := utility.GetHTTPClient()
@@ -106,7 +105,7 @@ func TestECSPodCreator(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSPodCreatorTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			pc, err := NewBasicECSPodCreator(c, nil)
@@ -126,7 +125,7 @@ func TestECSPodCreator(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSPodCreatorWithVaultTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			m := secret.NewBasicSecretsManager(smc)

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -3,7 +3,6 @@ package ecs
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/cocoa"
@@ -50,7 +49,7 @@ func TestBasicECSPod(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			hc := utility.GetHTTPClient()
@@ -105,7 +104,7 @@ func TestECSPod(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSPodTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			v := secret.NewBasicSecretsManager(smc)

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -15,7 +15,10 @@ type ECSPod interface {
 	Resources() ECSPodResources
 	// StatusInfo returns the current cached status information for the pod.
 	StatusInfo() ECSPodStatusInfo
-	// TODO (EVG-15161): add GetLatestStatus method to get non-cached status.
+	// LatestStatusInfo returns the latest non-cached status information for the
+	// pod. Implementations should query ECS directly for its most up-to-date
+	// status.
+	LatestStatusInfo(ctx context.Context) (*ECSPodStatusInfo, error)
 	// Stop stops the running pod without cleaning up any of its underlying
 	// resources.
 	Stop(ctx context.Context) error

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -44,7 +44,8 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			SetImage("image").
 			SetMemoryMB(128).
 			SetCPU(128).
-			SetName("container")
+			SetName("container").
+			SetCommand([]string{"echo"})
 	}
 
 	makePodCreationOpts := func(t *testing.T) *cocoa.ECSPodCreationOptions {
@@ -102,6 +103,41 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			require.Len(t, task.Tasks, 1)
 			require.Len(t, task.Tasks[0].Containers, 1)
 			assert.Equal(t, utility.FromStringPtr(opts.ContainerDefinitions[0].Image), utility.FromStringPtr(task.Tasks[0].Containers[0].Image))
+		},
+		"LatestStatusInfoSucceeds": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
+			p, err := pc.CreatePod(ctx, *makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t)))
+			require.NoError(t, err)
+
+			defer cleanupPod(ctx, t, p, c, v)
+
+			ps := p.StatusInfo()
+			assert.Equal(t, cocoa.StatusStarting, ps.Status)
+
+			_, err = c.StopTask(ctx, &ecs.StopTaskInput{
+				Cluster: p.Resources().Cluster,
+				Task:    p.Resources().TaskID,
+			})
+			require.NoError(t, err)
+
+			timer := time.NewTimer(0)
+			defer timer.Stop()
+
+		checkStopped:
+			for {
+				select {
+				case <-ctx.Done():
+					require.FailNow(t, "context errored before pod was terminated", "%s", ctx.Err())
+				case <-timer.C:
+					ps, err := p.LatestStatusInfo(ctx)
+					require.NoError(t, err)
+					if ps.Status == cocoa.StatusStopped {
+						require.Len(t, ps.Containers, 1)
+						assert.Equal(t, cocoa.StatusStopped, ps.Containers[0].Status)
+						break checkStopped
+					}
+					timer.Reset(time.Second)
+				}
+			}
 		},
 		"StopSucceeds": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c cocoa.ECSClient, v cocoa.Vault) {
 			opts := makePodCreationOpts(t).AddContainerDefinitions(

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -698,6 +698,9 @@ func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.S
 	task.StopCode = utility.ToStringPtr(ecs.TaskStopCodeUserInitiated)
 	task.StopReason = in.Reason
 	task.Stopped = utility.ToTimePtr(time.Now())
+	for i := range task.Containers {
+		task.Containers[i].Status = utility.ToStringPtr(ecs.DesiredStatusStopped)
+	}
 
 	cluster[utility.FromStringPtr(in.Task)] = task
 

--- a/mock/ecs_client_test.go
+++ b/mock/ecs_client_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// defaultTestTimeout is the default test timeout for mock tests.
+const defaultTestTimeout = time.Second
+
 func TestECSClient(t *testing.T) {
 	assert.Implements(t, (*cocoa.ECSClient)(nil), &ECSClient{})
 
@@ -29,7 +32,7 @@ func TestECSClient(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSClientTaskDefinitionTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()
@@ -58,7 +61,7 @@ func TestECSClient(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSClientRegisteredTaskDefinitionTests(*registerIn, *registerOut) {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()

--- a/mock/ecs_pod.go
+++ b/mock/ecs_pod.go
@@ -13,7 +13,10 @@ type ECSPod struct {
 
 	ResourcesOutput *cocoa.ECSPodResources
 
-	StatusOutput *cocoa.ECSPodStatusInfo
+	StatusInfoOutput *cocoa.ECSPodStatusInfo
+
+	LatestStatusInfoOutput *cocoa.ECSPodStatusInfo
+	LatestStatusInfoError  error
 
 	StopError error
 
@@ -31,11 +34,22 @@ func NewECSPod(p cocoa.ECSPod) *ECSPod {
 // output can be customized. By default, it will return the result of the
 // backing ECS pod.
 func (p *ECSPod) StatusInfo() cocoa.ECSPodStatusInfo {
-	if p.StatusOutput != nil {
-		return *p.StatusOutput
+	if p.StatusInfoOutput != nil {
+		return *p.StatusInfoOutput
 	}
 
 	return p.ECSPod.StatusInfo()
+}
+
+// LatestStatusInfo returns the mock latest status information about the pod.
+// The mock output can be customized. By default, it will return the result of
+// the backing ECS pod.
+func (p *ECSPod) LatestStatusInfo(ctx context.Context) (*cocoa.ECSPodStatusInfo, error) {
+	if p.LatestStatusInfoOutput != nil || p.LatestStatusInfoError != nil {
+		return p.LatestStatusInfoOutput, p.LatestStatusInfoError
+	}
+
+	return p.ECSPod.LatestStatusInfo(ctx)
 }
 
 // Resources returns mock resource information about the pod. The mock output

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/evergreen-ci/cocoa"
@@ -32,7 +31,7 @@ func TestECSPodCreator(t *testing.T) {
 
 	for tName, tCase := range ecsPodCreatorTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()
@@ -60,7 +59,7 @@ func TestECSPodCreator(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSPodCreatorTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()
@@ -81,7 +80,7 @@ func TestECSPodCreator(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSPodCreatorWithVaultTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -3,8 +3,8 @@ package mock
 import (
 	"context"
 	"testing"
-	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	awsECS "github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/evergreen-ci/cocoa"
@@ -26,7 +26,7 @@ func TestECSPod(t *testing.T) {
 
 	for tName, tCase := range ecsPodTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()
@@ -52,7 +52,7 @@ func TestECSPod(t *testing.T) {
 
 	for tName, tCase := range testcase.ECSPodTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()
@@ -93,7 +93,8 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			SetImage("image").
 			SetMemoryMB(128).
 			SetCPU(128).
-			SetName("container")
+			SetName("container").
+			SetCommand([]string{"echo"})
 	}
 
 	makePodCreationOpts := func(t *testing.T) *cocoa.ECSPodCreationOptions {
@@ -229,6 +230,45 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			require.NoError(t, p.Delete(ctx))
 
 			checkPodDeleted(ctx, t, p, c, smc, *opts)
+		},
+		"LatestStatusInfoFailsWhenRequestErrors": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
+			opts := makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t))
+			p, err := pc.CreatePod(ctx, *opts)
+			require.NoError(t, err)
+
+			c.DescribeTasksError = errors.New("fake error")
+
+			ps, err := p.LatestStatusInfo(ctx)
+			assert.Error(t, err)
+			assert.Zero(t, ps)
+		},
+		"LatestStatusInfoFailsWhenRequestReturnsNoInfo": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
+			opts := makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t))
+			p, err := pc.CreatePod(ctx, *opts)
+			require.NoError(t, err)
+
+			c.DescribeTasksOutput = &awsECS.DescribeTasksOutput{}
+
+			ps, err := p.LatestStatusInfo(ctx)
+			assert.Error(t, err)
+			assert.Zero(t, ps)
+		},
+		"LatestStatusInfoFailsWhenRequestReturnsFailures": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
+			opts := makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t))
+			p, err := pc.CreatePod(ctx, *opts)
+			require.NoError(t, err)
+
+			c.DescribeTasksOutput = &awsECS.DescribeTasksOutput{
+				Failures: []*awsECS.Failure{{
+					Arn:    p.Resources().TaskDefinition.ID,
+					Detail: aws.String("fake detail"),
+					Reason: aws.String("fake reason"),
+				}},
+			}
+
+			ps, err := p.LatestStatusInfo(ctx)
+			assert.Error(t, err)
+			assert.Zero(t, ps)
 		},
 	}
 }

--- a/mock/secrets_manager_client_test.go
+++ b/mock/secrets_manager_client_test.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
@@ -18,7 +17,7 @@ func TestSecretsManagerClient(t *testing.T) {
 
 	for tName, tCase := range testcase.SecretsManagerClientTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()

--- a/mock/secrets_manager_vault_test.go
+++ b/mock/secrets_manager_vault_test.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
@@ -26,7 +25,7 @@ func TestVaultWithSecretsManager(t *testing.T) {
 
 	for tName, tCase := range testcase.VaultTests(cleanupSecret) {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			cleanupECSAndSecretsManagerCache()

--- a/secret/secrets_manager_client_test.go
+++ b/secret/secrets_manager_client_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// defaultTestTimeout is the standard timeout for integration tests against
+// Secrets Manager.
+const defaultTestTimeout = time.Minute
+
 func TestSecretsManagerClient(t *testing.T) {
 	assert.Implements(t, (*cocoa.SecretsManagerClient)(nil), &BasicSecretsManagerClient{})
 
@@ -40,7 +44,7 @@ func TestSecretsManagerClient(t *testing.T) {
 
 	for tName, tCase := range testcase.SecretsManagerClientTests() {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			tCase(tctx, t, c)

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -3,7 +3,6 @@ package secret
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/cocoa"
@@ -46,7 +45,7 @@ func TestSecretsManager(t *testing.T) {
 
 	for tName, tCase := range testcase.VaultTests(cleanupSecret) {
 		t.Run(tName, func(t *testing.T) {
-			tctx, tcancel := context.WithTimeout(ctx, 30*time.Second)
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
 			m := NewBasicSecretsManager(c)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15161

* Add `LatestStatusInfo` method for pods to get status info directly from ECS rather than cached status.
* Use test timeout constants.