### PR TITLE
EVG-16899: support deleting cached secrets

### DIFF
--- a/internal/testutil/secret_cache.go
+++ b/internal/testutil/secret_cache.go
@@ -14,3 +14,8 @@ type NoopSecretCache struct{}
 func (c *NoopSecretCache) Put(context.Context, cocoa.SecretCacheItem) error {
 	return nil
 }
+
+// Delete is a no-op.
+func (c *NoopSecretCache) Delete(context.Context, string) error {
+	return nil
+}

--- a/mock/secret_cache.go
+++ b/mock/secret_cache.go
@@ -13,6 +13,9 @@ type SecretCache struct {
 
 	PutInput *cocoa.SecretCacheItem
 	PutError error
+
+	DeleteInput *string
+	DeleteError error
 }
 
 // NewSecretCache creates a mock secret cache backed by the given secret cache.
@@ -33,4 +36,17 @@ func (c *SecretCache) Put(ctx context.Context, item cocoa.SecretCacheItem) error
 	}
 
 	return c.SecretCache.Put(ctx, item)
+}
+
+// Delete removes the secret from the mock cache. The mock output can be
+// customized. By default, it will return the result of deleting the secret from
+// the backing secret cache.
+func (c *SecretCache) Delete(ctx context.Context, id string) error {
+	c.DeleteInput = &id
+
+	if c.DeleteError != nil {
+		return c.DeleteError
+	}
+
+	return c.SecretCache.Delete(ctx, id)
 }

--- a/secret_cache.go
+++ b/secret_cache.go
@@ -7,6 +7,9 @@ type SecretCache interface {
 	// Put adds a new secret with the given name and external resource
 	// identifier in the cache.
 	Put(ctx context.Context, item SecretCacheItem) error
+	// Delete deletes an existing secret with the given external resource
+	// identifier from the cache.
+	Delete(ctx context.Context, id string) error
 }
 
 // SecretCacheItem represents an item that can be cached in a SecretCache.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16899

When deleting a secret (in Secrets Manager), also delete it from the cache.