### PR TITLE
EVG-16877: support ListTasks and add container instance statuses

### DIFF
--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -49,7 +49,7 @@ func TestECSClient(t *testing.T) {
 		assert.NoError(t, c.Close(ctx))
 	}()
 
-	for tName, tCase := range testcase.ECSClientTaskDefinitionTests() {
+	for tName, tCase := range testcase.ECSClientTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()

--- a/ecs/status.go
+++ b/ecs/status.go
@@ -8,7 +8,7 @@ import (
 // container.
 type TaskStatus string
 
-// Constants represents ECS task or container states.
+// Constants representing ECS task or container states.
 const (
 	// TaskStatusProvisioning indicates that ECS is performing additional work
 	// before launching the task (e.g. provisioning a network interface for
@@ -94,3 +94,33 @@ func (s TaskStatus) ordinal() int {
 		return -1
 	}
 }
+
+// ContainerInstanceStatus represents a status from the ECS API for a container
+// instance running tasks.
+type ContainerInstanceStatus string
+
+// Constants representing ECS container instance states.
+const (
+	// ContainerInstanceStatusRegistering indicates that the container instance
+	// is registering with the cluster. For container instances using AWSVPC
+	// trunking, this includes provisioning the trunk elastic network interface.
+	ContainerInstanceStatusRegistering ContainerInstanceStatus = "REGISTERING"
+	// ContainerInstanceStatusRegistrationFailed indicates that the container
+	// instance attempted to register but failed.
+	ContainerInstanceStatusRegistrationFailed ContainerInstanceStatus = "REGISTRATION_FAILED"
+	// ContainerInstanceStatusActive indicates that the container instance is
+	// ready to run tasks. When the container instance is active, ECS can
+	// schedule tasks for placement on it.
+	ContainerInstanceStatusActive ContainerInstanceStatus = "ACTIVE"
+	// ContainerInstanceStatusDeregistering indicates that the container
+	// instance is deregistering from the cluster. For container instances using
+	// AWSVPC trunking, this includes deprovisioning the trunk elastic network
+	// interface.
+	ContainerInstanceStatusDeregistering ContainerInstanceStatus = "DEREGISTERING"
+	// ContainerInstanceStatusInactive indicates that the container instance has
+	// been terminated and deregistered from the cluster.
+	ContainerInstanceStatusInactive ContainerInstanceStatus = "INACTIVE"
+	// ContainerInstanceStatusDraining indicates that the container instance is
+	// running, but ECS will not schedule new tasks for placement on it.
+	ContainerInstanceStatusDraining ContainerInstanceStatus = "DRAINING"
+)

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -122,19 +122,20 @@ type ECSCluster map[string]ECSTask
 
 // ECSTask represents a mock running ECS task within a cluster.
 type ECSTask struct {
-	ARN         *string
-	TaskDef     ECSTaskDefinition
-	Cluster     *string
-	Containers  []ECSContainer
-	Group       *string
-	ExecEnabled *bool
-	Status      *string
-	GoalStatus  *string
-	Created     *time.Time
-	StopCode    *string
-	StopReason  *string
-	Stopped     *time.Time
-	Tags        map[string]string
+	ARN               *string
+	TaskDef           ECSTaskDefinition
+	Cluster           *string
+	ContainerInstance *string
+	Containers        []ECSContainer
+	Group             *string
+	ExecEnabled       *bool
+	Status            *string
+	GoalStatus        *string
+	Created           *time.Time
+	StopCode          *string
+	StopReason        *string
+	Stopped           *time.Time
+	Tags              map[string]string
 }
 
 func newECSTask(in *ecs.RunTaskInput, taskDef ECSTaskDefinition) ECSTask {
@@ -665,6 +666,10 @@ func (c *ECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs
 	var arns []string
 	for arn, task := range cluster {
 		if in.DesiredStatus != nil && utility.FromStringPtr(task.GoalStatus) != *in.DesiredStatus {
+			continue
+		}
+
+		if in.ContainerInstance != nil && utility.FromStringPtr(task.ContainerInstance) != *in.ContainerInstance {
 			continue
 		}
 

--- a/mock/ecs_client_test.go
+++ b/mock/ecs_client_test.go
@@ -28,7 +28,7 @@ func TestECSClient(t *testing.T) {
 		assert.NoError(t, c.Close(ctx))
 	}()
 
-	for tName, tCase := range testcase.ECSClientTaskDefinitionTests() {
+	for tName, tCase := range testcase.ECSClientTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16877

This is some boilerplate code for the actual features related to container instances. When we get an SNS notification that a container instance (i.e. an EC2 instance running tasks in ECS) is going to be interrupted, we need to check its status and if the instance status is `"DRAINING"`, use `ListTasks` to get the ECS tasks currently running on that container instance. This will help us figure out which ECS tasks are going to be abruptly stopped by spot instance interruption.

* Add constants for ECS container instance statuses.
* Add tests for `ListTasks` and improve fake ECS service.