### PR TITLE
EVG-16890: set up pod definition manager and cache

### DIFF
--- a/ecs/pod_definition_cache.go
+++ b/ecs/pod_definition_cache.go
@@ -1,0 +1,28 @@
+package ecs
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/evergreen-ci/cocoa"
+	"github.com/pkg/errors"
+)
+
+type PodDefinitionCache interface {
+	Put(ctx context.Context, res cocoa.ECSPodDefinitionOptions) error
+}
+
+type PodDefinitionManager struct {
+	cache PodDefinitionCache
+}
+
+// CreatePodDefinition creates a pod definition and caches it.
+// kim: TODO: pass PodDefinitionOptions to CreatePodDefinition
+func (m *PodDefinitionManager) CreatePodDefinition(ctx context.Context, opts ...cocoa.ECSPodDefinitionOptions) (*ecs.TaskDefinition, error) {
+	// kim: TODO: register task definition with "untracked" tag.
+
+	// kim: TODO: cache task definition.
+
+	// kim: TODO: re-tag task definition with "tracked" tag.
+	return nil, errors.New("kim: TODO: implement")
+}

--- a/ecs/pod_definition_cache.go
+++ b/ecs/pod_definition_cache.go
@@ -8,21 +8,20 @@ import (
 	"github.com/pkg/errors"
 )
 
+// PodDefinitionCache represents an external cache that tracks pod definitions.
 type PodDefinitionCache interface {
 	Put(ctx context.Context, res cocoa.ECSPodDefinitionOptions) error
 }
 
+// PodDefinitionManager manages pod definitions, which are configuration
+// templates used to run pods. It can be optionally backed by an external
+// PodDefinitionCache to keep track of the pod definitions.
 type PodDefinitionManager struct {
-	cache PodDefinitionCache
+	client cocoa.ECSClient    //nolint
+	cache  PodDefinitionCache //nolint
 }
 
 // CreatePodDefinition creates a pod definition and caches it.
-// kim: TODO: pass PodDefinitionOptions to CreatePodDefinition
 func (m *PodDefinitionManager) CreatePodDefinition(ctx context.Context, opts ...cocoa.ECSPodDefinitionOptions) (*ecs.TaskDefinition, error) {
-	// kim: TODO: register task definition with "untracked" tag.
-
-	// kim: TODO: cache task definition.
-
-	// kim: TODO: re-tag task definition with "tracked" tag.
-	return nil, errors.New("kim: TODO: implement")
+	return nil, errors.New("TODO: implement")
 }

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -31,13 +31,15 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetName("container")
 
 			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
-
-			opts := cocoa.NewECSPodCreationOptions().
+			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetNetworkMode(cocoa.NetworkModeBridge).
+				SetNetworkMode(cocoa.NetworkModeBridge)
+
+			opts := cocoa.NewECSPodCreationOptions().
+				SetDefinitionOptions(*defOpts).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -71,14 +73,15 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetName("container")
 
 			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
-
-			opts := cocoa.NewECSPodCreationOptions().
+			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
 				SetTaskRole(testutil.ECSTaskRole()).
-				SetExecutionRole(testutil.ECSExecutionRole()).
+				SetExecutionRole(testutil.ECSExecutionRole())
+
+			opts := cocoa.NewECSPodCreationOptions().SetDefinitionOptions(*defOpts).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -99,14 +102,16 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetName("container")
 
 			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
-
-			opts := cocoa.NewECSPodCreationOptions().
+			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
 				SetTaskRole(testutil.ECSTaskRole()).
-				SetExecutionRole(testutil.ECSExecutionRole()).
+				SetExecutionRole(testutil.ECSExecutionRole())
+
+			opts := cocoa.NewECSPodCreationOptions().
+				SetDefinitionOptions(*defOpts).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -142,13 +147,16 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 			execOpts := cocoa.NewECSPodExecutionOptions().
 				SetCluster(testutil.ECSClusterName())
 
-			opts := cocoa.NewECSPodCreationOptions().
+			defOpts := cocoa.NewECSPodDefinitionOptions().
+				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
-				SetTaskRole(testutil.ECSTaskRole()).
-				SetExecutionOptions(*execOpts).
-				SetName(testutil.NewTaskDefinitionFamily(t))
+				SetTaskRole(testutil.ECSTaskRole())
+
+			opts := cocoa.NewECSPodCreationOptions().
+				SetDefinitionOptions(*defOpts).
+				SetExecutionOptions(*execOpts)
 			assert.Error(t, opts.Validate())
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -173,13 +181,16 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 			execOpts := cocoa.NewECSPodExecutionOptions().
 				SetCluster(testutil.ECSClusterName())
 
-			opts := cocoa.NewECSPodCreationOptions().
+			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
 				SetTaskRole(testutil.ECSTaskRole()).
-				SetExecutionRole(testutil.ECSExecutionRole()).
+				SetExecutionRole(testutil.ECSExecutionRole())
+
+			opts := cocoa.NewECSPodCreationOptions().
+				SetDefinitionOptions(*defOpts).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 
@@ -212,13 +223,16 @@ func ECSPodCreatorWithVaultTests() map[string]ECSPodCreatorTestCase {
 			execOpts := cocoa.NewECSPodExecutionOptions().
 				SetCluster(testutil.ECSClusterName())
 
-			opts := cocoa.NewECSPodCreationOptions().
+			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
 				SetMemoryMB(128).
 				SetCPU(128).
 				SetTaskRole(testutil.ECSTaskRole()).
-				SetExecutionRole(testutil.ECSExecutionRole()).
+				SetExecutionRole(testutil.ECSExecutionRole())
+
+			opts := cocoa.NewECSPodCreationOptions().
+				SetDefinitionOptions(*defOpts).
 				SetExecutionOptions(*execOpts)
 			assert.NoError(t, opts.Validate())
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16890

* Set up the interface by which we can manage the lifecycle of cloud pod definitions and cache them (i.e. CRUD them in the DB). For now, there's only one method to create a pod definition, but we'll need to add more methods for other functionality like deleting later on. The implementation is going to be filled in as part of [EVG-16891](https://jira.mongodb.org/browse/EVG-16891).
* Refactor the `ECSPodCreationOptions` so that we can pass the pod definition options as an independent struct (`ECSPodDefinitionOptions`) to the pod definition manager. The `ECSPodCreationOptions` is supposed to both create the pod definition and run it; we need to isolate the first step of just creating the pod definition from some inputs so that the pod definition cache can create them.