### PR TITLE
EVG-16872: export method to translate ECS statuses to Cocoa statuses

### DIFF
--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -317,7 +317,7 @@ func (pc *BasicECSPodCreator) translateContainerSecrets(defs []cocoa.ECSContaine
 // status information.
 func translatePodStatusInfo(task *ecs.Task) cocoa.ECSPodStatusInfo {
 	return *cocoa.NewECSPodStatusInfo().
-		SetStatus(translateECSStatus(task.LastStatus)).
+		SetStatus(TranslateECSStatus(task.LastStatus)).
 		SetContainers(translateContainerStatusInfo(task.Containers))
 }
 
@@ -333,29 +333,11 @@ func translateContainerStatusInfo(containers []*ecs.Container) []cocoa.ECSContai
 		status := cocoa.NewECSContainerStatusInfo().
 			SetContainerID(utility.FromStringPtr(container.ContainerArn)).
 			SetName(utility.FromStringPtr(container.Name)).
-			SetStatus(translateECSStatus(container.LastStatus))
+			SetStatus(TranslateECSStatus(container.LastStatus))
 		statuses = append(statuses, *status)
 	}
 
 	return statuses
-}
-
-// translateECSStatus translate the ECS status into its equivalent cocoa
-// status.
-func translateECSStatus(status *string) cocoa.ECSStatus {
-	if status == nil {
-		return cocoa.StatusUnknown
-	}
-	switch *status {
-	case TaskStatusProvisioning, TaskStatusPending, TaskStatusActivating:
-		return cocoa.StatusStarting
-	case TaskStatusRunning:
-		return cocoa.StatusRunning
-	case TaskStatusDeactivating, TaskStatusStopping, TaskStatusDeprovisioning, TaskStatusStopped:
-		return cocoa.StatusStopped
-	default:
-		return cocoa.StatusUnknown
-	}
 }
 
 // exportPodCreationOptions converts options to create a pod into its equivalent

--- a/ecs/status.go
+++ b/ecs/status.go
@@ -1,5 +1,7 @@
 package ecs
 
+import "github.com/evergreen-ci/cocoa"
+
 // Constants represents ECS task states.
 const (
 	// TaskStatusProvisioning indicates that ECS is performing additional work
@@ -29,3 +31,23 @@ const (
 	// TaskStatusStopped indicates that the task is stopped.
 	TaskStatusStopped = "STOPPED"
 )
+
+// TranslateECSStatus translate the ECS status into its equivalent cocoa
+// status.
+func TranslateECSStatus(status *string) cocoa.ECSStatus {
+	if status == nil {
+		return cocoa.StatusUnknown
+	}
+	switch *status {
+	case TaskStatusProvisioning, TaskStatusPending, TaskStatusActivating:
+		return cocoa.StatusStarting
+	case TaskStatusRunning:
+		return cocoa.StatusRunning
+	case TaskStatusDeactivating, TaskStatusStopping, TaskStatusDeprovisioning:
+		return cocoa.StatusStopping
+	case TaskStatusStopped:
+		return cocoa.StatusStopped
+	default:
+		return cocoa.StatusUnknown
+	}
+}

--- a/ecs/status_test.go
+++ b/ecs/status_test.go
@@ -1,0 +1,39 @@
+package ecs
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTranslateECSStatus(t *testing.T) {
+	t.Run("ReturnsUnknownForNilStatus", func(t *testing.T) {
+		assert.Equal(t, cocoa.StatusUnknown, TranslateECSStatus(nil))
+	})
+	t.Run("ReturnsUnknownForUnrecognizedStatus", func(t *testing.T) {
+		assert.Equal(t, cocoa.StatusUnknown, TranslateECSStatus(utility.ToStringPtr("foo")))
+	})
+	t.Run("ReturnsUnknownForEmptyStatus", func(t *testing.T) {
+		assert.Equal(t, cocoa.StatusUnknown, TranslateECSStatus(utility.ToStringPtr("")))
+	})
+	t.Run("ReturnsStartingForStatusesBeforeRunning", func(t *testing.T) {
+		for _, status := range []string{TaskStatusProvisioning, TaskStatusPending, TaskStatusActivating} {
+			assert.Equal(t, cocoa.StatusStarting, TranslateECSStatus(utility.ToStringPtr(status)))
+		}
+	})
+	t.Run("ReturnsStartingForStatusesInBetweenRunningAndStopped", func(t *testing.T) {
+		for _, status := range []string{TaskStatusDeactivating, TaskStatusStopping, TaskStatusDeprovisioning} {
+			assert.Equal(t, cocoa.StatusStopping, TranslateECSStatus(utility.ToStringPtr(status)))
+		}
+	})
+	t.Run("ReturnsStartingForStatusesInBetweenRunningAndStopped", func(t *testing.T) {
+		for _, status := range []string{TaskStatusDeactivating, TaskStatusStopping, TaskStatusDeprovisioning} {
+			assert.Equal(t, cocoa.StatusStopping, TranslateECSStatus(utility.ToStringPtr(status)))
+		}
+	})
+	t.Run("ReturnsStartingForStoppedStatus", func(t *testing.T) {
+		assert.Equal(t, cocoa.StatusStopped, TranslateECSStatus(utility.ToStringPtr(TaskStatusStopped)))
+	})
+}

--- a/ecs_pod.go
+++ b/ecs_pod.go
@@ -296,7 +296,10 @@ const (
 	// StatusRunning indicates that the ECS pod or container is actively
 	// running.
 	StatusRunning ECSStatus = "running"
-	// StatusStopped indicates the that ECS pod or container is stopped. For a
+	// StatusStopping indicates that the ECS pod or container is in the process
+	// of stopping but is not stopped yet.
+	StatusStopping ECSStatus = "stopping"
+	// StatusStopped indicates that the ECS pod or container is stopped. For a
 	// pod, all of its resources are still available even if it's stopped.
 	StatusStopped ECSStatus = "stopped"
 	// StatusDeleted indicates that the ECS pod or container has been cleaned up


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16872

* Export method to translate ECS task lifecycle statuses into Cocoa pod statuses.
* Add new stopping state to represent states between running and fully stopped.