### PR TITLE
EVG-15176: implement method to create pod with existing definition

### DIFF
--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -60,20 +60,8 @@ func TestECSClient(t *testing.T) {
 		})
 	}
 
-	registerIn := &ecs.RegisterTaskDefinitionInput{
-		ContainerDefinitions: []*ecs.ContainerDefinition{
-			{
-				Command: []*string{aws.String("echo"), aws.String("foo")},
-				Image:   aws.String("busybox"),
-				Name:    aws.String("print_foo"),
-			},
-		},
-		Cpu:    aws.String("128"),
-		Memory: aws.String("4"),
-		Family: aws.String(testutil.NewTaskDefinitionFamily(t)),
-	}
-
-	registerOut, err := c.RegisterTaskDefinition(ctx, registerIn)
+	registerIn := validRegisterTaskDefinitionInput(t)
+	registerOut, err := c.RegisterTaskDefinition(ctx, &registerIn)
 	require.NoError(t, err)
 	require.NotZero(t, registerOut)
 	require.NotZero(t, registerOut.TaskDefinition)
@@ -84,7 +72,7 @@ func TestECSClient(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	for tName, tCase := range testcase.ECSClientRegisteredTaskDefinitionTests(*registerIn, *registerOut) {
+	for tName, tCase := range testcase.ECSClientRegisteredTaskDefinitionTests(registerIn, *registerOut) {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()

--- a/ecs/doc.go
+++ b/ecs/doc.go
@@ -1,0 +1,6 @@
+/*
+Package ecs provides implementations of interfaces to interact with and manage
+ECS-backed pods. It also contains some helper functionality for using the ECS
+API directly.
+*/
+package ecs

--- a/ecs/pod.go
+++ b/ecs/pod.go
@@ -149,7 +149,7 @@ func (p *BasicECSPod) LatestStatusInfo(ctx context.Context) (*cocoa.ECSPodStatus
 		return nil, errors.New("expected a task to exist in ECS, but none was returned")
 	}
 
-	p.statusInfo = translatePodStatusInfo(out.Tasks[0])
+	p.statusInfo = translatePodStatusInfo(*out.Tasks[0])
 
 	return &p.statusInfo, nil
 }

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,10 +15,11 @@ import (
 // ECSPodCreatorTestCase represents a test case for a cocoa.ECSPodCreator.
 type ECSPodCreatorTestCase func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator)
 
-// ECSPodCreatorTests returns common test cases that a cocoa.ECSPodCreator should support.
+// ECSPodCreatorTests returns common test cases that a cocoa.ECSPodCreator
+// should support.
 func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 	return map[string]ECSPodCreatorTestCase{
-		"CreatePodSucceedsWithNonSecretSettings": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
+		"CreatePodSucceedsWithoutSecretSettings": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
 			envVar := cocoa.NewEnvironmentVariable().SetName("name").SetValue("value")
 			containerDef := cocoa.NewECSContainerDefinition().
 				SetImage("image").
@@ -49,7 +52,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			ps := p.StatusInfo()
 			assert.Equal(t, cocoa.StatusStarting, ps.Status)
 		},
-		"CreatePodFailsWithInvalidCreationOpts": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
+		"CreatePodFailsWithInvalidCreationOptions": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
 			opts := cocoa.NewECSPodCreationOptions()
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -111,10 +114,18 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 			require.Error(t, err)
 			require.Zero(t, p)
 		},
+		"CreatePodFromExistingDefinitionFailsWithInvalidTaskDefinition": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
+			def := cocoa.NewECSTaskDefinition()
+			require.Error(t, def.Validate())
+			p, err := c.CreatePodFromExistingDefinition(ctx, *def)
+			require.Error(t, err)
+			require.Zero(t, p)
+		},
 	}
 }
 
-// ECSPodCreatorWithVaultTests returns common test cases that a cocoa.ECSPodCreator should support with a Vault.
+// ECSPodCreatorWithVaultTests returns common test cases that a
+// cocoa.ECSPodCreator should support with a Vault.
 func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 	return map[string]ECSPodCreatorTestCase{
 		"CreatePodFailsWithSecretsButNoExecutionRole": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
@@ -220,6 +231,62 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 			}()
 
 			checkPodStatus(t, p, cocoa.StatusStarting)
+		},
+	}
+}
+
+// ECSPodCreatorRegisteredTaskDefinitionTests returns common test cases that a
+// cocoa.ECSPodCreator should support with a pre-created task definition.
+func ECSPodCreatorRegisteredTaskDefinitionTests(def ecs.TaskDefinition) map[string]func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
+	return map[string]func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator){
+		"CreatePodFromExistingDefinitionSucceeds": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
+			taskDef := cocoa.NewECSTaskDefinition().SetID(utility.FromStringPtr(def.TaskDefinitionArn))
+			opts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
+
+			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *opts)
+			require.NoError(t, err)
+			require.NotZero(t, p)
+
+			defer func() {
+				assert.NoError(t, p.Delete(ctx))
+			}()
+
+			require.NotZero(t, p.Resources().TaskDefinition)
+			assert.Equal(t, utility.FromStringPtr(p.Resources().TaskDefinition.ID), utility.FromStringPtr(def.TaskDefinitionArn))
+			assert.False(t, utility.FromBoolPtr(p.Resources().TaskDefinition.Owned), def.TaskDefinitionArn)
+			assert.Equal(t, testutil.ECSClusterName(), utility.FromStringPtr(p.Resources().Cluster))
+			assert.Len(t, p.Resources().Containers, len(def.ContainerDefinitions))
+			assert.Len(t, p.StatusInfo().Containers, len(def.ContainerDefinitions))
+			checkPodStatus(t, p, cocoa.StatusStarting)
+		},
+		"CreatePodFromExistingDefinitionFailsWithNonexistentCluster": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
+			taskDef := cocoa.NewECSTaskDefinition().SetID(utility.FromStringPtr(def.TaskDefinitionArn))
+			opts := cocoa.NewECSPodExecutionOptions().SetCluster("foo")
+
+			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *opts)
+			require.Error(t, err)
+			require.Zero(t, p)
+		},
+		"CreatePodFromExistingDefinitionFailsWithNonexistentTaskDefinition": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
+			taskDef := cocoa.NewECSTaskDefinition().SetID(testutil.NewTaskDefinitionFamily(t) + ":1")
+			opts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
+
+			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *opts)
+			require.Error(t, err)
+			require.Zero(t, p)
+		},
+		"CreatePodFromExistingDefinitionFailsWithInvalidExecutionOptions": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
+			taskDef := cocoa.NewECSTaskDefinition().SetID(utility.FromStringPtr(def.TaskDefinitionArn))
+			require.NoError(t, taskDef.Validate())
+			placementOpts := cocoa.NewECSPodPlacementOptions().SetStrategy("foo")
+			require.Error(t, placementOpts.Validate())
+			opts := cocoa.NewECSPodExecutionOptions().
+				SetCluster(testutil.ECSClusterName()).
+				SetPlacementOptions(*placementOpts)
+
+			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *opts)
+			require.Error(t, err)
+			require.Zero(t, p)
 		},
 	}
 }

--- a/mock/ecs_pod_creator.go
+++ b/mock/ecs_pod_creator.go
@@ -4,18 +4,20 @@ import (
 	"context"
 
 	"github.com/evergreen-ci/cocoa"
-	"github.com/pkg/errors"
 )
 
 // ECSPodCreator provides a mock implementation of a cocoa.ECSPodCreator
-// that produces mock ECS pods. It can also be mocked to produce a pre-defined
-// cocoa.ECSPod.
+// backed by another ECS pod creator implementation.
 type ECSPodCreator struct {
 	cocoa.ECSPodCreator
 
 	CreatePodInput  []cocoa.ECSPodCreationOptions
 	CreatePodOutput *cocoa.ECSPod
 	CreatePodError  error
+
+	CreatePodFromExistingDefinitionInput  []cocoa.ECSPodExecutionOptions
+	CreatePodFromExistingDefinitionOutput *cocoa.ECSPod
+	CreatePodFromExistingDefinitionError  error
 }
 
 // NewECSPodCreator creates a mock ECS Pod Creator backed by the given Pod Creator.
@@ -26,8 +28,8 @@ func NewECSPodCreator(c cocoa.ECSPodCreator) *ECSPodCreator {
 }
 
 // CreatePod saves the input and returns a new mock pod. The mock output can be
-// customized. By default, it will create a new pod based on the input that is
-// backed by a mock ECSClient.
+// customized. By default, it will return the result of the backing ECS pod
+// creator.
 func (m *ECSPodCreator) CreatePod(ctx context.Context, opts ...cocoa.ECSPodCreationOptions) (cocoa.ECSPod, error) {
 	m.CreatePodInput = opts
 
@@ -41,8 +43,16 @@ func (m *ECSPodCreator) CreatePod(ctx context.Context, opts ...cocoa.ECSPodCreat
 }
 
 // CreatePodFromExistingDefinition saves the input and returns a new mock pod.
-// The mock output can be customized. By default, it will create a new pod from
-// the existing task definition that is backed by a mock ECSClient.
+// The mock output can be customized. By default, it will return the result of
+// the backing ECS pod creator.
 func (m *ECSPodCreator) CreatePodFromExistingDefinition(ctx context.Context, def cocoa.ECSTaskDefinition, opts ...cocoa.ECSPodExecutionOptions) (cocoa.ECSPod, error) {
-	return nil, errors.New("TODO: implement")
+	m.CreatePodFromExistingDefinitionInput = opts
+
+	if m.CreatePodFromExistingDefinitionOutput != nil {
+		return *m.CreatePodOutput, m.CreatePodFromExistingDefinitionError
+	} else if m.CreatePodError != nil {
+		return nil, m.CreatePodError
+	}
+
+	return m.ECSPodCreator.CreatePodFromExistingDefinition(ctx, def, opts...)
 }

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -105,13 +105,44 @@ func TestECSPodCreator(t *testing.T) {
 			tCase(tctx, t, mpc)
 		})
 	}
+
+	c := &ECSClient{}
+	defer func() {
+		assert.NoError(t, c.Close(ctx))
+	}()
+	registerIn := validRegisterTaskDefinitionInput(t)
+	registerOut, err := c.RegisterTaskDefinition(ctx, &registerIn)
+	require.NoError(t, err)
+	require.NotZero(t, registerOut)
+	require.NotZero(t, registerOut.TaskDefinition)
+
+	for tName, tCase := range testcase.ECSPodCreatorRegisteredTaskDefinitionTests(*registerOut.TaskDefinition) {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
+			defer tcancel()
+
+			cleanupECSAndSecretsManagerCache()
+
+			sm := &SecretsManagerClient{}
+			defer func() {
+				assert.NoError(t, sm.Close(tctx))
+			}()
+
+			pc, err := ecs.NewBasicECSPodCreator(c, nil)
+			require.NoError(t, err)
+
+			mpc := NewECSPodCreator(pc)
+
+			tCase(tctx, t, mpc)
+		})
+	}
 }
 
 // ecsPodCreatorTests are mock-specific tests for ECS and Secrets Manager with
 // the ECS pod creator.
 func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
 	return map[string]func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient){
-		"RegistersTaskDefinitionAndRunsTaskWithAllFieldsSet": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
+		"CreatePodRegistersTaskDefinitionAndRunsTaskWithAllFieldsSet": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
 			envVar := cocoa.NewEnvironmentVariable().
 				SetName("env_var_name").
 				SetValue("env_var_value")
@@ -194,7 +225,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			assert.Equal(t, execOpts.Tags["execution_tag"], utility.FromStringPtr(c.RunTaskInput.Tags[0].Value))
 			assert.True(t, utility.FromBoolPtr(c.RunTaskInput.EnableExecuteCommand))
 		},
-		"RegistersTaskDefinitionAndRunsTaskWithCreatedSecrets": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
+		"CreatePodRegistersTaskDefinitionAndRunsTaskWithCreatedSecrets": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
 			secretOpts := cocoa.NewSecretOptions().
 				SetName("secret_name").
 				SetNewValue("secret_value")
@@ -236,7 +267,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			assert.Equal(t, utility.FromStringPtr(secretOpts.Name), utility.FromStringPtr(sm.CreateSecretInput.Name))
 			assert.Equal(t, utility.FromStringPtr(secretOpts.NewValue), utility.FromStringPtr(sm.CreateSecretInput.SecretString))
 		},
-		"RegistersTaskDefinitionAndRunsTaskWithCreatedRepositoryCredentials": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
+		"CreatePodRegistersTaskDefinitionAndRunsTaskWithCreatedRepositoryCredentials": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
 			repoCreds := cocoa.NewRepositoryCredentials().
 				SetName("repo_creds_secret_name").
 				SetNewCredentials(*cocoa.NewStoredRepositoryCredentials().
@@ -329,6 +360,52 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 			require.NoError(t, err)
 			require.NotZero(t, getSecretOut)
 			assert.Equal(t, utility.FromStringPtr(secretOpts.NewValue), utility.FromStringPtr(getSecretOut.SecretString))
+		},
+		"CreatePodFromExistingDefinitionRunsTaskWithExpectedTaskDefinitionAndExecutionOptions": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, sm *SecretsManagerClient) {
+			registerIn := validRegisterTaskDefinitionInput(t)
+			registerOut, err := c.RegisterTaskDefinition(ctx, &registerIn)
+			require.NoError(t, err)
+			require.NotZero(t, registerOut)
+			require.NotZero(t, registerOut.TaskDefinition)
+
+			placementOpts := cocoa.NewECSPodPlacementOptions().
+				SetGroup("group").
+				SetStrategy(cocoa.StrategyBinpack).
+				SetStrategyParameter(cocoa.StrategyParamBinpackMemory).
+				AddInstanceFilters("runningTaskCount == 0", cocoa.ConstraintDistinctInstance)
+			awsvpcOpts := cocoa.NewAWSVPCOptions().
+				AddSubnets("subnet-12345").
+				AddSecurityGroups("sg-12345")
+			execOpts := cocoa.NewECSPodExecutionOptions().
+				SetCluster(testutil.ECSClusterName()).
+				SetPlacementOptions(*placementOpts).
+				SetAWSVPCOptions(*awsvpcOpts).
+				SetTags(map[string]string{"execution_tag": "execution_val"}).
+				SetSupportsDebugMode(true)
+
+			def := cocoa.NewECSTaskDefinition().SetID(utility.FromStringPtr(registerOut.TaskDefinition.TaskDefinitionArn))
+			_, err = pc.CreatePodFromExistingDefinition(ctx, *def, *execOpts)
+			require.NoError(t, err)
+
+			require.NotZero(t, c.RunTaskInput)
+			assert.Equal(t, utility.FromStringPtr(execOpts.Cluster), utility.FromStringPtr(c.RunTaskInput.Cluster))
+			assert.Equal(t, utility.FromStringPtr(placementOpts.Group), utility.FromStringPtr(c.RunTaskInput.Group))
+			require.Len(t, c.RunTaskInput.PlacementStrategy, 1)
+			assert.EqualValues(t, *placementOpts.Strategy, utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Type))
+			assert.Equal(t, utility.FromStringPtr(placementOpts.StrategyParameter), utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Field))
+			require.Len(t, c.RunTaskInput.PlacementConstraints, 2)
+			assert.Equal(t, "memberOf", utility.FromStringPtr(c.RunTaskInput.PlacementConstraints[0].Type))
+			assert.Equal(t, placementOpts.InstanceFilters[0], utility.FromStringPtr(c.RunTaskInput.PlacementConstraints[0].Expression))
+			assert.Equal(t, cocoa.ConstraintDistinctInstance, utility.FromStringPtr(c.RunTaskInput.PlacementConstraints[1].Type))
+			assert.Zero(t, c.RunTaskInput.PlacementConstraints[1].Expression)
+			require.NotZero(t, c.RunTaskInput.NetworkConfiguration)
+			require.NotZero(t, c.RunTaskInput.NetworkConfiguration.AwsvpcConfiguration)
+			assert.ElementsMatch(t, execOpts.AWSVPCOpts.Subnets, utility.FromStringPtrSlice(c.RunTaskInput.NetworkConfiguration.AwsvpcConfiguration.Subnets))
+			assert.ElementsMatch(t, execOpts.AWSVPCOpts.SecurityGroups, utility.FromStringPtrSlice(c.RunTaskInput.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups))
+			require.Len(t, c.RunTaskInput.Tags, 1)
+			assert.Equal(t, "execution_tag", utility.FromStringPtr(c.RunTaskInput.Tags[0].Key))
+			assert.Equal(t, execOpts.Tags["execution_tag"], utility.FromStringPtr(c.RunTaskInput.Tags[0].Value))
+			assert.True(t, utility.FromBoolPtr(c.RunTaskInput.EnableExecuteCommand))
 		},
 	}
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15176

The way that ECS runs containers is that you first register an ECS task definition, which is basically the template of how to run the task, then run the task by passing in that task definition. The way `CreatePod` works right now is that it will always generate a new task definition right before running the task. In some cases, we may instead want to rely on a pre-created shared task definition.

* Implement method to create a pod from a pre-existing definition.
* Add some more test helper functions to avoid some copy-pasting.