### PR TITLE
EVG-16896, EVG-16897: add means to cache secrets

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -20,7 +20,9 @@ directly to the ECS API using this client.
 
 The Vault is an ancillary service for pods that supports interacting with a
 dedicated secrets management service. It conveniently integrates with pods to
-securely pass secrets into containers.
+securely pass secrets into containers. This can be used in conjunction with a
+SecretCache to both manage the cloud secrets and also keep track of these
+secrets in an external cache.
 
 The SecretsManagerClient provides a convenience wrapper around the AWS Secrets
 Manager API. If the Vault does not fulfill your needs, you can instead make

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -271,8 +271,8 @@ func createSecret(ctx context.Context, v cocoa.Vault, secret cocoa.SecretOptions
 		SetValue(utility.FromStringPtr(secret.NewValue)))
 }
 
-// exportTags converts a mapping of tag names to values into ECS tags.
-func exportTags(tags map[string]string) []*ecs.Tag {
+// ExportTags converts a mapping of tag names to values into ECS tags.
+func ExportTags(tags map[string]string) []*ecs.Tag {
 	var ecsTags []*ecs.Tag
 
 	for k, v := range tags {
@@ -457,7 +457,7 @@ func exportPodDefinitionOptions(opts cocoa.ECSPodDefinitionOptions) *ecs.Registe
 	taskDef.SetFamily(utility.FromStringPtr(opts.Name)).
 		SetTaskRoleArn(utility.FromStringPtr(opts.TaskRole)).
 		SetExecutionRoleArn(utility.FromStringPtr(opts.ExecutionRole)).
-		SetTags(exportTags(opts.Tags))
+		SetTags(ExportTags(opts.Tags))
 
 	return &taskDef
 }
@@ -503,7 +503,7 @@ func (pc *BasicECSPodCreator) exportTaskExecutionOptions(opts cocoa.ECSPodExecut
 	runTask.SetCluster(utility.FromStringPtr(opts.Cluster)).
 		SetCapacityProviderStrategy(pc.exportCapacityProvider(opts.CapacityProvider)).
 		SetTaskDefinition(utility.FromStringPtr(taskDef.ID)).
-		SetTags(exportTags(opts.Tags)).
+		SetTags(ExportTags(opts.Tags)).
 		SetEnableExecuteCommand(utility.FromBoolPtr(opts.SupportsDebugMode)).
 		SetPlacementStrategy(pc.exportStrategy(opts.PlacementOpts)).
 		SetPlacementConstraints(pc.exportPlacementConstraints(opts.PlacementOpts)).

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -66,7 +66,8 @@ func TestBasicECSPodCreator(t *testing.T) {
 				assert.NoError(t, smc.Close(tctx))
 			}()
 
-			m := secret.NewBasicSecretsManager(smc)
+			m, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
+			require.NoError(t, err)
 			require.NotNil(t, m)
 
 			tCase(tctx, t, c, m)
@@ -119,7 +120,8 @@ func TestECSPodCreator(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
-			m := secret.NewBasicSecretsManager(smc)
+			m, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
+			require.NoError(t, err)
 			require.NotNil(t, m)
 
 			pc, err := NewBasicECSPodCreator(c, m)

--- a/ecs/pod_definition_manager.go
+++ b/ecs/pod_definition_manager.go
@@ -37,13 +37,13 @@ func NewBasicPodDefinitionManagerOptions() *BasicPodDefinitionManagerOptions {
 	return &BasicPodDefinitionManagerOptions{}
 }
 
-// SetClient sets the client the pod uses to communicate with ECS.
+// SetClient sets the client the pod manager uses to communicate with ECS.
 func (o *BasicPodDefinitionManagerOptions) SetClient(c cocoa.ECSClient) *BasicPodDefinitionManagerOptions {
 	o.Client = c
 	return o
 }
 
-// SetVault sets the vault that the pod uses to manage secrets.
+// SetVault sets the vault that the pod manager uses to manage secrets.
 func (o *BasicPodDefinitionManagerOptions) SetVault(v cocoa.Vault) *BasicPodDefinitionManagerOptions {
 	o.Vault = v
 	return o
@@ -132,7 +132,7 @@ func (m *BasicPodDefinitionManager) CreatePodDefinition(ctx context.Context, opt
 	}
 
 	if err := m.cache.Put(ctx, item); err != nil {
-		return nil, errors.Wrapf(err, "adding pod definition item '%s' to cache", item.ID)
+		return nil, errors.Wrapf(err, "adding pod definition item '%s' named '%s' to cache", item.ID, utility.FromStringPtr(item.DefinitionOpts.Name))
 	}
 
 	// Now that the cloud pod definition is being tracked in the cache, re-tag
@@ -141,7 +141,7 @@ func (m *BasicPodDefinitionManager) CreatePodDefinition(ctx context.Context, opt
 		ResourceArn: aws.String(item.ID),
 		Tags:        exportTags(map[string]string{m.cacheTag: strconv.FormatBool(true)}),
 	}); err != nil {
-		return nil, errors.Wrapf(err, "re-tagging pod definition item '%s' to indicate that it is tracked", item.ID)
+		return nil, errors.Wrapf(err, "re-tagging pod definition item '%s' named '%s' to indicate that it is tracked", item.ID, utility.FromStringPtr(item.DefinitionOpts.Name))
 	}
 
 	return &item, nil

--- a/ecs/pod_definition_manager.go
+++ b/ecs/pod_definition_manager.go
@@ -139,7 +139,7 @@ func (m *BasicPodDefinitionManager) CreatePodDefinition(ctx context.Context, opt
 	// it to indicate that it's being tracked.
 	if _, err := m.client.TagResource(ctx, &ecs.TagResourceInput{
 		ResourceArn: aws.String(item.ID),
-		Tags:        exportTags(map[string]string{m.cacheTag: strconv.FormatBool(true)}),
+		Tags:        ExportTags(map[string]string{m.cacheTag: strconv.FormatBool(true)}),
 	}); err != nil {
 		return nil, errors.Wrapf(err, "re-tagging pod definition item '%s' named '%s' to indicate that it is tracked", item.ID, utility.FromStringPtr(item.DefinitionOpts.Name))
 	}

--- a/ecs/pod_definition_manager_test.go
+++ b/ecs/pod_definition_manager_test.go
@@ -87,7 +87,8 @@ func TestECSPodDefinitionManager(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
-			v := secret.NewBasicSecretsManager(smc)
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
+			require.NoError(t, err)
 			require.NotNil(t, v)
 
 			opts := NewBasicPodDefinitionManagerOptions().
@@ -120,7 +121,8 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 	t.Run("SetVault", func(t *testing.T) {
 		c, err := secret.NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
 		require.NoError(t, err)
-		v := secret.NewBasicSecretsManager(c)
+		v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(c))
+		require.NoError(t, err)
 		opts := NewBasicPodDefinitionManagerOptions().SetVault(v)
 		assert.Equal(t, v, opts.Vault)
 	})
@@ -145,7 +147,8 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			require.NoError(t, err)
 			smClient, err := secret.NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
 			require.NoError(t, err)
-			v := secret.NewBasicSecretsManager(smClient)
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smClient))
+			require.NoError(t, err)
 			opts := NewBasicPodDefinitionManagerOptions().
 				SetClient(ecsClient).
 				SetVault(v).
@@ -156,7 +159,8 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 		t.Run("FailsWithoutClient", func(t *testing.T) {
 			smClient, err := secret.NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
 			require.NoError(t, err)
-			v := secret.NewBasicSecretsManager(smClient)
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smClient))
+			require.NoError(t, err)
 			opts := NewBasicPodDefinitionManagerOptions().
 				SetVault(v).
 				SetCache(&testutil.NoopECSPodDefinitionCache{}).

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -98,7 +98,8 @@ func TestECSPod(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
-			v := secret.NewBasicSecretsManager(smc)
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
+			require.NoError(t, err)
 
 			pc, err := NewBasicECSPodCreator(c, v)
 			require.NoError(t, err)
@@ -145,7 +146,8 @@ func TestBasicECSPodOptions(t *testing.T) {
 	t.Run("SetVault", func(t *testing.T) {
 		c, err := secret.NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
 		require.NoError(t, err)
-		v := secret.NewBasicSecretsManager(c)
+		v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(c))
+		require.NoError(t, err)
 		opts := NewBasicECSPodOptions().SetVault(v)
 		assert.Equal(t, v, opts.Vault)
 	})
@@ -187,7 +189,8 @@ func TestBasicECSPodOptions(t *testing.T) {
 			require.NoError(t, err)
 			smClient, err := secret.NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
 			require.NoError(t, err)
-			v := secret.NewBasicSecretsManager(smClient)
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smClient))
+			require.NoError(t, err)
 			opts := NewBasicECSPodOptions().
 				SetClient(ecsClient).
 				SetVault(v).
@@ -198,7 +201,8 @@ func TestBasicECSPodOptions(t *testing.T) {
 		t.Run("FailsWithoutClient", func(t *testing.T) {
 			smClient, err := secret.NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
 			require.NoError(t, err)
-			v := secret.NewBasicSecretsManager(smClient)
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smClient))
+			require.NoError(t, err)
 			opts := NewBasicECSPodOptions().
 				SetVault(v).
 				SetResources(validResources()).

--- a/internal/testcase/ecs_client.go
+++ b/internal/testcase/ecs_client.go
@@ -52,6 +52,7 @@ func ECSClientTests() map[string]ECSClientTestCase {
 		},
 		"RegisterAndDeregisterTaskDefinitionSucceeds": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			registerOut := testutil.RegisterTaskDefinition(ctx, t, c, testutil.ValidRegisterTaskDefinitionInput(t))
+			defer cleanupTaskDefinition(ctx, t, c, &registerOut)
 			assert.Equal(t, awsECS.TaskDefinitionStatusActive, *registerOut.TaskDefinition.Status)
 			assert.NotZero(t, utility.FromTimePtr(registerOut.TaskDefinition.RegisteredAt))
 
@@ -123,14 +124,7 @@ func ECSClientTests() map[string]ECSClientTestCase {
 		},
 		"TagResourceSucceeds": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			registerOut := testutil.RegisterTaskDefinition(ctx, t, c, testutil.ValidRegisterTaskDefinitionInput(t))
-			defer func() {
-				deregisterOut, err := c.DeregisterTaskDefinition(ctx, &awsECS.DeregisterTaskDefinitionInput{
-					TaskDefinition: registerOut.TaskDefinition.TaskDefinitionArn,
-				})
-				assert.NoError(t, err)
-				assert.NotZero(t, deregisterOut)
-			}()
-
+			defer cleanupTaskDefinition(ctx, t, c, &registerOut)
 			tags := []*awsECS.Tag{
 				{
 					Key:   aws.String("some_key"),
@@ -156,13 +150,7 @@ func ECSClientTests() map[string]ECSClientTestCase {
 		},
 		"TagResourceIsIdempotent": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			registerOut := testutil.RegisterTaskDefinition(ctx, t, c, testutil.ValidRegisterTaskDefinitionInput(t))
-			defer func() {
-				deregisterOut, err := c.DeregisterTaskDefinition(ctx, &awsECS.DeregisterTaskDefinitionInput{
-					TaskDefinition: registerOut.TaskDefinition.TaskDefinitionArn,
-				})
-				assert.NoError(t, err)
-				assert.NotZero(t, deregisterOut)
-			}()
+			defer cleanupTaskDefinition(ctx, t, c, &registerOut)
 
 			tags := []*awsECS.Tag{
 				{
@@ -191,13 +179,7 @@ func ECSClientTests() map[string]ECSClientTestCase {
 		},
 		"TagResourceOverwritesExistingTagValue": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			registerOut := testutil.RegisterTaskDefinition(ctx, t, c, testutil.ValidRegisterTaskDefinitionInput(t))
-			defer func() {
-				deregisterOut, err := c.DeregisterTaskDefinition(ctx, &awsECS.DeregisterTaskDefinitionInput{
-					TaskDefinition: registerOut.TaskDefinition.TaskDefinitionArn,
-				})
-				assert.NoError(t, err)
-				assert.NotZero(t, deregisterOut)
-			}()
+			defer cleanupTaskDefinition(ctx, t, c, &registerOut)
 
 			oldTags := []*awsECS.Tag{
 				{

--- a/internal/testutil/secret.go
+++ b/internal/testutil/secret.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const projectName = "cocoa"
@@ -82,4 +83,14 @@ func cleanupSecretsWithToken(ctx context.Context, t *testing.T, c cocoa.SecretsM
 	}
 
 	return out.NextToken
+}
+
+// CreateSecret is a convenience function for creating a Secrets Manager secret
+// and verifying that the result is successful and populates the secret ARN.
+func CreateSecret(ctx context.Context, t *testing.T, c cocoa.SecretsManagerClient, in secretsmanager.CreateSecretInput) secretsmanager.CreateSecretOutput {
+	out, err := c.CreateSecret(ctx, &in)
+	require.NoError(t, err)
+	require.NotZero(t, out)
+	require.NotZero(t, out.ARN)
+	return *out
 }

--- a/internal/testutil/secret_cache.go
+++ b/internal/testutil/secret_cache.go
@@ -1,0 +1,16 @@
+package testutil
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/cocoa"
+)
+
+// NoopSecretCache is an implementation of cocoa.SecretCache that no-ops for all
+// operations.
+type NoopSecretCache struct{}
+
+// Put is a no-op.
+func (c *NoopSecretCache) Put(context.Context, cocoa.SecretCacheItem) error {
+	return nil
+}

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	awsECS "github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/cocoa/ecs"
 	"github.com/evergreen-ci/utility"
 )
 
@@ -31,7 +32,7 @@ type ECSTaskDefinition struct {
 	Deregistered  *time.Time
 }
 
-func newECSTaskDefinition(def *ecs.RegisterTaskDefinitionInput, rev int) ECSTaskDefinition {
+func newECSTaskDefinition(def *awsECS.RegisterTaskDefinitionInput, rev int) ECSTaskDefinition {
 	id := arn.ARN{
 		Partition: "aws",
 		Service:   "ecs",
@@ -45,7 +46,7 @@ func newECSTaskDefinition(def *ecs.RegisterTaskDefinitionInput, rev int) ECSTask
 		CPU:        def.Cpu,
 		MemoryMB:   def.Memory,
 		TaskRole:   def.TaskRoleArn,
-		Status:     utility.ToStringPtr(ecs.TaskDefinitionStatusActive),
+		Status:     utility.ToStringPtr(awsECS.TaskDefinitionStatusActive),
 		Registered: utility.ToTimePtr(time.Now()),
 	}
 
@@ -61,13 +62,13 @@ func newECSTaskDefinition(def *ecs.RegisterTaskDefinitionInput, rev int) ECSTask
 	return taskDef
 }
 
-func (d *ECSTaskDefinition) export() *ecs.TaskDefinition {
-	var containerDefs []*ecs.ContainerDefinition
+func (d *ECSTaskDefinition) export() *awsECS.TaskDefinition {
+	var containerDefs []*awsECS.ContainerDefinition
 	for _, def := range d.ContainerDefs {
 		containerDefs = append(containerDefs, def.export())
 	}
 
-	return &ecs.TaskDefinition{
+	return &awsECS.TaskDefinition{
 		TaskDefinitionArn:    d.ARN,
 		Family:               d.Family,
 		Revision:             d.Revision,
@@ -93,7 +94,7 @@ type ECSContainerDefinition struct {
 	Secrets  map[string]string
 }
 
-func newECSContainerDefinition(def *ecs.ContainerDefinition) ECSContainerDefinition {
+func newECSContainerDefinition(def *awsECS.ContainerDefinition) ECSContainerDefinition {
 	return ECSContainerDefinition{
 		Name:     def.Name,
 		Image:    def.Image,
@@ -105,8 +106,8 @@ func newECSContainerDefinition(def *ecs.ContainerDefinition) ECSContainerDefinit
 	}
 }
 
-func (d *ECSContainerDefinition) export() *ecs.ContainerDefinition {
-	return &ecs.ContainerDefinition{
+func (d *ECSContainerDefinition) export() *awsECS.ContainerDefinition {
+	return &awsECS.ContainerDefinition{
 		Name:        d.Name,
 		Image:       d.Image,
 		Command:     utility.ToStringPtrSlice(d.Command),
@@ -140,7 +141,7 @@ type ECSTask struct {
 	Tags              map[string]string
 }
 
-func newECSTask(in *ecs.RunTaskInput, taskDef ECSTaskDefinition) ECSTask {
+func newECSTask(in *awsECS.RunTaskInput, taskDef ECSTaskDefinition) ECSTask {
 	id := arn.ARN{
 		Partition: "aws",
 		Service:   "ecs",
@@ -153,8 +154,8 @@ func newECSTask(in *ecs.RunTaskInput, taskDef ECSTaskDefinition) ECSTask {
 		CapacityProvider: newCapacityProvider(in.CapacityProviderStrategy),
 		ExecEnabled:      in.EnableExecuteCommand,
 		Group:            in.Group,
-		Status:           utility.ToStringPtr(ecs.DesiredStatusPending),
-		GoalStatus:       utility.ToStringPtr(ecs.DesiredStatusRunning),
+		Status:           utility.ToStringPtr(awsECS.DesiredStatusPending),
+		GoalStatus:       utility.ToStringPtr(awsECS.DesiredStatusRunning),
 		Created:          utility.ToTimePtr(time.Now()),
 		TaskDef:          taskDef,
 		Tags:             newECSTags(in.Tags),
@@ -167,8 +168,8 @@ func newECSTask(in *ecs.RunTaskInput, taskDef ECSTaskDefinition) ECSTask {
 	return t
 }
 
-func (t *ECSTask) export(includeTags bool) *ecs.Task {
-	exported := ecs.Task{
+func (t *ECSTask) export(includeTags bool) *awsECS.Task {
+	exported := awsECS.Task{
 		TaskArn:              t.ARN,
 		ClusterArn:           t.Cluster,
 		CapacityProviderName: t.CapacityProvider,
@@ -185,7 +186,7 @@ func (t *ECSTask) export(includeTags bool) *ecs.Task {
 		StoppedAt:            t.Stopped,
 	}
 	if includeTags {
-		exported.Tags = exportECSTags(t.Tags)
+		exported.Tags = ecs.ExportTags(t.Tags)
 	}
 
 	for _, container := range t.Containers {
@@ -225,13 +226,13 @@ func newECSContainer(def ECSContainerDefinition, task ECSTask) ECSContainer {
 		Image:      def.Image,
 		CPU:        def.CPU,
 		MemoryMB:   def.MemoryMB,
-		Status:     utility.ToStringPtr(ecs.DesiredStatusPending),
-		GoalStatus: utility.ToStringPtr(ecs.DesiredStatusRunning),
+		Status:     utility.ToStringPtr(awsECS.DesiredStatusPending),
+		GoalStatus: utility.ToStringPtr(awsECS.DesiredStatusRunning),
 	}
 }
 
-func (c *ECSContainer) export() *ecs.Container {
-	exported := &ecs.Container{
+func (c *ECSContainer) export() *awsECS.Container {
+	exported := &awsECS.Container{
 		ContainerArn: c.ARN,
 		TaskArn:      c.TaskARN,
 		Name:         c.Name,
@@ -249,7 +250,7 @@ func (c *ECSContainer) export() *ecs.Container {
 	return exported
 }
 
-func newECSTags(tags []*ecs.Tag) map[string]string {
+func newECSTags(tags []*awsECS.Tag) map[string]string {
 	converted := map[string]string{}
 	for _, t := range tags {
 		if t == nil {
@@ -260,18 +261,7 @@ func newECSTags(tags []*ecs.Tag) map[string]string {
 	return converted
 }
 
-func exportECSTags(tags map[string]string) []*ecs.Tag {
-	var exported []*ecs.Tag
-	for k, v := range tags {
-		exported = append(exported, &ecs.Tag{
-			Key:   utility.ToStringPtr(k),
-			Value: utility.ToStringPtr(v),
-		})
-	}
-	return exported
-}
-
-func newCapacityProvider(providers []*ecs.CapacityProviderStrategyItem) *string {
+func newCapacityProvider(providers []*awsECS.CapacityProviderStrategyItem) *string {
 	if len(providers) == 0 {
 		return nil
 	}
@@ -280,7 +270,7 @@ func newCapacityProvider(providers []*ecs.CapacityProviderStrategyItem) *string 
 	return providers[0].CapacityProvider
 }
 
-func newEnvVars(envVars []*ecs.KeyValuePair) map[string]string {
+func newEnvVars(envVars []*awsECS.KeyValuePair) map[string]string {
 	converted := map[string]string{}
 	for _, envVar := range envVars {
 		if envVar == nil {
@@ -291,10 +281,10 @@ func newEnvVars(envVars []*ecs.KeyValuePair) map[string]string {
 	return converted
 }
 
-func exportEnvVars(envVars map[string]string) []*ecs.KeyValuePair {
-	var exported []*ecs.KeyValuePair
+func exportEnvVars(envVars map[string]string) []*awsECS.KeyValuePair {
+	var exported []*awsECS.KeyValuePair
 	for k, v := range envVars {
-		exported = append(exported, &ecs.KeyValuePair{
+		exported = append(exported, &awsECS.KeyValuePair{
 			Name:  utility.ToStringPtr(k),
 			Value: utility.ToStringPtr(v),
 		})
@@ -302,7 +292,7 @@ func exportEnvVars(envVars map[string]string) []*ecs.KeyValuePair {
 	return exported
 }
 
-func newSecrets(secrets []*ecs.Secret) map[string]string {
+func newSecrets(secrets []*awsECS.Secret) map[string]string {
 	converted := map[string]string{}
 	for _, secret := range secrets {
 		if secret == nil {
@@ -313,10 +303,10 @@ func newSecrets(secrets []*ecs.Secret) map[string]string {
 	return converted
 }
 
-func exportSecrets(secrets map[string]string) []*ecs.Secret {
-	var exported []*ecs.Secret
+func exportSecrets(secrets map[string]string) []*awsECS.Secret {
+	var exported []*awsECS.Secret
 	for k, v := range secrets {
-		exported = append(exported, &ecs.Secret{
+		exported = append(exported, &awsECS.Secret{
 			Name:      utility.ToStringPtr(k),
 			ValueFrom: utility.ToStringPtr(v),
 		})
@@ -367,7 +357,7 @@ func (s *ECSService) getLatestTaskDefinition(id string) (*ECSTaskDefinition, err
 	}
 
 	for i := len(revisions) - 1; i >= 0; i-- {
-		if utility.FromStringPtr(revisions[i].Status) == ecs.TaskDefinitionStatusActive {
+		if utility.FromStringPtr(revisions[i].Status) == awsECS.TaskDefinitionStatusActive {
 			return &revisions[i], nil
 		}
 	}
@@ -439,40 +429,40 @@ func (s *ECSService) taskDefIndexFromARN(arn string) (family string, revNum int,
 // output. It provides some default implementations where possible. For unmocked
 // methods, it will issue the API calls to the fake GlobalECSService.
 type ECSClient struct {
-	RegisterTaskDefinitionInput  *ecs.RegisterTaskDefinitionInput
-	RegisterTaskDefinitionOutput *ecs.RegisterTaskDefinitionOutput
+	RegisterTaskDefinitionInput  *awsECS.RegisterTaskDefinitionInput
+	RegisterTaskDefinitionOutput *awsECS.RegisterTaskDefinitionOutput
 	RegisterTaskDefinitionError  error
 
-	DescribeTaskDefinitionInput  *ecs.DescribeTaskDefinitionInput
-	DescribeTaskDefinitionOutput *ecs.DescribeTaskDefinitionOutput
+	DescribeTaskDefinitionInput  *awsECS.DescribeTaskDefinitionInput
+	DescribeTaskDefinitionOutput *awsECS.DescribeTaskDefinitionOutput
 	DescribeTaskDefinitionError  error
 
-	ListTaskDefinitionsInput  *ecs.ListTaskDefinitionsInput
-	ListTaskDefinitionsOutput *ecs.ListTaskDefinitionsOutput
+	ListTaskDefinitionsInput  *awsECS.ListTaskDefinitionsInput
+	ListTaskDefinitionsOutput *awsECS.ListTaskDefinitionsOutput
 	ListTaskDefinitionsError  error
 
-	DeregisterTaskDefinitionInput  *ecs.DeregisterTaskDefinitionInput
-	DeregisterTaskDefinitionOutput *ecs.DeregisterTaskDefinitionOutput
+	DeregisterTaskDefinitionInput  *awsECS.DeregisterTaskDefinitionInput
+	DeregisterTaskDefinitionOutput *awsECS.DeregisterTaskDefinitionOutput
 	DeregisterTaskDefinitionError  error
 
-	RunTaskInput  *ecs.RunTaskInput
-	RunTaskOutput *ecs.RunTaskOutput
+	RunTaskInput  *awsECS.RunTaskInput
+	RunTaskOutput *awsECS.RunTaskOutput
 	RunTaskError  error
 
-	DescribeTasksInput  *ecs.DescribeTasksInput
-	DescribeTasksOutput *ecs.DescribeTasksOutput
+	DescribeTasksInput  *awsECS.DescribeTasksInput
+	DescribeTasksOutput *awsECS.DescribeTasksOutput
 	DescribeTasksError  error
 
-	ListTasksInput  *ecs.ListTasksInput
-	ListTasksOutput *ecs.ListTasksOutput
+	ListTasksInput  *awsECS.ListTasksInput
+	ListTasksOutput *awsECS.ListTasksOutput
 	ListTasksError  error
 
-	StopTaskInput  *ecs.StopTaskInput
-	StopTaskOutput *ecs.StopTaskOutput
+	StopTaskInput  *awsECS.StopTaskInput
+	StopTaskOutput *awsECS.StopTaskOutput
 	StopTaskError  error
 
-	TagResourceInput  *ecs.TagResourceInput
-	TagResourceOutput *ecs.TagResourceOutput
+	TagResourceInput  *awsECS.TagResourceInput
+	TagResourceOutput *awsECS.TagResourceOutput
 	TagResourceError  error
 
 	CloseError error
@@ -481,7 +471,7 @@ type ECSClient struct {
 // RegisterTaskDefinition saves the input and returns a new mock task
 // definition. The mock output can be customized. By default, it will create a
 // cached task definition based on the input.
-func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
+func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *awsECS.RegisterTaskDefinitionInput) (*awsECS.RegisterTaskDefinitionOutput, error) {
 	c.RegisterTaskDefinitionInput = in
 
 	if c.RegisterTaskDefinitionOutput != nil || c.RegisterTaskDefinitionError != nil {
@@ -489,7 +479,7 @@ func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.Register
 	}
 
 	if in.Family == nil {
-		return nil, awserr.New(ecs.ErrCodeInvalidParameterException, "missing family", nil)
+		return nil, awserr.New(awsECS.ErrCodeInvalidParameterException, "missing family", nil)
 	}
 
 	revisions := GlobalECSService.TaskDefs[utility.FromStringPtr(in.Family)]
@@ -499,7 +489,7 @@ func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.Register
 
 	GlobalECSService.TaskDefs[utility.FromStringPtr(in.Family)] = append(revisions, taskDef)
 
-	return &ecs.RegisterTaskDefinitionOutput{
+	return &awsECS.RegisterTaskDefinitionOutput{
 		TaskDefinition: taskDef.export(),
 		Tags:           in.Tags,
 	}, nil
@@ -508,7 +498,7 @@ func (c *ECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.Register
 // DescribeTaskDefinition saves the input and returns information about the
 // matching task definition. The mock output can be customized. By default, it
 // will return the task definition information if it exists.
-func (c *ECSClient) DescribeTaskDefinition(ctx context.Context, in *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
+func (c *ECSClient) DescribeTaskDefinition(ctx context.Context, in *awsECS.DescribeTaskDefinitionInput) (*awsECS.DescribeTaskDefinitionOutput, error) {
 	c.DescribeTaskDefinitionInput = in
 
 	if c.DescribeTaskDefinitionOutput != nil || c.DescribeTaskDefinitionError != nil {
@@ -519,14 +509,14 @@ func (c *ECSClient) DescribeTaskDefinition(ctx context.Context, in *ecs.Describe
 
 	def, err := GlobalECSService.getLatestTaskDefinition(id)
 	if err != nil {
-		return nil, awserr.New(ecs.ErrCodeResourceNotFoundException, "task definition not found", err)
+		return nil, awserr.New(awsECS.ErrCodeResourceNotFoundException, "task definition not found", err)
 	}
 
-	resp := ecs.DescribeTaskDefinitionOutput{
+	resp := awsECS.DescribeTaskDefinitionOutput{
 		TaskDefinition: def.export(),
 	}
 	if shouldIncludeTags(in.Include) {
-		resp.Tags = exportECSTags(def.Tags)
+		resp.Tags = ecs.ExportTags(def.Tags)
 	}
 
 	return &resp, nil
@@ -535,7 +525,7 @@ func (c *ECSClient) DescribeTaskDefinition(ctx context.Context, in *ecs.Describe
 // ListTaskDefinitions saves the input and lists all matching task definitions.
 // The mock output can be customized. By default, it will list all cached task
 // definitions that match the input filters.
-func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDefinitionsInput) (*ecs.ListTaskDefinitionsOutput, error) {
+func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *awsECS.ListTaskDefinitionsInput) (*awsECS.ListTaskDefinitionsOutput, error) {
 	c.ListTaskDefinitionsInput = in
 
 	if c.ListTaskDefinitionsOutput != nil || c.ListTaskDefinitionsError != nil {
@@ -556,7 +546,7 @@ func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDef
 		}
 	}
 
-	return &ecs.ListTaskDefinitionsOutput{
+	return &awsECS.ListTaskDefinitionsOutput{
 		TaskDefinitionArns: arns,
 	}, nil
 }
@@ -564,7 +554,7 @@ func (c *ECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDef
 // DeregisterTaskDefinition saves the input and deletes an existing mock task
 // definition. The mock output can be customized. By default, it will delete a
 // cached task definition if it exists.
-func (c *ECSClient) DeregisterTaskDefinition(ctx context.Context, in *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error) {
+func (c *ECSClient) DeregisterTaskDefinition(ctx context.Context, in *awsECS.DeregisterTaskDefinitionInput) (*awsECS.DeregisterTaskDefinitionOutput, error) {
 	c.DeregisterTaskDefinitionInput = in
 
 	if c.DeregisterTaskDefinitionOutput != nil || c.DeregisterTaskDefinitionError != nil {
@@ -572,21 +562,21 @@ func (c *ECSClient) DeregisterTaskDefinition(ctx context.Context, in *ecs.Deregi
 	}
 
 	if in.TaskDefinition == nil {
-		return nil, awserr.New(ecs.ErrCodeInvalidParameterException, "missing task definition", nil)
+		return nil, awserr.New(awsECS.ErrCodeInvalidParameterException, "missing task definition", nil)
 	}
 
 	id := utility.FromStringPtr(in.TaskDefinition)
 
 	def, err := GlobalECSService.getTaskDefinition(id)
 	if err != nil {
-		return nil, awserr.New(ecs.ErrCodeResourceNotFoundException, "task definition not found", err)
+		return nil, awserr.New(awsECS.ErrCodeResourceNotFoundException, "task definition not found", err)
 	}
 
-	def.Status = utility.ToStringPtr(ecs.TaskDefinitionStatusInactive)
+	def.Status = utility.ToStringPtr(awsECS.TaskDefinitionStatusInactive)
 	def.Deregistered = utility.ToTimePtr(time.Now())
 	GlobalECSService.TaskDefs[utility.FromStringPtr(def.Family)][utility.FromInt64Ptr(def.Revision)-1] = *def
 
-	return &ecs.DeregisterTaskDefinitionOutput{
+	return &awsECS.DeregisterTaskDefinitionOutput{
 		TaskDefinition: def.export(),
 	}, nil
 }
@@ -594,7 +584,7 @@ func (c *ECSClient) DeregisterTaskDefinition(ctx context.Context, in *ecs.Deregi
 // RunTask saves the input options and returns the mock result of running a task
 // definition. The mock output can be customized. By default, it will create
 // mock output based on the input.
-func (c *ECSClient) RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
+func (c *ECSClient) RunTask(ctx context.Context, in *awsECS.RunTaskInput) (*awsECS.RunTaskOutput, error) {
 	c.RunTaskInput = in
 
 	if c.RunTaskOutput != nil || c.RunTaskError != nil {
@@ -602,28 +592,28 @@ func (c *ECSClient) RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.Run
 	}
 
 	if in.TaskDefinition == nil {
-		return nil, awserr.New(ecs.ErrCodeInvalidParameterException, "missing task definition", nil)
+		return nil, awserr.New(awsECS.ErrCodeInvalidParameterException, "missing task definition", nil)
 	}
 
 	clusterName := c.getOrDefaultCluster(in.Cluster)
 	cluster, ok := GlobalECSService.Clusters[clusterName]
 	if !ok {
-		return nil, awserr.New(ecs.ErrCodeResourceNotFoundException, "cluster not found", nil)
+		return nil, awserr.New(awsECS.ErrCodeResourceNotFoundException, "cluster not found", nil)
 	}
 
 	taskDefID := utility.FromStringPtr(in.TaskDefinition)
 
 	def, err := GlobalECSService.getLatestTaskDefinition(taskDefID)
 	if err != nil {
-		return nil, awserr.New(ecs.ErrCodeResourceNotFoundException, "task definition not found", err)
+		return nil, awserr.New(awsECS.ErrCodeResourceNotFoundException, "task definition not found", err)
 	}
 
 	task := newECSTask(in, *def)
 
 	cluster[utility.FromStringPtr(task.ARN)] = task
 
-	return &ecs.RunTaskOutput{
-		Tasks: []*ecs.Task{task.export(true)},
+	return &awsECS.RunTaskOutput{
+		Tasks: []*awsECS.Task{task.export(true)},
 	}, nil
 }
 
@@ -637,7 +627,7 @@ func (c *ECSClient) getOrDefaultCluster(name *string) string {
 // DescribeTasks saves the input and returns information about the existing
 // tasks. The mock output can be customized. By default, it will describe all
 // cached tasks that match.
-func (c *ECSClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
+func (c *ECSClient) DescribeTasks(ctx context.Context, in *awsECS.DescribeTasksInput) (*awsECS.DescribeTasksOutput, error) {
 	c.DescribeTasksInput = in
 
 	if c.DescribeTasksOutput != nil || c.DescribeTasksError != nil {
@@ -646,18 +636,18 @@ func (c *ECSClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInpu
 
 	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]
 	if !ok {
-		return nil, awserr.New(ecs.ErrCodeResourceNotFoundException, "cluster not found", nil)
+		return nil, awserr.New(awsECS.ErrCodeResourceNotFoundException, "cluster not found", nil)
 	}
 
 	includeTags := shouldIncludeTags(in.Include)
 	ids := utility.FromStringPtrSlice(in.Tasks)
 
-	var tasks []*ecs.Task
-	var failures []*ecs.Failure
+	var tasks []*awsECS.Task
+	var failures []*awsECS.Failure
 	for _, id := range ids {
 		task, ok := cluster[id]
 		if !ok {
-			failures = append(failures, &ecs.Failure{
+			failures = append(failures, &awsECS.Failure{
 				Arn: utility.ToStringPtr(id),
 				// This reason specifically matches the one returned by ECS when
 				// it cannot find the task.
@@ -669,7 +659,7 @@ func (c *ECSClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInpu
 		tasks = append(tasks, task.export(includeTags))
 	}
 
-	return &ecs.DescribeTasksOutput{
+	return &awsECS.DescribeTasksOutput{
 		Tasks:    tasks,
 		Failures: failures,
 	}, nil
@@ -691,7 +681,7 @@ func shouldIncludeTags(includes []*string) bool {
 // ListTasks saves the input and lists all matching tasks. The mock output can
 // be customized. By default, it will list all cached task definitions that
 // match the input filters.
-func (c *ECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
+func (c *ECSClient) ListTasks(ctx context.Context, in *awsECS.ListTasksInput) (*awsECS.ListTasksOutput, error) {
 	c.ListTasksInput = in
 
 	if c.ListTasksOutput != nil || c.ListTasksError != nil {
@@ -700,7 +690,7 @@ func (c *ECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs
 
 	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]
 	if !ok {
-		return &ecs.ListTasksOutput{}, nil
+		return &awsECS.ListTasksOutput{}, nil
 	}
 
 	var arns []string
@@ -720,7 +710,7 @@ func (c *ECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs
 		arns = append(arns, arn)
 	}
 
-	return &ecs.ListTasksOutput{
+	return &awsECS.ListTasksOutput{
 		TaskArns: utility.ToStringPtrSlice(arns),
 	}, nil
 }
@@ -728,7 +718,7 @@ func (c *ECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs
 // StopTask saves the input and stops a mock task. The mock output can be
 // customized. By default, it will mark a cached task as stopped if it exists
 // and is running.
-func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.StopTaskOutput, error) {
+func (c *ECSClient) StopTask(ctx context.Context, in *awsECS.StopTaskInput) (*awsECS.StopTaskOutput, error) {
 	c.StopTaskInput = in
 
 	if c.StopTaskOutput != nil || c.StopTaskError != nil {
@@ -737,7 +727,7 @@ func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.S
 
 	cluster, ok := GlobalECSService.Clusters[c.getOrDefaultCluster(in.Cluster)]
 	if !ok {
-		return nil, awserr.New(ecs.ErrCodeResourceNotFoundException, "cluster not found", nil)
+		return nil, awserr.New(awsECS.ErrCodeResourceNotFoundException, "cluster not found", nil)
 	}
 
 	task, ok := cluster[utility.FromStringPtr(in.Task)]
@@ -745,18 +735,18 @@ func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.S
 		return nil, cocoa.NewECSTaskNotFoundError(utility.FromStringPtr(in.Task))
 	}
 
-	task.Status = utility.ToStringPtr(ecs.DesiredStatusStopped)
-	task.GoalStatus = utility.ToStringPtr(ecs.DesiredStatusStopped)
-	task.StopCode = utility.ToStringPtr(ecs.TaskStopCodeUserInitiated)
+	task.Status = utility.ToStringPtr(awsECS.DesiredStatusStopped)
+	task.GoalStatus = utility.ToStringPtr(awsECS.DesiredStatusStopped)
+	task.StopCode = utility.ToStringPtr(awsECS.TaskStopCodeUserInitiated)
 	task.StopReason = in.Reason
 	task.Stopped = utility.ToTimePtr(time.Now())
 	for i := range task.Containers {
-		task.Containers[i].Status = utility.ToStringPtr(ecs.DesiredStatusStopped)
+		task.Containers[i].Status = utility.ToStringPtr(awsECS.DesiredStatusStopped)
 	}
 
 	cluster[utility.FromStringPtr(in.Task)] = task
 
-	return &ecs.StopTaskOutput{
+	return &awsECS.StopTaskOutput{
 		Task: task.export(true),
 	}, nil
 }
@@ -764,7 +754,7 @@ func (c *ECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.S
 // TagResource saves the input and tags a mock task or task definition. The mock
 // output can be customized. By default, it will add the tag to the resource if
 // it exists.
-func (c *ECSClient) TagResource(ctx context.Context, in *ecs.TagResourceInput) (*ecs.TagResourceOutput, error) {
+func (c *ECSClient) TagResource(ctx context.Context, in *awsECS.TagResourceInput) (*awsECS.TagResourceOutput, error) {
 	c.TagResourceInput = in
 
 	if c.TagResourceOutput != nil || c.TagResourceError != nil {
@@ -778,7 +768,7 @@ func (c *ECSClient) TagResource(ctx context.Context, in *ecs.TagResourceInput) (
 		for k, v := range newECSTags(in.Tags) {
 			taskDef.Tags[k] = v
 		}
-		return &ecs.TagResourceOutput{}, nil
+		return &awsECS.TagResourceOutput{}, nil
 	}
 
 	for _, cluster := range GlobalECSService.Clusters {
@@ -790,10 +780,10 @@ func (c *ECSClient) TagResource(ctx context.Context, in *ecs.TagResourceInput) (
 			task.Tags[k] = v
 		}
 		cluster[id] = task
-		return &ecs.TagResourceOutput{}, nil
+		return &awsECS.TagResourceOutput{}, nil
 	}
 
-	return nil, awserr.New(ecs.ErrCodeResourceNotFoundException, "task or task definition not found", nil)
+	return nil, awserr.New(awsECS.ErrCodeResourceNotFoundException, "task or task definition not found", nil)
 }
 
 // Close closes the mock client. The mock output can be customized. By default,

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -47,9 +47,11 @@ func TestECSPodCreator(t *testing.T) {
 				assert.NoError(t, sm.Close(tctx))
 			}()
 
-			v := NewVault(secret.NewBasicSecretsManager(sm))
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(sm))
+			require.NoError(t, err)
+			mv := NewVault(v)
 
-			pc, err := ecs.NewBasicECSPodCreator(c, v)
+			pc, err := ecs.NewBasicECSPodCreator(c, mv)
 			require.NoError(t, err)
 
 			mpc := NewECSPodCreator(pc)
@@ -96,9 +98,11 @@ func TestECSPodCreator(t *testing.T) {
 				assert.NoError(t, sm.Close(tctx))
 			}()
 
-			v := NewVault(secret.NewBasicSecretsManager(sm))
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(sm))
+			require.NoError(t, err)
+			mv := NewVault(v)
 
-			pc, err := ecs.NewBasicECSPodCreator(c, v)
+			pc, err := ecs.NewBasicECSPodCreator(c, mv)
 			require.NoError(t, err)
 
 			mpc := NewECSPodCreator(pc)

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -42,9 +42,12 @@ func TestECSPod(t *testing.T) {
 			defer func() {
 				assert.NoError(t, smc.Close(tctx))
 			}()
-			v := NewVault(secret.NewBasicSecretsManager(smc))
 
-			pc, err := ecs.NewBasicECSPodCreator(c, v)
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
+			require.NoError(t, err)
+			mv := NewVault(v)
+
+			pc, err := ecs.NewBasicECSPodCreator(c, mv)
 			require.NoError(t, err)
 			mpc := NewECSPodCreator(pc)
 
@@ -68,9 +71,12 @@ func TestECSPod(t *testing.T) {
 			defer func() {
 				assert.NoError(t, smc.Close(tctx))
 			}()
-			v := NewVault(secret.NewBasicSecretsManager(smc))
 
-			pc, err := ecs.NewBasicECSPodCreator(c, v)
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
+			require.NoError(t, err)
+			mv := NewVault(v)
+
+			pc, err := ecs.NewBasicECSPodCreator(c, mv)
 			require.NoError(t, err)
 			mpc := NewECSPodCreator(pc)
 
@@ -321,7 +327,10 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			assert.Error(t, noVault.Delete(ctx), "should fail when deleting the pod secrets")
 			assert.Equal(t, cocoa.StatusStopped, noVault.StatusInfo().Status)
 
-			podOpts.SetVault(NewVault(secret.NewBasicSecretsManager(smc)))
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
+			require.NoError(t, err)
+			podOpts.SetVault(NewVault(v))
+
 			withVault, err := makePod(podOpts)
 			require.NoError(t, err)
 

--- a/mock/secret_cache.go
+++ b/mock/secret_cache.go
@@ -1,0 +1,36 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/cocoa"
+)
+
+// SecretCache provides a mock implementation of a cocoa.SecretCache backed by
+// another secret cache implementation.
+type SecretCache struct {
+	cocoa.SecretCache
+
+	PutInput *cocoa.SecretCacheItem
+	PutError error
+}
+
+// NewSecretCache creates a mock secret cache backed by the given secret cache.
+func NewSecretCache(sc cocoa.SecretCache) *SecretCache {
+	return &SecretCache{
+		SecretCache: sc,
+	}
+}
+
+// Put adds the secret to the mock cache. The mock output can be customized. By
+// default, it will return the result of putting the secret in the backing
+// secret cache.
+func (c *SecretCache) Put(ctx context.Context, item cocoa.SecretCacheItem) error {
+	c.PutInput = &item
+
+	if c.PutError != nil {
+		return c.PutError
+	}
+
+	return c.SecretCache.Put(ctx, item)
+}

--- a/mock/secret_cache_test.go
+++ b/mock/secret_cache_test.go
@@ -1,0 +1,12 @@
+package mock
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/cocoa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecretCache(t *testing.T) {
+	assert.Implements(t, (*cocoa.SecretCache)(nil), &SecretCache{})
+}

--- a/mock/secrets_manager_vault_test.go
+++ b/mock/secrets_manager_vault_test.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
+	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/cocoa/secret"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,6 +19,33 @@ func TestVaultWithSecretsManager(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	for tName, tCase := range secretsManagerVaultTests() {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
+			defer tcancel()
+
+			resetECSAndSecretsManagerCache()
+
+			c := &SecretsManagerClient{}
+			defer func() {
+				assert.NoError(t, c.Close(tctx))
+			}()
+
+			sc := NewSecretCache(&testutil.NoopSecretCache{})
+
+			const cacheTag = "cache_tag"
+
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().
+				SetClient(c).
+				SetCache(sc).
+				SetCacheTag(cacheTag))
+			require.NoError(t, err)
+			mv := NewVault(v)
+
+			tCase(tctx, t, mv, sc, c, cacheTag)
+		})
+	}
 
 	cleanupSecret := func(ctx context.Context, t *testing.T, v cocoa.Vault, id string) {
 		if id != "" {
@@ -36,9 +66,80 @@ func TestVaultWithSecretsManager(t *testing.T) {
 			defer func() {
 				assert.NoError(t, c.Close(tctx))
 			}()
-			v := NewVault(secret.NewBasicSecretsManager(c))
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(c))
+			require.NoError(t, err)
+			mv := NewVault(v)
 
-			tCase(tctx, t, v)
+			tCase(tctx, t, mv)
 		})
+	}
+}
+
+// secretsManagerVaultTests are mock-specific tests for the Secrets Manager
+// vault with a cache.
+func secretsManagerVaultTests() map[string]func(ctx context.Context, t *testing.T, v cocoa.Vault, sc *SecretCache, c *SecretsManagerClient, cacheTag string) {
+	return map[string]func(ctx context.Context, t *testing.T, v cocoa.Vault, sc *SecretCache, c *SecretsManagerClient, cacheTag string){
+		"CreateSecretSucceedsAndCaches": func(ctx context.Context, t *testing.T, v cocoa.Vault, sc *SecretCache, c *SecretsManagerClient, cacheTag string) {
+			ns := cocoa.NewNamedSecret().
+				SetName(testutil.NewSecretName(t)).
+				SetValue("value")
+			id, err := v.CreateSecret(ctx, *ns)
+			require.NoError(t, err)
+			require.NotZero(t, id)
+
+			require.NotZero(t, c.CreateSecretInput, "should have created a secret")
+
+			assert.Equal(t, utility.FromStringPtr(ns.Name), utility.FromStringPtr(c.CreateSecretInput.Name))
+			assert.Equal(t, utility.FromStringPtr(ns.Value), utility.FromStringPtr(c.CreateSecretInput.SecretString))
+			require.Len(t, c.CreateSecretInput.Tags, 1, "should have a cache tracking tag")
+			assert.Equal(t, cacheTag, utility.FromStringPtr(c.CreateSecretInput.Tags[0].Key))
+			assert.Equal(t, "false", utility.FromStringPtr(c.CreateSecretInput.Tags[0].Value), "cache tag should initially mark secret as uncached before caching")
+
+			require.NotZero(t, sc.PutInput, "should have cache the secret")
+			assert.Equal(t, id, sc.PutInput.ID)
+			assert.Equal(t, utility.FromStringPtr(ns.Name), sc.PutInput.Name)
+
+			require.NotZero(t, c.TagResourceInput, "should have re-tagged resource to indicate that it's cached")
+			assert.Equal(t, id, utility.FromStringPtr(c.TagResourceInput.SecretId))
+			require.Len(t, c.TagResourceInput.Tags, 1)
+			assert.Equal(t, cacheTag, utility.FromStringPtr(c.TagResourceInput.Tags[0].Key))
+			assert.Equal(t, "true", utility.FromStringPtr(c.TagResourceInput.Tags[0].Value), "cache tag should be marked as cached")
+		},
+		"CreateSecretTagsStrandedSecretAsUncachedWhenCachingFails": func(ctx context.Context, t *testing.T, v cocoa.Vault, sc *SecretCache, c *SecretsManagerClient, cacheTag string) {
+			sc.PutError = errors.New("fake error")
+
+			ns := cocoa.NewNamedSecret().
+				SetName(testutil.NewSecretName(t)).
+				SetValue("value")
+			id, err := v.CreateSecret(ctx, *ns)
+			assert.Error(t, err, "should have failed to cache the secret")
+			assert.Zero(t, id)
+
+			require.NotZero(t, c.CreateSecretInput, "should have created a secret")
+
+			assert.Equal(t, utility.FromStringPtr(ns.Name), utility.FromStringPtr(c.CreateSecretInput.Name))
+			assert.Equal(t, utility.FromStringPtr(ns.Value), utility.FromStringPtr(c.CreateSecretInput.SecretString))
+			require.Len(t, c.CreateSecretInput.Tags, 1, "should have cache tracking tag")
+			assert.Equal(t, cacheTag, utility.FromStringPtr(c.CreateSecretInput.Tags[0].Key))
+			assert.Equal(t, "false", utility.FromStringPtr(c.CreateSecretInput.Tags[0].Value), "cache tag should initially mark secret as uncached")
+
+			assert.NotZero(t, sc.PutInput, "should have attempted to cache the secret")
+			assert.Zero(t, c.TagResourceInput, "should not have re-tagged secret because it is not cached")
+		},
+		"CreateSecretDoesNotCacheWhenCreatingSecretFails": func(ctx context.Context, t *testing.T, v cocoa.Vault, sc *SecretCache, c *SecretsManagerClient, cacheTag string) {
+			c.CreateSecretError = errors.New("fake error")
+
+			ns := cocoa.NewNamedSecret().
+				SetName(testutil.NewSecretName(t)).
+				SetValue("value")
+
+			id, err := v.CreateSecret(ctx, *ns)
+			assert.Error(t, err, "shoud have failed to register task definition")
+			assert.Zero(t, id)
+
+			assert.NotZero(t, c.CreateSecretInput, "should have attempted to create a secret")
+
+			assert.Zero(t, sc.PutInput, "should not have attempted to cache the secret after secret creation failed")
+		},
 	}
 }

--- a/mock/vault_test.go
+++ b/mock/vault_test.go
@@ -1,0 +1,12 @@
+package mock
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/cocoa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVault(t *testing.T) {
+	assert.Implements(t, (*cocoa.Vault)(nil), &Vault{})
+}

--- a/secret/secrets_manager_vault.go
+++ b/secret/secrets_manager_vault.go
@@ -2,8 +2,11 @@ package secret
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,14 +17,75 @@ import (
 // BasicSecretsManager provides a cocoa.Vault implementation backed by AWS
 // Secrets Manager.
 type BasicSecretsManager struct {
-	client cocoa.SecretsManagerClient
+	client   cocoa.SecretsManagerClient
+	cache    cocoa.SecretCache
+	cacheTag string
+}
+
+// BasicSecretsManagerOptions are options to create a basic Secrets Manager
+// vault that's optionally backed by a cache.
+type BasicSecretsManagerOptions struct {
+	Client   cocoa.SecretsManagerClient
+	Cache    cocoa.SecretCache
+	CacheTag *string
+}
+
+// NewBasicSecretsManagerOptions returns new uninitialized options to create a
+// basic Secrets Manager vault.
+func NewBasicSecretsManagerOptions() *BasicSecretsManagerOptions {
+	return &BasicSecretsManagerOptions{}
+}
+
+// SetClient sets the client that the vault uses to communicate with Secrets
+// Manager.
+func (o *BasicSecretsManagerOptions) SetClient(c cocoa.SecretsManagerClient) *BasicSecretsManagerOptions {
+	o.Client = c
+	return o
+}
+
+// SetCache sets the cache used to track secrets externally.
+func (o *BasicSecretsManagerOptions) SetCache(sc cocoa.SecretCache) *BasicSecretsManagerOptions {
+	o.Cache = sc
+	return o
+}
+
+// SetCacheTag sets the tag used to track pod definitions in the cloud.
+func (o *BasicSecretsManagerOptions) SetCacheTag(tag string) *BasicSecretsManagerOptions {
+	o.CacheTag = &tag
+	return o
+}
+
+var (
+	defaultCacheTrackingTag = "cocoa-tracked"
+)
+
+// Validate checks that the required parameters to initialize a Secrets Manager
+// vault are given.
+func (o *BasicSecretsManagerOptions) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(o.Client == nil, "must specify a client")
+	catcher.NewWhen(o.CacheTag != nil && o.Cache == nil, "cannot specify a cache tracking tag when there is no cache")
+	if catcher.HasErrors() {
+		return catcher.Resolve()
+	}
+
+	if o.CacheTag == nil {
+		o.CacheTag = &defaultCacheTrackingTag
+	}
+
+	return nil
 }
 
 // NewBasicSecretsManager creates a Vault backed by AWS Secrets Manager.
-func NewBasicSecretsManager(c cocoa.SecretsManagerClient) *BasicSecretsManager {
-	return &BasicSecretsManager{
-		client: c,
+func NewBasicSecretsManager(opts BasicSecretsManagerOptions) (*BasicSecretsManager, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid options")
 	}
+	return &BasicSecretsManager{
+		client:   opts.Client,
+		cache:    opts.Cache,
+		cacheTag: utility.FromStringPtr(opts.CacheTag),
+	}, nil
 }
 
 // CreateSecret creates a new secret. If the secret already exists, it will
@@ -31,10 +95,20 @@ func (m *BasicSecretsManager) CreateSecret(ctx context.Context, s cocoa.NamedSec
 	if err := s.Validate(); err != nil {
 		return "", errors.Wrap(err, "invalid secret")
 	}
-	out, err := m.client.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+	in := &secretsmanager.CreateSecretInput{
 		Name:         s.Name,
 		SecretString: s.Value,
-	})
+	}
+	if m.shouldCache() {
+		// If the secret needs to be cached, we could successfully create a
+		// cloud secret but fail to cache it. Adding a tag makes it possible to
+		// track whether the secret has been created but has not been
+		// successfully cached. In that case, the application can query Secrets
+		// Manager for secrets that are tagged as untracked to clean them up.
+		in.Tags = exportTags(map[string]string{m.cacheTag: strconv.FormatBool(false)})
+	}
+
+	out, err := m.client.CreateSecret(ctx, in)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == secretsmanager.ErrCodeResourceExistsException {
 			// The secret already exists, so describe it to get the ARN.
@@ -52,7 +126,32 @@ func (m *BasicSecretsManager) CreateSecret(ctx context.Context, s cocoa.NamedSec
 	if out == nil || out.ARN == nil {
 		return "", errors.New("expected an ID in the response, but none was returned from Secrets Manager")
 	}
-	return *out.ARN, nil
+
+	arn := utility.FromStringPtr(out.ARN)
+
+	if !m.shouldCache() {
+		return arn, nil
+	}
+
+	item := cocoa.SecretCacheItem{
+		ID:   arn,
+		Name: utility.FromStringPtr(s.Name),
+	}
+
+	if err := m.cache.Put(ctx, item); err != nil {
+		return "", errors.Wrapf(err, "adding secret cache item '%s' named '%s' to cache", item.ID, item.Name)
+	}
+
+	// Now that the secret is being tracked in the cache, re-tag it to indicate
+	// that it's being tracked.
+	if _, err := m.client.TagResource(ctx, &secretsmanager.TagResourceInput{
+		SecretId: aws.String(arn),
+		Tags:     exportTags(map[string]string{m.cacheTag: strconv.FormatBool(true)}),
+	}); err != nil {
+		return "", errors.Wrapf(err, "re-tagging secret cache item '%s' named '%s' to indicate that it is tracked", item.ID, item.Name)
+	}
+
+	return arn, nil
 }
 
 // GetValue returns an existing secret's decrypted value.
@@ -85,6 +184,8 @@ func (m *BasicSecretsManager) UpdateValue(ctx context.Context, s cocoa.NamedSecr
 
 // DeleteSecret deletes an existing secret.
 // If the secret does not exist, this will perform no operation.
+// kim: TODO: mark the cached secret as preparing to delete, then delete, then
+// mark as deleted.
 func (m *BasicSecretsManager) DeleteSecret(ctx context.Context, id string) error {
 	if id == "" {
 		return errors.New("must specify a non-empty ID")
@@ -94,4 +195,23 @@ func (m *BasicSecretsManager) DeleteSecret(ctx context.Context, id string) error
 		SecretId:                   &id,
 	})
 	return err
+}
+
+// shouldCache
+func (m *BasicSecretsManager) shouldCache() bool {
+	return m.cache != nil
+}
+
+// exportTags converts a mapping of tag names to values into Secrets Manager
+// tags.
+func exportTags(tags map[string]string) []*secretsmanager.Tag {
+	var smTags []*secretsmanager.Tag
+
+	for k, v := range tags {
+		var tag secretsmanager.Tag
+		tag.SetKey(k).SetValue(v)
+		smTags = append(smTags, &tag)
+	}
+
+	return smTags
 }

--- a/secret/secrets_manager_vault.go
+++ b/secret/secrets_manager_vault.go
@@ -105,7 +105,7 @@ func (m *BasicSecretsManager) CreateSecret(ctx context.Context, s cocoa.NamedSec
 		// track whether the secret has been created but has not been
 		// successfully cached. In that case, the application can query Secrets
 		// Manager for secrets that are tagged as untracked to clean them up.
-		in.Tags = exportTags(map[string]string{m.cacheTag: strconv.FormatBool(false)})
+		in.Tags = ExportTags(map[string]string{m.cacheTag: strconv.FormatBool(false)})
 	}
 
 	out, err := m.client.CreateSecret(ctx, in)
@@ -146,7 +146,7 @@ func (m *BasicSecretsManager) CreateSecret(ctx context.Context, s cocoa.NamedSec
 	// that it's being tracked.
 	if _, err := m.client.TagResource(ctx, &secretsmanager.TagResourceInput{
 		SecretId: aws.String(arn),
-		Tags:     exportTags(map[string]string{m.cacheTag: strconv.FormatBool(true)}),
+		Tags:     ExportTags(map[string]string{m.cacheTag: strconv.FormatBool(true)}),
 	}); err != nil {
 		return "", errors.Wrapf(err, "re-tagging secret cache item '%s' named '%s' to indicate that it is tracked", item.ID, item.Name)
 	}
@@ -199,9 +199,9 @@ func (m *BasicSecretsManager) shouldCache() bool {
 	return m.cache != nil
 }
 
-// exportTags converts a mapping of tag names to values into Secrets Manager
+// ExportTags converts a mapping of tag names to values into Secrets Manager
 // tags.
-func exportTags(tags map[string]string) []*secretsmanager.Tag {
+func ExportTags(tags map[string]string) []*secretsmanager.Tag {
 	var smTags []*secretsmanager.Tag
 
 	for k, v := range tags {

--- a/secret/secrets_manager_vault.go
+++ b/secret/secrets_manager_vault.go
@@ -184,8 +184,6 @@ func (m *BasicSecretsManager) UpdateValue(ctx context.Context, s cocoa.NamedSecr
 
 // DeleteSecret deletes an existing secret.
 // If the secret does not exist, this will perform no operation.
-// kim: TODO: mark the cached secret as preparing to delete, then delete, then
-// mark as deleted.
 func (m *BasicSecretsManager) DeleteSecret(ctx context.Context, id string) error {
 	if id == "" {
 		return errors.New("must specify a non-empty ID")

--- a/secret/secrets_manager_vault.go
+++ b/secret/secrets_manager_vault.go
@@ -195,7 +195,6 @@ func (m *BasicSecretsManager) DeleteSecret(ctx context.Context, id string) error
 	return err
 }
 
-// shouldCache
 func (m *BasicSecretsManager) shouldCache() bool {
 	return m.cache != nil
 }

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -24,9 +24,43 @@ func validIntegrationAWSOpts(hc *http.Client) awsutil.ClientOptions {
 		SetRegion(testutil.AWSRegion())
 }
 
-func TestSecretsManager(t *testing.T) {
+// validNonIntegrationAWSOpts returns valid options to create an AWS client that
+// doesn't make any actual requests to AWS.
+func validNonIntegrationAWSOpts(hc *http.Client) awsutil.ClientOptions {
+	return *awsutil.NewClientOptions().
+		SetCredentials(credentials.NewEnvCredentials()).
+		SetRegion("us-east-1")
+}
+
+func TestBasicSecretsManager(t *testing.T) {
 	assert.Implements(t, (*cocoa.Vault)(nil), &BasicSecretsManager{})
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hc := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(hc)
+
+	t.Run("NewBasicSecretsManager", func(t *testing.T) {
+		c, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+		require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, c.Close(ctx))
+		}()
+		t.Run("FailsWithZeroOptions", func(t *testing.T) {
+			sm, err := NewBasicSecretsManager(*NewBasicSecretsManagerOptions())
+			assert.Error(t, err)
+			assert.Zero(t, sm)
+		})
+		t.Run("SucceedsWithValidOptions", func(t *testing.T) {
+			sm, err := NewBasicSecretsManager(*NewBasicSecretsManagerOptions().SetClient(c))
+			assert.NoError(t, err)
+			assert.NotZero(t, sm)
+		})
+	})
+}
+
+func TestSecretsManager(t *testing.T) {
 	testutil.CheckAWSEnvVarsForSecretsManager(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -54,10 +88,77 @@ func TestSecretsManager(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
-			m := NewBasicSecretsManager(c)
+			m, err := NewBasicSecretsManager(*NewBasicSecretsManagerOptions().SetClient(c))
+			require.NoError(t, err)
 			require.NotNil(t, m)
 
 			tCase(tctx, t, m)
 		})
 	}
+}
+
+func TestBasicSecretsManagerOptions(t *testing.T) {
+	hc := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(hc)
+
+	t.Run("NewBasicSecretsManagerOptions", func(t *testing.T) {
+		opts := NewBasicSecretsManagerOptions()
+		require.NotZero(t, opts)
+		assert.Zero(t, *opts)
+	})
+	t.Run("SetClient", func(t *testing.T) {
+		c, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+		require.NoError(t, err)
+		opts := NewBasicSecretsManagerOptions().SetClient(c)
+		assert.Equal(t, c, opts.Client)
+	})
+	t.Run("SetCache", func(t *testing.T) {
+		sc := &testutil.NoopSecretCache{}
+		opts := NewBasicSecretsManagerOptions().SetCache(sc)
+		require.NotZero(t, opts.Cache)
+		assert.Equal(t, sc, opts.Cache)
+	})
+	t.Run("SetCacheTag", func(t *testing.T) {
+		tag := "tag"
+		opts := NewBasicSecretsManagerOptions().SetCacheTag(tag)
+		assert.Equal(t, tag, utility.FromStringPtr(opts.CacheTag))
+	})
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("FailsWithEmpty", func(t *testing.T) {
+			opts := NewBasicSecretsManagerOptions()
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
+			smClient, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+			require.NoError(t, err)
+			opts := NewBasicSecretsManagerOptions().
+				SetClient(smClient).
+				SetCache(&testutil.NoopSecretCache{}).
+				SetCacheTag("tag")
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("FailsWithoutClient", func(t *testing.T) {
+			opts := NewBasicSecretsManagerOptions().
+				SetCache(&testutil.NoopSecretCache{}).
+				SetCacheTag("tag")
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("FailsWithCacheTagButNoCache", func(t *testing.T) {
+			c, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+			require.NoError(t, err)
+			opts := NewBasicSecretsManagerOptions().
+				SetClient(c).
+				SetCacheTag("tag")
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("DefaultsCacheTagWithCache", func(t *testing.T) {
+			c, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+			require.NoError(t, err)
+			opts := NewBasicSecretsManagerOptions().
+				SetClient(c).
+				SetCache(&testutil.NoopSecretCache{})
+			assert.NoError(t, opts.Validate())
+			assert.Equal(t, defaultCacheTrackingTag, utility.FromStringPtr(opts.CacheTag))
+		})
+	})
 }

--- a/secret_cache.go
+++ b/secret_cache.go
@@ -1,0 +1,18 @@
+package cocoa
+
+import "context"
+
+// SecretCache represents an external cache that tracks secrets.
+type SecretCache interface {
+	// Put adds a new secret with the given name and external resource
+	// identifier in the cache.
+	Put(ctx context.Context, item SecretCacheItem) error
+}
+
+// SecretCacheItem represents an item that can be cached in a SecretCache.
+type SecretCacheItem struct {
+	// ID is the unique resource identifier for the stored secret.
+	ID string
+	// Name is the friendly name of the secret.
+	Name string
+}

--- a/secrets_manager_client.go
+++ b/secrets_manager_client.go
@@ -23,6 +23,8 @@ type SecretsManagerClient interface {
 	UpdateSecretValue(ctx context.Context, in *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error)
 	// DeleteSecret deletes an existing secret.
 	DeleteSecret(ctx context.Context, in *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error)
+	// TagResource adds tags to a secret.
+	TagResource(ctx context.Context, in *secretsmanager.TagResourceInput) (*secretsmanager.TagResourceOutput, error)
 	// Close closes the client and cleans up its resources. Implementations
 	// should ensure that this is idempotent.
 	Close(ctx context.Context) error

--- a/secrets_manager_client.go
+++ b/secrets_manager_client.go
@@ -23,7 +23,7 @@ type SecretsManagerClient interface {
 	UpdateSecretValue(ctx context.Context, in *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error)
 	// DeleteSecret deletes an existing secret.
 	DeleteSecret(ctx context.Context, in *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error)
-	// TagResource adds tags to a secret.
+	// TagResource adds tags to an existing secret.
 	TagResource(ctx context.Context, in *secretsmanager.TagResourceInput) (*secretsmanager.TagResourceOutput, error)
 	// Close closes the client and cleans up its resources. Implementations
 	// should ensure that this is idempotent.

--- a/vault.go
+++ b/vault.go
@@ -24,7 +24,7 @@ type Vault interface {
 // NamedSecret represents a secret with a name.
 type NamedSecret struct {
 	// Name is either the friendly human-readable name to assign to the secret
-	// or the resource name.
+	// or the resource identifier if the secret already exists.
 	Name *string
 	// Value is the stored value of the secret.
 	Value *string


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-16896
https://jira.mongodb.org/browse/EVG-16897

This is similar to the pod definition cache #77 in terms of implementation/interface. We want to be able to externally store secrets after they're created (in the DB) so that secret values like repo creds in ECS can be tracked in the DB.

* Add interface for attaching optional secret cache to the Secrets Manager vault implementation.
* Implement `TagResource` API call for Secrets Manager to keep track of whether secrets are tracked or not.
* Add mock implementation of secret cache for testing purposes.
* Add tests for secret caching behavior. Also tidy up a couple of the existing tests.