### PR TITLE
EVG-17026: add option to set pod capacity provider

### DIFF
--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -494,6 +494,7 @@ func (pc *BasicECSPodCreator) exportRepoCreds(creds *cocoa.RepositoryCredentials
 func (pc *BasicECSPodCreator) exportTaskExecutionOptions(opts cocoa.ECSPodExecutionOptions, taskDef cocoa.ECSTaskDefinition) *ecs.RunTaskInput {
 	var runTask ecs.RunTaskInput
 	runTask.SetCluster(utility.FromStringPtr(opts.Cluster)).
+		SetCapacityProviderStrategy(pc.exportCapacityProvider(opts.CapacityProvider)).
 		SetTaskDefinition(utility.FromStringPtr(taskDef.ID)).
 		SetTags(pc.exportTags(opts.Tags)).
 		SetEnableExecuteCommand(utility.FromBoolPtr(opts.SupportsDebugMode)).
@@ -504,6 +505,17 @@ func (pc *BasicECSPodCreator) exportTaskExecutionOptions(opts cocoa.ECSPodExecut
 		runTask.SetGroup(utility.FromStringPtr(opts.PlacementOpts.Group))
 	}
 	return &runTask
+}
+
+// exportCapacityProvider converts the capacity provider name into an ECS
+// capacity provider strategy.
+func (pc *BasicECSPodCreator) exportCapacityProvider(provider *string) []*ecs.CapacityProviderStrategyItem {
+	if provider == nil {
+		return nil
+	}
+	var converted ecs.CapacityProviderStrategyItem
+	converted.SetCapacityProvider(utility.FromStringPtr(provider))
+	return []*ecs.CapacityProviderStrategyItem{&converted}
 }
 
 // exportPortMappings converts port mappings into ECS port mappings.

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -682,6 +682,10 @@ type ECSPodExecutionOptions struct {
 	// Cluster is the name of the cluster where the pod will run. If none is
 	// specified, this will run in the default cluster.
 	Cluster *string
+	// CapacityProvider is the name of the capacity provider that the pod will
+	// use, which in turn determines the infrastructure that the pod will run
+	// on. If none is specified, this will run in the default capacity provider.
+	CapacityProvider *string
 	// PlacementOptions specify options that determine how a pod is assigned to
 	// a container instance.
 	PlacementOpts *ECSPodPlacementOptions
@@ -705,6 +709,13 @@ func NewECSPodExecutionOptions() *ECSPodExecutionOptions {
 // SetCluster sets the name of the cluster where the pod will run.
 func (o *ECSPodExecutionOptions) SetCluster(cluster string) *ECSPodExecutionOptions {
 	o.Cluster = &cluster
+	return o
+}
+
+// SetCapacityProvider sets the name of the capacity provider that the pod will
+// use.
+func (o *ECSPodExecutionOptions) SetCapacityProvider(provider string) *ECSPodExecutionOptions {
+	o.CapacityProvider = &provider
 	return o
 }
 
@@ -776,6 +787,10 @@ func MergeECSPodExecutionOptions(opts ...ECSPodExecutionOptions) ECSPodExecution
 	for _, opt := range opts {
 		if opt.Cluster != nil {
 			merged.Cluster = opt.Cluster
+		}
+
+		if opt.CapacityProvider != nil {
+			merged.CapacityProvider = opt.CapacityProvider
 		}
 
 		if opt.PlacementOpts != nil {

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -863,9 +863,14 @@ func TestECSPodExecutionOptions(t *testing.T) {
 		assert.Zero(t, *opts)
 	})
 	t.Run("SetCluster", func(t *testing.T) {
-		cluster := "cluster"
-		opts := NewECSPodExecutionOptions().SetCluster("cluster")
+		const cluster = "cluster"
+		opts := NewECSPodExecutionOptions().SetCluster(cluster)
 		assert.Equal(t, cluster, utility.FromStringPtr(opts.Cluster))
+	})
+	t.Run("SetCapacityProvider", func(t *testing.T) {
+		const provider = "capacity_provider"
+		opts := NewECSPodExecutionOptions().SetCapacityProvider(provider)
+		assert.Equal(t, provider, utility.FromStringPtr(opts.CapacityProvider))
 	})
 	t.Run("SetPlacementOptions", func(t *testing.T) {
 		placementOpts := NewECSPodPlacementOptions().SetStrategy(StrategyBinpack)

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -277,16 +277,6 @@ func newCapacityProvider(providers []*ecs.CapacityProviderStrategyItem) *string 
 	return providers[0].CapacityProvider
 }
 
-func exportCapacityProviders(providers []string) []*ecs.CapacityProviderStrategyItem {
-	var converted []*ecs.CapacityProviderStrategyItem
-	for _, p := range providers {
-		converted = append(converted, &ecs.CapacityProviderStrategyItem{
-			CapacityProvider: utility.ToStringPtr(p),
-		})
-	}
-	return converted
-}
-
 func newEnvVars(envVars []*ecs.KeyValuePair) map[string]string {
 	converted := map[string]string{}
 	for _, envVar := range envVars {

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -165,6 +165,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 				AddSecurityGroups("sg-12345")
 			execOpts := cocoa.NewECSPodExecutionOptions().
 				SetCluster(testutil.ECSClusterName()).
+				SetCapacityProvider("capacity_provider").
 				SetPlacementOptions(*placementOpts).
 				SetAWSVPCOptions(*awsvpcOpts).
 				SetTags(map[string]string{"execution_tag": "execution_val"}).
@@ -208,6 +209,8 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 
 			require.NotZero(t, c.RunTaskInput)
 			assert.Equal(t, utility.FromStringPtr(execOpts.Cluster), utility.FromStringPtr(c.RunTaskInput.Cluster))
+			require.Len(t, c.RunTaskInput.CapacityProviderStrategy, 1)
+			assert.Equal(t, utility.FromStringPtr(execOpts.CapacityProvider), utility.FromStringPtr(c.RunTaskInput.CapacityProviderStrategy[0].CapacityProvider))
 			assert.Equal(t, utility.FromStringPtr(placementOpts.Group), utility.FromStringPtr(c.RunTaskInput.Group))
 			require.Len(t, c.RunTaskInput.PlacementStrategy, 1)
 			assert.EqualValues(t, *placementOpts.Strategy, utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Type))
@@ -379,6 +382,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 				AddSecurityGroups("sg-12345")
 			execOpts := cocoa.NewECSPodExecutionOptions().
 				SetCluster(testutil.ECSClusterName()).
+				SetCapacityProvider("capacity_provider").
 				SetPlacementOptions(*placementOpts).
 				SetAWSVPCOptions(*awsvpcOpts).
 				SetTags(map[string]string{"execution_tag": "execution_val"}).
@@ -390,6 +394,8 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 
 			require.NotZero(t, c.RunTaskInput)
 			assert.Equal(t, utility.FromStringPtr(execOpts.Cluster), utility.FromStringPtr(c.RunTaskInput.Cluster))
+			require.Len(t, c.RunTaskInput.CapacityProviderStrategy, 1)
+			assert.Equal(t, utility.FromStringPtr(execOpts.CapacityProvider), utility.FromStringPtr(c.RunTaskInput.CapacityProviderStrategy[0].CapacityProvider))
 			assert.Equal(t, utility.FromStringPtr(placementOpts.Group), utility.FromStringPtr(c.RunTaskInput.Group))
 			require.Len(t, c.RunTaskInput.PlacementStrategy, 1)
 			assert.EqualValues(t, *placementOpts.Strategy, utility.FromStringPtr(c.RunTaskInput.PlacementStrategy[0].Type))


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17026

Build changed the way the cluster infrastructure is set up, which also necessitates us changing how we configure pods. Before, we used a single capacity provider and chose an instance with the correct CPU architecture for the container by specifying [placement constraints](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html). They changed it so that we use multiple [capacity providers](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html), each of which maps to an AMI that runs an instance with a particular CPU architecture. This adds support for specifying which capacity provider the pod should use so that we can still have the pod run on a the targeted architecture.