### PR TITLE
EVG-16892: support deleting cached pod definitions

### DIFF
--- a/ecs/pod_definition_manager.go
+++ b/ecs/pod_definition_manager.go
@@ -157,9 +157,7 @@ func (m *BasicPodDefinitionManager) DeletePodDefinition(ctx context.Context, id 
 	}
 
 	if m.usesCache() {
-		if err := m.cache.Delete(ctx, id); err != nil {
-			return errors.Wrapf(err, "deleting pod definition '%s' from cache", id)
-		}
+		return errors.Wrapf(m.cache.Delete(ctx, id), "deleting pod definition '%s' from cache", id)
 	}
 
 	return nil

--- a/ecs/pod_definition_manager.go
+++ b/ecs/pod_definition_manager.go
@@ -103,7 +103,7 @@ func (m *BasicPodDefinitionManager) CreatePodDefinition(ctx context.Context, opt
 	if err := mergedOpts.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid pod definition options")
 	}
-	if m.shouldCache() {
+	if m.usesCache() {
 		// If the definition needs to be cached, we could successfully create a
 		// cloud pod definition but fail to cache it. Adding a tag makes it
 		// possible to track whether the pod definition has been created but
@@ -127,7 +127,7 @@ func (m *BasicPodDefinitionManager) CreatePodDefinition(ctx context.Context, opt
 		DefinitionOpts: mergedOpts,
 	}
 
-	if !m.shouldCache() {
+	if !m.usesCache() {
 		return &item, nil
 	}
 
@@ -147,6 +147,24 @@ func (m *BasicPodDefinitionManager) CreatePodDefinition(ctx context.Context, opt
 	return &item, nil
 }
 
-func (m *BasicPodDefinitionManager) shouldCache() bool {
+// DeletePodDefinition deletes a pod definition and deletes it from the cache if
+// it is using a cache.
+func (m *BasicPodDefinitionManager) DeletePodDefinition(ctx context.Context, id string) error {
+	if _, err := m.client.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
+		TaskDefinition: aws.String(id),
+	}); err != nil {
+		return errors.Wrapf(err, "deregistering task definition '%s'", id)
+	}
+
+	if m.usesCache() {
+		if err := m.cache.Delete(ctx, id); err != nil {
+			return errors.Wrapf(err, "deleting pod definition '%s' from cache", id)
+		}
+	}
+
+	return nil
+}
+
+func (m *BasicPodDefinitionManager) usesCache() bool {
 	return m.cache != nil
 }

--- a/ecs_pod_definition_manager.go
+++ b/ecs_pod_definition_manager.go
@@ -8,13 +8,15 @@ type ECSPodDefinitionCache interface {
 	// Put adds a new pod definition item or or updates an existing pod
 	// definition item.
 	Put(ctx context.Context, item ECSPodDefinitionItem) error
+	// Delete deletes by its unique identifier in ECS.
+	Delete(ctx context.Context, id string) error
 }
 
 // ECSPodDefinitionItem represents an item that can be cached in a
 // ECSPodDefinitionCache.
 type ECSPodDefinitionItem struct {
-	// ID is the unique external identifier in ECS for pod definition
-	// represented by the item.
+	// ID is the unique identifier in ECS for pod definition represented by the
+	// item.
 	ID string
 	// DefinitionOpts are the options used to create the pod definition.
 	DefinitionOpts ECSPodDefinitionOptions
@@ -25,4 +27,7 @@ type ECSPodDefinitionItem struct {
 type ECSPodDefinitionManager interface {
 	// CreatePodDefinition creates a pod definition.
 	CreatePodDefinition(ctx context.Context, opts ...ECSPodDefinitionOptions) (*ECSPodDefinitionItem, error)
+	// DeletePodDefinition deletes an existing pod definition. Implementations
+	// should ensure that deletion is idempotent.
+	DeletePodDefinition(ctx context.Context, id string) error
 }

--- a/internal/testutil/ecs_pod_definition_cache.go
+++ b/internal/testutil/ecs_pod_definition_cache.go
@@ -14,3 +14,8 @@ type NoopECSPodDefinitionCache struct{}
 func (c *NoopECSPodDefinitionCache) Put(context.Context, cocoa.ECSPodDefinitionItem) error {
 	return nil
 }
+
+// Delete is a no-op.
+func (c *NoopECSPodDefinitionCache) Delete(context.Context, string) error {
+	return nil
+}

--- a/mock/ecs_pod_definition_cache.go
+++ b/mock/ecs_pod_definition_cache.go
@@ -14,6 +14,9 @@ type ECSPodDefinitionCache struct {
 
 	PutInput *cocoa.ECSPodDefinitionItem
 	PutError error
+
+	DeleteInput *string
+	DeleteError error
 }
 
 // NewECSPodDefinitionCache creates a mock ECS pod definition cache backed
@@ -35,4 +38,18 @@ func (c *ECSPodDefinitionCache) Put(ctx context.Context, item cocoa.ECSPodDefini
 	}
 
 	return c.ECSPodDefinitionCache.Put(ctx, item)
+}
+
+// Delete deletes the pod definition matching the identifier from the mock
+// cache. The mock output can be customized. By default, it will return the
+// result of deleting the pod definition from the backing ECS pod definition
+// cache.
+func (c *ECSPodDefinitionCache) Delete(ctx context.Context, id string) error {
+	c.DeleteInput = &id
+
+	if c.DeleteError != nil {
+		return c.DeleteError
+	}
+
+	return c.ECSPodDefinitionCache.Delete(ctx, id)
 }

--- a/mock/ecs_pod_definition_manager_test.go
+++ b/mock/ecs_pod_definition_manager_test.go
@@ -121,31 +121,37 @@ func TestECSPodDefinitionManager(t *testing.T) {
 // ecsPodDefinitionManagerTests are mock-specific tests for ECS and Secrets
 // Manager with the ECS pod definition manager.
 func ecsPodDefinitionManagerTests() map[string]func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string) {
+	getValidPodDefOpts := func(t *testing.T) cocoa.ECSPodDefinitionOptions {
+		containerDef := cocoa.NewECSContainerDefinition().
+			SetName("name").
+			SetImage("image").
+			SetCommand([]string{"echo", "foo"}).
+			SetWorkingDir("working_dir").
+			SetMemoryMB(128).
+			SetCPU(256)
+		opts := cocoa.NewECSPodDefinitionOptions().
+			SetName(testutil.NewTaskDefinitionFamily(t)).
+			SetMemoryMB(512).
+			SetCPU(1024).
+			SetTaskRole("task_role").
+			SetExecutionRole("execution_role").
+			SetNetworkMode(cocoa.NetworkModeAWSVPC).
+			SetTags(map[string]string{"creation_tag": "creation_val"}).
+			AddContainerDefinitions(*containerDef)
+		require.NoError(t, opts.Validate())
+		return *opts
+	}
 	return map[string]func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string){
 		"CreatePodDefinitionRegistersTaskDefinitionAndCachesWithAllFieldsSet": func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string) {
 			envVar := cocoa.NewEnvironmentVariable().
 				SetName("env_var_name").
 				SetValue("env_var_value")
-			containerDef := cocoa.NewECSContainerDefinition().
-				SetName("name").
-				SetImage("image").
-				SetCommand([]string{"echo", "foo"}).
-				SetWorkingDir("working_dir").
-				SetMemoryMB(128).
-				SetCPU(256).
-				AddEnvironmentVariables(*envVar)
-			opts := cocoa.NewECSPodDefinitionOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t)).
-				SetMemoryMB(512).
-				SetCPU(1024).
-				SetTaskRole("task_role").
-				SetExecutionRole("execution_role").
-				SetNetworkMode(cocoa.NetworkModeAWSVPC).
-				SetTags(map[string]string{"creation_tag": "creation_val"}).
-				AddContainerDefinitions(*containerDef)
-			assert.NoError(t, opts.Validate())
+			opts := getValidPodDefOpts(t)
+			containerDef := opts.ContainerDefinitions[0]
+			containerDef.AddEnvironmentVariables(*envVar)
+			opts.SetContainerDefinitions([]cocoa.ECSContainerDefinition{containerDef})
 
-			pdi, err := pdm.CreatePodDefinition(ctx, *opts)
+			pdi, err := pdm.CreatePodDefinition(ctx, opts)
 			require.NoError(t, err)
 			require.NotZero(t, pdi.ID)
 			require.NotZero(t, pdi.DefinitionOpts)
@@ -192,32 +198,24 @@ func ecsPodDefinitionManagerTests() map[string]func(ctx context.Context, t *test
 			assert.Equal(t, cacheTag, utility.FromStringPtr(c.TagResourceInput.Tags[0].Key))
 			assert.Equal(t, "true", utility.FromStringPtr(c.TagResourceInput.Tags[0].Value), "cache tag should be marked as cached")
 		},
+		"CreatePodDefinitionFailsWithInvalidPodDefinition": func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string) {
+			opts := cocoa.NewECSPodDefinitionOptions()
+			assert.Error(t, opts.Validate())
+
+			pdi, err := pdm.CreatePodDefinition(ctx, *opts)
+			assert.Error(t, err)
+			assert.Zero(t, pdi)
+
+			assert.Zero(t, c.RegisterTaskDefinitionInput, "should not have tried to register a task definition that's known to be invalid")
+			assert.Zero(t, pdc.PutInput, "should not have tried to cache the pod definition when it's known to be invalid")
+		},
 		"CreatePodDefinitionTagsStrandedPodDefinitionAsUncachedWhenCachingFails": func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string) {
 			pdc.PutError = errors.New("fake error")
 
-			envVar := cocoa.NewEnvironmentVariable().
-				SetName("env_var_name").
-				SetValue("env_var_value")
-			containerDef := cocoa.NewECSContainerDefinition().
-				SetName("name").
-				SetImage("image").
-				SetCommand([]string{"echo", "foo"}).
-				SetWorkingDir("working_dir").
-				SetMemoryMB(128).
-				SetCPU(256).
-				AddEnvironmentVariables(*envVar)
-			opts := cocoa.NewECSPodDefinitionOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t)).
-				SetMemoryMB(512).
-				SetCPU(1024).
-				SetTaskRole("task_role").
-				SetExecutionRole("execution_role").
-				SetNetworkMode(cocoa.NetworkModeAWSVPC).
-				SetTags(map[string]string{"creation_tag": "creation_val"}).
-				AddContainerDefinitions(*containerDef)
-			assert.NoError(t, opts.Validate())
+			opts := getValidPodDefOpts(t)
+			containerDef := opts.ContainerDefinitions[0]
 
-			pdi, err := pdm.CreatePodDefinition(ctx, *opts)
+			pdi, err := pdm.CreatePodDefinition(ctx, opts)
 			assert.Error(t, err, "should have failed to put into cache")
 			assert.Zero(t, pdi)
 
@@ -250,9 +248,6 @@ func ecsPodDefinitionManagerTests() map[string]func(ctx context.Context, t *test
 			assert.Equal(t, utility.FromStringPtr(containerDef.WorkingDir), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].WorkingDirectory))
 			assert.EqualValues(t, utility.FromIntPtr(containerDef.MemoryMB), utility.FromInt64Ptr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Memory))
 			assert.EqualValues(t, utility.FromIntPtr(containerDef.CPU), utility.FromInt64Ptr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Cpu))
-			require.Len(t, c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Environment, 1)
-			assert.Equal(t, utility.FromStringPtr(envVar.Name), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Environment[0].Name))
-			assert.Equal(t, utility.FromStringPtr(envVar.Value), utility.FromStringPtr(c.RegisterTaskDefinitionInput.ContainerDefinitions[0].Environment[0].Value))
 
 			assert.NotZero(t, pdc.PutInput, "should have attempted to cache the pod definition")
 
@@ -261,34 +256,56 @@ func ecsPodDefinitionManagerTests() map[string]func(ctx context.Context, t *test
 		"CreatePodDefinitionDoesNotCacheWhenRegisteringTaskDefinitionFails": func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string) {
 			c.RegisterTaskDefinitionError = errors.New("fake error")
 
-			envVar := cocoa.NewEnvironmentVariable().
-				SetName("env_var_name").
-				SetValue("env_var_value")
-			containerDef := cocoa.NewECSContainerDefinition().
-				SetName("name").
-				SetImage("image").
-				SetCommand([]string{"echo", "foo"}).
-				SetWorkingDir("working_dir").
-				SetMemoryMB(128).
-				SetCPU(256).
-				AddEnvironmentVariables(*envVar)
-			opts := cocoa.NewECSPodDefinitionOptions().
-				SetMemoryMB(512).
-				SetCPU(1024).
-				SetTaskRole("task_role").
-				SetExecutionRole("execution_role").
-				SetNetworkMode(cocoa.NetworkModeAWSVPC).
-				SetTags(map[string]string{"creation_tag": "creation_val"}).
-				AddContainerDefinitions(*containerDef)
-			assert.NoError(t, opts.Validate())
-
-			pdi, err := pdm.CreatePodDefinition(ctx, *opts)
+			pdi, err := pdm.CreatePodDefinition(ctx, getValidPodDefOpts(t))
 			assert.Error(t, err, "should have failed to register task definition")
 			assert.Zero(t, pdi)
 
 			assert.NotZero(t, c.RegisterTaskDefinitionInput, "should have attempted to register a task definition")
 
 			assert.Zero(t, pdc.PutInput, "should not have attempted to cache the pod definition after registration failed")
+		},
+		"DeletePodDefinitionDeletesAndUncachesWithValidID": func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string) {
+			pdi, err := pdm.CreatePodDefinition(ctx, getValidPodDefOpts(t))
+			require.NoError(t, err)
+
+			assert.NotZero(t, c.RegisterTaskDefinitionInput, "should have attempted registered a task definition")
+			assert.Zero(t, c.DeregisterTaskDefinitionInput, "should not have deregistered the task definition")
+			assert.NotZero(t, pdc.PutInput, "should have cached the pod definition")
+			assert.Zero(t, pdc.DeleteInput, "should not have deleted the cached pod definition")
+			assert.Equal(t, pdi.ID, pdc.PutInput.ID)
+
+			require.NoError(t, pdm.DeletePodDefinition(ctx, pdi.ID))
+			assert.NotZero(t, c.DeregisterTaskDefinitionInput, "should have deregistered the task definition")
+			assert.NotZero(t, pdc.DeleteInput, "should have deleted the cached pod definition")
+		},
+		"DeletePodDefinitionFailsWithNonexistentID": func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string) {
+			assert.Error(t, pdm.DeletePodDefinition(ctx, "foo"))
+			assert.Zero(t, pdc.PutInput, "should not have attempted to uncache a nonexistent pod definition")
+		},
+		"DeletePodDefinitionDoesNotDeleteFromCacheWhenDeregisteringTaskDefinitionFails": func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string) {
+			c.DeregisterTaskDefinitionError = errors.New("fake error")
+
+			pdi, err := pdm.CreatePodDefinition(ctx, getValidPodDefOpts(t))
+			require.NoError(t, err)
+
+			assert.Error(t, pdm.DeletePodDefinition(ctx, pdi.ID))
+
+			assert.NotZero(t, c.DeregisterTaskDefinitionInput, "should have attempted to deregister the task definition")
+			assert.Zero(t, pdc.DeleteInput, "should not have attempted to delete the cached pod definition")
+		},
+		"DeletePodDefinitionIsIdempotent": func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager, pdc *ECSPodDefinitionCache, c *ECSClient, sm *SecretsManagerClient, cacheTag string) {
+			opts := getValidPodDefOpts(t)
+
+			pdi, err := pdm.CreatePodDefinition(ctx, opts)
+			require.NoError(t, err)
+
+			for i := 0; i < 3; i++ {
+				assert.NoError(t, pdm.DeletePodDefinition(ctx, pdi.ID))
+
+				assert.NotZero(t, c.DeregisterTaskDefinitionInput, "should not have deregistered the task definition")
+				assert.NotZero(t, pdc.DeleteInput, "should not have deleted the cached pod definition")
+				assert.Equal(t, pdi.ID, utility.FromStringPtr(pdc.DeleteInput))
+			}
 		},
 	}
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16892

Add a method to the Secrets Manager vault to support deleting pod definitions.