### PR TITLE
EVG-16911: compute hash digest for pod definitions

### DIFF
--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -109,7 +109,7 @@ func TestECSPod(t *testing.T) {
 }
 
 // validNonIntegrationAWSOpts returns valid options to create an AWS client that
-// doesn't actually make any actual requests to AWS.
+// doesn't make any actual requests to AWS.
 func validNonIntegrationAWSOpts(hc *http.Client) awsutil.ClientOptions {
 	return *awsutil.NewClientOptions().
 		SetCredentials(credentials.NewEnvCredentials()).

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -356,9 +356,6 @@ func (htp hashableTagPairs) hash() string {
 	return h.sum()
 }
 
-// kim: TODO: test hash fn for same/different inputs incrementally for each
-// field/substruct. Test order of fields doesn't matter.
-
 // Hash returns the hash digest of the pod definition.
 func (o *ECSPodDefinitionOptions) Hash() string {
 	h := newSHA1Hasher()

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -596,7 +596,7 @@ func (d *ECSContainerDefinition) Validate() error {
 	return nil
 }
 
-// hash returns the hash digest of the definition.
+// hash returns the hash digest of the container definition.
 func (d *ECSContainerDefinition) hash() string {
 	h := newSHA1Hasher()
 	if d.Name != nil {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16911

Add a `Hash` function to compute the hash digest of the pod definitions, which is [based on Cedar's hash-based ID generation](https://github.com/evergreen-ci/cedar/blob/346b0b2bdaa508a5c3b78b3f4d3e2dbc2c17dd1e/model/buildlogger.go#L365-L402). Evergreen needs to be able to quickly compute the hash for pod definitions, because it needs to be able to easily determine whether or not a pod definition is already present in its cache (i.e. in the DB) based on all the inputs given when registering the definition in ECS. Cache hits/misses are based on whether a pod definition in the cache with an identical hash already exists. The hashing should work such that if two pod definitions have the same hash, then they will run identical pods when `RunTask` is called; otherwise, they're considered different pod definitions.

Some other notes:
* I considered writing this using reflection since the recursive hashing has a lot of similar logic and it could be more elegant, but I decided it would just end up being more confusing to have to verify the correctness of reflection logic.
* I made it resilient to ordering of slices where order doesn't matter. For example, if you swap two container definitions in the pod definition, this doesn't change the hash because the order that the containers are defined does not matter.