### PR TITLE
EVG-16895: add test for idempotent secret creation

### DIFF
--- a/internal/testcase/vault.go
+++ b/internal/testcase/vault.go
@@ -23,6 +23,19 @@ func VaultTests(cleanupSecret func(ctx context.Context, t *testing.T, v cocoa.Va
 
 			defer cleanupSecret(ctx, t, v, id)
 		},
+		"CreateSecretIsIdempotent": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
+			s := cocoa.NewNamedSecret().SetName(testutil.NewSecretName(t)).SetValue("hello")
+			id, err := v.CreateSecret(ctx, *s)
+			require.NoError(t, err)
+			require.NotZero(t, id)
+
+			dupID, err := v.CreateSecret(ctx, *s)
+			require.NoError(t, err)
+			require.NotZero(t, dupID)
+			assert.Equal(t, id, dupID, "creating a secret with an identical name should return the same unique identifier")
+
+			defer cleanupSecret(ctx, t, v, id)
+		},
 		"CreateSecretFailsWithInvalidInput": func(ctx context.Context, t *testing.T, v cocoa.Vault) {
 			id, err := v.CreateSecret(ctx, cocoa.NamedSecret{})
 			assert.Error(t, err)

--- a/secret/secrets_manager_vault.go
+++ b/secret/secrets_manager_vault.go
@@ -40,17 +40,17 @@ func (m *BasicSecretsManager) CreateSecret(ctx context.Context, s cocoa.NamedSec
 			// The secret already exists, so describe it to get the ARN.
 			describeOut, err := m.client.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{SecretId: s.Name})
 			if err != nil {
-				return "", err
+				return "", errors.Wrap(err, "describing already-existing secret")
 			}
 			if describeOut == nil || describeOut.ARN == nil {
-				return "", errors.New("expected an ID for an existing secret, but none was returned from Secrets Manager")
+				return "", errors.New("expected an ID for an already-existing secret in the response, but none was returned from Secrets Manager")
 			}
 			return *describeOut.ARN, nil
 		}
 		return "", err
 	}
 	if out == nil || out.ARN == nil {
-		return "", errors.New("expected an ID, but none was returned from Secrets Manager")
+		return "", errors.New("expected an ID in the response, but none was returned from Secrets Manager")
 	}
 	return *out.ARN, nil
 }
@@ -58,7 +58,7 @@ func (m *BasicSecretsManager) CreateSecret(ctx context.Context, s cocoa.NamedSec
 // GetValue returns an existing secret's decrypted value.
 func (m *BasicSecretsManager) GetValue(ctx context.Context, id string) (val string, err error) {
 	if id == "" {
-		return "", errors.New("must specify a non-empty id")
+		return "", errors.New("must specify a non-empty ID")
 	}
 
 	out, err := m.client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{SecretId: &id})
@@ -66,7 +66,7 @@ func (m *BasicSecretsManager) GetValue(ctx context.Context, id string) (val stri
 		return "", err
 	}
 	if out == nil || out.SecretString == nil {
-		return "", errors.New("expected a value, but none was returned from Secrets Manager")
+		return "", errors.New("expected a value in the response, but none was returned from Secrets Manager")
 	}
 	return *out.SecretString, nil
 }
@@ -87,7 +87,7 @@ func (m *BasicSecretsManager) UpdateValue(ctx context.Context, s cocoa.NamedSecr
 // If the secret does not exist, this will perform no operation.
 func (m *BasicSecretsManager) DeleteSecret(ctx context.Context, id string) error {
 	if id == "" {
-		return errors.New("must specify a non-empty id")
+		return errors.New("must specify a non-empty ID")
 	}
 	_, err := m.client.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
 		ForceDeleteWithoutRecovery: aws.Bool(true),


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16895

[EVG-15247](https://jira.mongodb.org/browse/EVG-15247) already did the work to make `CreateSecret` idempotent. I just wrote a test to prove that `CreateSecret` behaves as expected when called multiple times. The one catch is that `CreateSecret` is idempotent but does not behave like a DB upsert. If you try creating a secret with the same name but a different value, it won't overwrite the existing value. `UpdateSecret` is meant to cover updating a secret's value.