### PR TITLE
EVG-17170: handle error due to missing task

### DIFF
--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -81,3 +81,29 @@ func TestECSClient(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertFailureToError(t *testing.T) {
+	t.Run("ConvertsToFormattedError", func(t *testing.T) {
+		const (
+			arn    = "some_arn"
+			reason = "some reason"
+			detail = "some detail"
+		)
+		err := ConvertFailureToError(ecs.Failure{
+			Arn:    aws.String(arn),
+			Reason: aws.String(reason),
+			Detail: aws.String(detail),
+		})
+		require.NotZero(t, err)
+		assert.Contains(t, err.Error(), arn)
+		assert.Contains(t, err.Error(), reason)
+		assert.Contains(t, err.Error(), detail)
+	})
+	t.Run("ConvertsMissingTaskFailureToTaskNotFound", func(t *testing.T) {
+		err := ConvertFailureToError(ecs.Failure{
+			Arn:    aws.String("arn"),
+			Reason: aws.String("MISSING"),
+		})
+		assert.True(t, cocoa.IsECSTaskNotFoundError(err))
+	})
+}

--- a/ecs/pod.go
+++ b/ecs/pod.go
@@ -169,10 +169,10 @@ func (p *BasicECSPod) Stop(ctx context.Context) error {
 	stopTask.SetCluster(utility.FromStringPtr(p.resources.Cluster)).SetTask(utility.FromStringPtr(p.resources.TaskID))
 
 	_, err := p.client.StopTask(ctx, &stopTask)
-	// If the pod is already been stopped, ECS will not be have information
-	// about the task after some period of time, resulting in a not found error.
-	// In case the task is not found, stopping is considered successful since
-	// the task either never existed or has already been stopped.
+	// If the pod has already been stopped, ECS will not have information about
+	// the task after some period of time, resulting in a not found error. In
+	// case the task is not found, stopping is considered successful since the
+	// task either never existed or has already been stopped.
 	if err != nil && !cocoa.IsECSTaskNotFoundError(err) {
 		return errors.Wrap(err, "stopping pod")
 	}

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -172,8 +172,11 @@ func (pc *BasicECSPodCreator) runTask(ctx context.Context, opts cocoa.ECSPodExec
 func (pc *BasicECSPodCreator) validateRunTaskOutput(out *ecs.RunTaskOutput) error {
 	if len(out.Failures) > 0 {
 		catcher := grip.NewBasicCatcher()
-		for _, failure := range out.Failures {
-			catcher.Errorf("task '%s': %s: %s\n", utility.FromStringPtr(failure.Arn), utility.FromStringPtr(failure.Detail), utility.FromStringPtr(failure.Reason))
+		for _, f := range out.Failures {
+			if f == nil {
+				continue
+			}
+			catcher.Add(ConvertFailureToError(*f))
 		}
 		return errors.Wrap(catcher.Resolve(), "running task")
 	}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,34 @@
+package cocoa
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// ECSTaskNotFoundError indicates that the reason for an error or failure in an
+// ECS request is because the task with the specified ARN could not be found.
+type ECSTaskNotFoundError struct {
+	ARN string
+}
+
+// Error returns the formatted error message including the ARN of the task.
+func (e *ECSTaskNotFoundError) Error() string {
+	return fmt.Sprintf("task '%s' not found", e.ARN)
+}
+
+// NewECSTaskNotFoundError returns a new error with the given ARN indicating
+// that the task could not be found in ECS.
+func NewECSTaskNotFoundError(arn string) *ECSTaskNotFoundError {
+	return &ECSTaskNotFoundError{ARN: arn}
+}
+
+// IsECSTaskNotFoundError returns whether or not the error is due to not being
+// able to find the task in ECS.
+func IsECSTaskNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := errors.Cause(err).(*ECSTaskNotFoundError)
+	return ok
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,26 @@
+package cocoa
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestECSTaskNotFoundError(t *testing.T) {
+	assert.Implements(t, (*error)(nil), new(ECSTaskNotFoundError))
+	t.Run("IsECSTaskNotFoundError", func(t *testing.T) {
+		err := NewECSTaskNotFoundError("arn")
+		assert.Error(t, err)
+		assert.True(t, IsECSTaskNotFoundError(err))
+	})
+	t.Run("OtherErrorsAreNotECSTaskNotFound", func(t *testing.T) {
+		err := errors.New("some error")
+		assert.False(t, IsECSTaskNotFoundError(err))
+	})
+	t.Run("WrappedECSTaskNotFoundError", func(t *testing.T) {
+		err := errors.Wrap(NewECSTaskNotFoundError("arn"), "wrapping message")
+		assert.True(t, IsECSTaskNotFoundError(err))
+	})
+}

--- a/internal/testcase/ecs_client.go
+++ b/internal/testcase/ecs_client.go
@@ -140,7 +140,9 @@ func ECSClientTests() map[string]ECSClientTestCase {
 		"ListTasksFailsWithInvalidInput": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			out, err := c.ListTasks(ctx, &awsECS.ListTasksInput{})
 			assert.Error(t, err)
-			assert.Zero(t, out)
+			if out != nil {
+				assert.Empty(t, out.TaskArns)
+			}
 		},
 		"ListTasksSucceedsWithNoResultsWithValidButNonexistentInput": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			out, err := c.ListTasks(ctx, &awsECS.ListTasksInput{

--- a/internal/testcase/ecs_client.go
+++ b/internal/testcase/ecs_client.go
@@ -137,9 +137,9 @@ func ECSClientTests() map[string]ECSClientTestCase {
 			assert.Error(t, err)
 			assert.Zero(t, out)
 		},
-		"ListTasksFailsWithInvalidInput": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
+		"ListTasksSucceedsWithNoResultWithZeroInput": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			out, err := c.ListTasks(ctx, &awsECS.ListTasksInput{})
-			assert.Error(t, err)
+			assert.NoError(t, err)
 			if out != nil {
 				assert.Empty(t, out.TaskArns)
 			}

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -675,7 +675,7 @@ func (c *ECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs
 
 	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]
 	if !ok {
-		return nil, awserr.New(ecs.ErrCodeResourceNotFoundException, "cluster not found", nil)
+		return &ecs.ListTasksOutput{}, nil
 	}
 
 	var arns []string

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/utility"
 )
 
@@ -645,8 +646,10 @@ func (c *ECSClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInpu
 		task, ok := cluster[id]
 		if !ok {
 			failures = append(failures, &ecs.Failure{
-				Arn:    utility.ToStringPtr(id),
-				Reason: utility.ToStringPtr("task not found"),
+				Arn: utility.ToStringPtr(id),
+				// This reason specifically matches the one returned by ECS when
+				// it cannot find the task.
+				Reason: utility.ToStringPtr("MISSING"),
 			})
 			continue
 		}
@@ -714,7 +717,7 @@ func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.S
 
 	task, ok := cluster[utility.FromStringPtr(in.Task)]
 	if !ok {
-		return nil, awserr.New(ecs.ErrCodeResourceNotFoundException, "task not found", nil)
+		return nil, cocoa.NewECSTaskNotFoundError(utility.FromStringPtr(in.Task))
 	}
 
 	task.Status = utility.ToStringPtr(ecs.DesiredStatusStopped)

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -195,6 +195,15 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			require.NoError(t, p.Stop(ctx))
 			assert.Equal(t, cocoa.StatusStopped, p.StatusInfo().Status)
 		},
+		"StopSucceedsWhenTaskIsNotFound": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
+			opts := makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t))
+			p, err := pc.CreatePod(ctx, *opts)
+			require.NoError(t, err)
+
+			c.StopTaskError = cocoa.NewECSTaskNotFoundError(utility.FromStringPtr(p.Resources().TaskID))
+
+			assert.NoError(t, p.Stop(ctx), "should successfully stop pod when its task cannot be found")
+		},
 		"DeleteSucceedsWithoutTaskDefinition": func(ctx context.Context, t *testing.T, pc cocoa.ECSPodCreator, c *ECSClient, smc *SecretsManagerClient) {
 			opts := makePodCreationOpts(t).AddContainerDefinitions(*makeContainerDef(t))
 			p, err := pc.CreatePod(ctx, *opts)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17170

The ECS SDK returns either an error or a failure response indicating that the task cannot be found in ECS if the task either doesn't exist or the task has been stopped for a long time and ECS no longer has information about it. It seems like for API calls that require you to specify a single task ARN (like [`StopTask`](https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#StopTaskInput)), it will return an error when the task cannot be found; for API calls that allow you to pass many task ARNs (like `DescribeTasks`), it will return nil error and will instead populate the [`Failures` field in the response](https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#DescribeTasksOutput) with one failure for each task that it cannot find.

* Add special error type when task cannot be found and add helper to check for it.
* Add logic to ECS client and mock so that they return the special error when the task cannot be found.
* Ignore task not found errors when the pod is stopping itself or deleting its resources.