### PR TITLE
EVG-17398: implement resource tag client

### DIFF
--- a/awsutil/base_client.go
+++ b/awsutil/base_client.go
@@ -1,0 +1,55 @@
+package awsutil
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+)
+
+// BaseClient provides various helpers to set up and use AWS clients for various
+// services.
+type BaseClient struct {
+	opts    ClientOptions
+	session *session.Session
+}
+
+// NewBaseClient creates a new base AWS client from the client options.
+func NewBaseClient(opts ClientOptions) BaseClient {
+	return BaseClient{opts: opts}
+}
+
+// GetSession ensures that the session is initialized and returns it.
+func (c *BaseClient) GetSession() (*session.Session, error) {
+	if err := c.opts.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid options")
+	}
+
+	if c.session != nil {
+		return c.session, nil
+	}
+
+	sess, err := c.opts.GetSession()
+	if err != nil {
+		return nil, errors.Wrap(err, "creating session")
+	}
+
+	c.session = sess
+
+	return c.session, nil
+}
+
+// GetRetryOptions returns the retry options for the client.
+func (c *BaseClient) GetRetryOptions() utility.RetryOptions {
+	if c.opts.RetryOpts == nil {
+		c.opts.RetryOpts = &utility.RetryOptions{}
+	}
+	return *c.opts.RetryOpts
+}
+
+// Close closes the client and cleans up its resources.
+func (c *BaseClient) Close(ctx context.Context) error {
+	c.opts.Close()
+	return nil
+}

--- a/awsutil/client_options_test.go
+++ b/awsutil/client_options_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// defaultTestTimeout is the default test timeout for AWS utility tests.
-const defaultTestTimeout = time.Second
-
 func TestClientOptions(t *testing.T) {
 	t.Run("SetCredentials", func(t *testing.T) {
 		creds := credentials.NewEnvCredentials()

--- a/awsutil/client_options_test.go
+++ b/awsutil/client_options_test.go
@@ -1,9 +1,7 @@
 package awsutil
 
 import (
-	"context"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -170,37 +168,4 @@ func TestClientOptions(t *testing.T) {
 			assert.True(t, opts.ownsHTTPClient)
 		})
 	})
-}
-
-func TestClientOptionsGetCredentials(t *testing.T) {
-	hc := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(hc)
-
-	if val := os.Getenv("AWS_REGION"); val == "" {
-		require.FailNow(t, "missing required AWS_REGION environment variable")
-	}
-	if val := os.Getenv("AWS_ROLE"); val == "" {
-		require.FailNow(t, "missing required AWS_ROLE environment variable")
-	}
-
-	opts := NewClientOptions().
-		SetCredentials(credentials.NewEnvCredentials()).
-		SetRole(os.Getenv("AWS_REGION")).
-		SetRegion(os.Getenv("AWS_ROLE")).
-		SetHTTPClient(hc)
-
-	require.NoError(t, opts.Validate())
-
-	creds, err := opts.GetCredentials()
-	require.NoError(t, err)
-	require.NotZero(t, creds)
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
-	defer cancel()
-
-	resolved, err := creds.GetWithContext(ctx)
-	require.NoError(t, err)
-	assert.NotZero(t, resolved.AccessKeyID)
-	assert.NotZero(t, resolved.SecretAccessKey)
-	assert.NotZero(t, resolved.SessionToken)
 }

--- a/awsutil/client_options_test.go
+++ b/awsutil/client_options_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -174,10 +173,15 @@ func TestClientOptions(t *testing.T) {
 }
 
 func TestClientOptionsGetCredentials(t *testing.T) {
-	testutil.CheckAWSEnvVars(t)
-
 	hc := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(hc)
+
+	if val := os.Getenv("AWS_REGION"); val == "" {
+		require.FailNow(t, "missing required AWS_REGION environment variable")
+	}
+	if val := os.Getenv("AWS_ROLE"); val == "" {
+		require.FailNow(t, "missing required AWS_ROLE environment variable")
+	}
 
 	opts := NewClientOptions().
 		SetCredentials(credentials.NewEnvCredentials()).

--- a/awsutil/client_options_test.go
+++ b/awsutil/client_options_test.go
@@ -3,6 +3,7 @@ package awsutil
 import (
 	"context"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -180,8 +181,8 @@ func TestClientOptionsGetCredentials(t *testing.T) {
 
 	opts := NewClientOptions().
 		SetCredentials(credentials.NewEnvCredentials()).
-		SetRole(testutil.AWSRole()).
-		SetRegion(testutil.AWSRegion()).
+		SetRole(os.Getenv("AWS_REGION")).
+		SetRegion(os.Getenv("AWS_ROLE")).
 		SetHTTPClient(hc)
 
 	require.NoError(t, opts.Validate())

--- a/doc.go
+++ b/doc.go
@@ -29,7 +29,7 @@ Manager API. If the Vault does not fulfill your needs, you can instead make
 calls directly to the Secrets Manager API using this client.
 
 The TagClient provides a wrapper around the AWS Resource Groups Tagging API.
-This can be useful for managing tagged resources such as secrets, pod
-definitions, and pods.
+This can be useful for managing tagged resources across different services, such
+as secrets, pod definitions, and pods.
 */
 package cocoa

--- a/doc.go
+++ b/doc.go
@@ -27,5 +27,9 @@ secrets in an external cache.
 The SecretsManagerClient provides a convenience wrapper around the AWS Secrets
 Manager API. If the Vault does not fulfill your needs, you can instead make
 calls directly to the Secrets Manager API using this client.
+
+The TagClient provides a wrapper around the AWS Resource Groups Tagging API.
+This can be useful for managing tagged resources such as secrets, pod
+definitions, and pods.
 */
 package cocoa

--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -17,7 +17,7 @@ import (
 
 const defaultTestTimeout = time.Minute
 
-func TestECSClient(t *testing.T) {
+func TestBasicECSClient(t *testing.T) {
 	assert.Implements(t, (*cocoa.ECSClient)(nil), &BasicECSClient{})
 
 	testutil.CheckAWSEnvVarsForECS(t)
@@ -28,7 +28,7 @@ func TestECSClient(t *testing.T) {
 	hc := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(hc)
 
-	c, err := NewBasicECSClient(validIntegrationAWSOpts(hc))
+	c, err := NewBasicECSClient(testutil.ValidIntegrationAWSOptions(hc))
 	require.NoError(t, err)
 	require.NotNil(t, c)
 

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -51,7 +51,7 @@ func TestBasicECSPodCreator(t *testing.T) {
 			hc := utility.GetHTTPClient()
 			defer utility.PutHTTPClient(hc)
 
-			awsOpts := validNonIntegrationAWSOpts(hc)
+			awsOpts := testutil.ValidNonIntegrationAWSOptions()
 
 			c, err := NewBasicECSClient(awsOpts)
 			require.NoError(t, err)

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -84,7 +84,7 @@ func TestECSPodCreator(t *testing.T) {
 	hc := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(hc)
 
-	awsOpts := validIntegrationAWSOpts(hc)
+	awsOpts := testutil.ValidIntegrationAWSOptions(hc)
 
 	c, err := NewBasicECSClient(awsOpts)
 	require.NoError(t, err)

--- a/ecs/pod_definition_manager_test.go
+++ b/ecs/pod_definition_manager_test.go
@@ -50,7 +50,7 @@ func TestECSPodDefinitionManager(t *testing.T) {
 	hc := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(hc)
 
-	awsOpts := validIntegrationAWSOpts(hc)
+	awsOpts := testutil.ValidIntegrationAWSOptions(hc)
 
 	c, err := NewBasicECSClient(awsOpts)
 	require.NoError(t, err)

--- a/ecs/pod_definition_manager_test.go
+++ b/ecs/pod_definition_manager_test.go
@@ -23,7 +23,7 @@ func TestBasicPodDefinitionManager(t *testing.T) {
 	defer utility.PutHTTPClient(hc)
 
 	t.Run("NewPodDefinitionManager", func(t *testing.T) {
-		c, err := NewBasicECSClient(validNonIntegrationAWSOpts(hc))
+		c, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, c.Close(ctx))
@@ -113,13 +113,13 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 		assert.Zero(t, *opts)
 	})
 	t.Run("SetClient", func(t *testing.T) {
-		c, err := NewBasicECSClient(validNonIntegrationAWSOpts(hc))
+		c, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
 		require.NoError(t, err)
 		opts := NewBasicPodDefinitionManagerOptions().SetClient(c)
 		assert.Equal(t, c, opts.Client)
 	})
 	t.Run("SetVault", func(t *testing.T) {
-		c, err := secret.NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+		c, err := secret.NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
 		require.NoError(t, err)
 		v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(c))
 		require.NoError(t, err)
@@ -143,9 +143,9 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
-			ecsClient, err := NewBasicECSClient(validNonIntegrationAWSOpts(hc))
+			ecsClient, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
-			smClient, err := secret.NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+			smClient, err := secret.NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smClient))
 			require.NoError(t, err)
@@ -157,7 +157,7 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("FailsWithoutClient", func(t *testing.T) {
-			smClient, err := secret.NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+			smClient, err := secret.NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smClient))
 			require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("FailsWithCacheTagButNoCache", func(t *testing.T) {
-			c, err := NewBasicECSClient(validNonIntegrationAWSOpts(hc))
+			c, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			opts := NewBasicPodDefinitionManagerOptions().
 				SetClient(c).
@@ -176,7 +176,7 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("DefaultsCacheTagWithCache", func(t *testing.T) {
-			c, err := NewBasicECSClient(validNonIntegrationAWSOpts(hc))
+			c, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			opts := NewBasicPodDefinitionManagerOptions().
 				SetClient(c).

--- a/internal/testcase/ecs_client.go
+++ b/internal/testcase/ecs_client.go
@@ -245,9 +245,9 @@ func ECSClientTests() map[string]ECSClientTestCase {
 // cocoa.ECSClient with a task definition already registered.
 type ECSClientRegisteredTaskDefinitionTestCase func(ctx context.Context, t *testing.T, c cocoa.ECSClient, def awsECS.TaskDefinition)
 
-// ECSClientRegisteredTaskDefinitionTests returns common test cases that a
-// cocoa.ECSClient should support that rely on an already-registered task
-// definition.
+// ECSClientRegisteredTaskDefinitionTests returns common test cases which rely
+// on an already-registered task definition that a cocoa.ECSClient should
+// support.
 func ECSClientRegisteredTaskDefinitionTests() map[string]ECSClientRegisteredTaskDefinitionTestCase {
 	return map[string]ECSClientRegisteredTaskDefinitionTestCase{
 		"RunAndStopTaskSucceeds": func(ctx context.Context, t *testing.T, c cocoa.ECSClient, def awsECS.TaskDefinition) {

--- a/internal/testcase/tag_client.go
+++ b/internal/testcase/tag_client.go
@@ -1,0 +1,309 @@
+package testcase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/cocoa/internal/testutil"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TagClientTestCase represents a test case for a cocoa.TagClient.
+type TagClientTestCase func(ctx context.Context, t *testing.T, c cocoa.TagClient)
+
+// TagClientTests returns common test cases that a cocoa.TagClient should
+// support.
+func TagClientTests() map[string]TagClientTestCase {
+	return map[string]TagClientTestCase{
+		"GetResourcesFailsWithInvalidInput": func(ctx context.Context, t *testing.T, c cocoa.TagClient) {
+			out, err := c.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("nonexistent")},
+			})
+			assert.Error(t, err)
+			assert.Zero(t, out)
+		},
+		"GetResourcesSucceedsWithNoResults": func(ctx context.Context, t *testing.T, c cocoa.TagClient) {
+			out, err := c.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("secretsmanager")},
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Key:    aws.String("nonexistent"),
+						Values: []*string{aws.String("nonexistent")},
+					},
+				},
+			})
+			require.NoError(t, err)
+			require.NotZero(t, out)
+			assert.Empty(t, out.ResourceTagMappingList)
+		},
+	}
+}
+
+// TagClientSecretTestCase represents a test case for a cocoa.TagClient with a
+// cocoa.SecretsManagerClient.
+type TagClientSecretTestCase func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient)
+
+// TagClientSecretTests returns common test cases that rely on Secrets Manager
+// that a cocoa.TagClient should support.
+func TagClientSecretTests() map[string]TagClientSecretTestCase {
+	checkResources := func(t *testing.T, out resourcegroupstaggingapi.GetResourcesOutput, expected []string) {
+		require.Len(t, out.ResourceTagMappingList, len(expected), "number of results should match expected")
+		for _, res := range out.ResourceTagMappingList {
+			arn := utility.FromStringPtr(res.ResourceARN)
+			assert.True(t, utility.StringSliceContains(expected, arn), "unexpected resource '%s' in results", arn)
+		}
+	}
+	return map[string]TagClientSecretTestCase{
+		"GetResourcesMatchesSingleTagKeyAndValueForSingleResource": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {
+			inputTags := []*secretsmanager.Tag{
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+			}
+			createSecretOut := testutil.CreateSecret(ctx, t, smClient, secretsmanager.CreateSecretInput{
+				Name:         aws.String(testutil.NewSecretName(t)),
+				SecretString: aws.String(utility.RandomString()),
+				Tags:         inputTags,
+			})
+			defer cleanupSecret(ctx, t, smClient, &createSecretOut)
+
+			getResourcesOut, err := tagClient.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("secretsmanager:secret")},
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Key:    inputTags[0].Key,
+						Values: []*string{inputTags[0].Value},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			checkResources(t, *getResourcesOut, []string{utility.FromStringPtr(createSecretOut.ARN)})
+		},
+		"GetResourcesMatchesSingleKeyAndValueForMultipleResources": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {
+			inputTags := []*secretsmanager.Tag{
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+			}
+			var arns []string
+			for i := 0; i < 3; i++ {
+				createSecretOut := testutil.CreateSecret(ctx, t, smClient, secretsmanager.CreateSecretInput{
+					Name:         aws.String(testutil.NewSecretName(t)),
+					SecretString: aws.String(utility.RandomString()),
+					Tags:         inputTags,
+				})
+				defer cleanupSecret(ctx, t, smClient, &createSecretOut)
+				arns = append(arns, utility.FromStringPtr(createSecretOut.ARN))
+			}
+
+			getResourcesOut, err := tagClient.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("secretsmanager:secret")},
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Key:    inputTags[0].Key,
+						Values: []*string{inputTags[0].Value},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			checkResources(t, *getResourcesOut, arns)
+		},
+		"GetResourcesMatchesSingleTagKeyAndOneOfMultipleValues": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {
+			inputTags := []*secretsmanager.Tag{
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+			}
+			createSecretOut := testutil.CreateSecret(ctx, t, smClient, secretsmanager.CreateSecretInput{
+				Name:         aws.String(testutil.NewSecretName(t)),
+				SecretString: aws.String(utility.RandomString()),
+				Tags:         inputTags,
+			})
+			defer cleanupSecret(ctx, t, smClient, &createSecretOut)
+
+			getResourcesOut, err := tagClient.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("secretsmanager:secret")},
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Key:    inputTags[0].Key,
+						Values: []*string{aws.String("foo"), aws.String("bar"), inputTags[0].Value, aws.String("baz")},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			checkResources(t, *getResourcesOut, []string{utility.FromStringPtr(createSecretOut.ARN)})
+		},
+		"GetResourcesMatchesMultipleTagKeys": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {
+			inputTags := []*secretsmanager.Tag{
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+			}
+			createSecretOut := testutil.CreateSecret(ctx, t, smClient, secretsmanager.CreateSecretInput{
+				Name:         aws.String(testutil.NewSecretName(t)),
+				SecretString: aws.String(utility.RandomString()),
+				Tags:         inputTags,
+			})
+			defer cleanupSecret(ctx, t, smClient, &createSecretOut)
+
+			getResourcesOut, err := tagClient.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("secretsmanager:secret")},
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Key: inputTags[0].Key,
+					},
+					{
+						Key: inputTags[1].Key,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			checkResources(t, *getResourcesOut, []string{utility.FromStringPtr(createSecretOut.ARN)})
+		},
+		"GetResourcesMatchesMultipleTagKeysAndValues": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {
+			inputTags := []*secretsmanager.Tag{
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+			}
+			createSecretOut := testutil.CreateSecret(ctx, t, smClient, secretsmanager.CreateSecretInput{
+				Name:         aws.String(testutil.NewSecretName(t)),
+				SecretString: aws.String(utility.RandomString()),
+				Tags:         inputTags,
+			})
+			defer cleanupSecret(ctx, t, smClient, &createSecretOut)
+
+			getResourcesOut, err := tagClient.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("secretsmanager:secret")},
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Key:    inputTags[0].Key,
+						Values: []*string{aws.String("foo"), inputTags[0].Value, aws.String("baz")},
+					},
+					{
+						Key:    inputTags[1].Key,
+						Values: []*string{aws.String("qux"), inputTags[1].Value, aws.String("quux")},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			checkResources(t, *getResourcesOut, []string{utility.FromStringPtr(createSecretOut.ARN)})
+		},
+		"GetResourcesReturnsNoResultsForUnmatchedResourceType": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {
+			inputTags := []*secretsmanager.Tag{
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+			}
+			createSecretOut := testutil.CreateSecret(ctx, t, smClient, secretsmanager.CreateSecretInput{
+				Name:         aws.String(testutil.NewSecretName(t)),
+				SecretString: aws.String(utility.RandomString()),
+				Tags:         inputTags,
+			})
+			defer cleanupSecret(ctx, t, smClient, &createSecretOut)
+
+			getResourcesOut, err := tagClient.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("ecs:task-definition")},
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Key:    inputTags[0].Key,
+						Values: []*string{inputTags[0].Value},
+					},
+				},
+			})
+			require.NoError(t, err)
+			require.NotZero(t, getResourcesOut)
+			assert.Empty(t, getResourcesOut.ResourceTagMappingList)
+		},
+		"GetResourcesOmitsResultForAnyUnmatchedTagKey": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {
+			inputTags := []*secretsmanager.Tag{
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+			}
+			createSecretOut := testutil.CreateSecret(ctx, t, smClient, secretsmanager.CreateSecretInput{
+				Name:         aws.String(testutil.NewSecretName(t)),
+				SecretString: aws.String(utility.RandomString()),
+				Tags:         inputTags,
+			})
+			defer cleanupSecret(ctx, t, smClient, &createSecretOut)
+
+			getResourcesOut, err := tagClient.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("secretsmanager:secret")},
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Key:    inputTags[0].Key,
+						Values: []*string{inputTags[0].Value},
+					},
+					{
+						Key: aws.String("nonexistent"),
+					},
+				},
+			})
+			require.NoError(t, err)
+			require.NotZero(t, getResourcesOut)
+			assert.Empty(t, getResourcesOut.ResourceTagMappingList)
+		},
+		"GetResourcesOmitsResultsForAnyUnmatchedTagValues": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {
+			inputTags := []*secretsmanager.Tag{
+				{
+					Key:   aws.String(utility.RandomString()),
+					Value: aws.String(utility.RandomString()),
+				},
+			}
+			createSecretOut := testutil.CreateSecret(ctx, t, smClient, secretsmanager.CreateSecretInput{
+				Name:         aws.String(testutil.NewSecretName(t)),
+				SecretString: aws.String(utility.RandomString()),
+				Tags:         inputTags,
+			})
+			defer cleanupSecret(ctx, t, smClient, &createSecretOut)
+
+			getResourcesOut, err := tagClient.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				ResourceTypeFilters: []*string{aws.String("secretsmanager:secret")},
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Key:    inputTags[0].Key,
+						Values: []*string{inputTags[0].Value},
+					},
+					{
+						Key:    inputTags[0].Key,
+						Values: []*string{aws.String("nonexistent")},
+					},
+				},
+			})
+			require.NoError(t, err)
+			require.NotZero(t, getResourcesOut)
+			assert.Empty(t, getResourcesOut.ResourceTagMappingList)
+		},
+		// "": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {},
+		// "": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {},
+		// "": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {},
+		// "": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {},
+	}
+}

--- a/internal/testcase/tag_client.go
+++ b/internal/testcase/tag_client.go
@@ -23,6 +23,17 @@ func TagClientTests() map[string]TagClientTestCase {
 	return map[string]TagClientTestCase{
 		"GetResourcesFailsWithInvalidInput": func(ctx context.Context, t *testing.T, c cocoa.TagClient) {
 			out, err := c.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+				TagFilters: []*resourcegroupstaggingapi.TagFilter{
+					{
+						Values: []*string{aws.String("")},
+					},
+				},
+			})
+			assert.Error(t, err)
+			assert.Zero(t, out)
+		},
+		"GetResourcesFailsWithInvalidResourceType": func(ctx context.Context, t *testing.T, c cocoa.TagClient) {
+			out, err := c.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
 				ResourceTypeFilters: []*string{aws.String("nonexistent")},
 			})
 			assert.Error(t, err)
@@ -301,9 +312,5 @@ func TagClientSecretTests() map[string]TagClientSecretTestCase {
 			require.NotZero(t, getResourcesOut)
 			assert.Empty(t, getResourcesOut.ResourceTagMappingList)
 		},
-		// "": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {},
-		// "": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {},
-		// "": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {},
-		// "": func(ctx context.Context, t *testing.T, tagClient cocoa.TagClient, smClient cocoa.SecretsManagerClient) {},
 	}
 }

--- a/internal/testutil/aws.go
+++ b/internal/testutil/aws.go
@@ -39,8 +39,8 @@ func ValidIntegrationAWSOptions(hc *http.Client) awsutil.ClientOptions {
 		SetRegion(AWSRegion())
 }
 
-// ValidNonIntegrationAWSOpts returns valid options to create an AWS client that
-// doesn't make any actual requests to AWS.
+// ValidNonIntegrationAWSOptions returns valid options to create an AWS client
+// that doesn't make any actual requests to AWS.
 func ValidNonIntegrationAWSOptions() awsutil.ClientOptions {
 	return *awsutil.NewClientOptions().
 		SetCredentials(credentials.NewEnvCredentials()).

--- a/internal/testutil/aws.go
+++ b/internal/testutil/aws.go
@@ -1,8 +1,11 @@
 package testutil
 
 import (
+	"net/http"
 	"os"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/evergreen-ci/cocoa/awsutil"
 	"github.com/evergreen-ci/utility"
 )
 
@@ -24,4 +27,23 @@ func AWSRegion() string {
 // AWSRole returns the AWS IAM role from the environment variable.
 func AWSRole() string {
 	return os.Getenv("AWS_ROLE")
+}
+
+// ValidIntegrationAWSOptions returns valid options to create an AWS client that
+// can make actual requests to AWS for integration testing.
+func ValidIntegrationAWSOptions(hc *http.Client) awsutil.ClientOptions {
+	return *awsutil.NewClientOptions().
+		SetHTTPClient(hc).
+		SetCredentials(credentials.NewEnvCredentials()).
+		SetRole(AWSRole()).
+		SetRegion(AWSRegion())
+}
+
+// ValidNonIntegrationAWSOpts returns valid options to create an AWS client that
+// doesn't make any actual requests to AWS.
+// kim: TODO: remove http Client parameter.
+func ValidNonIntegrationAWSOptions() awsutil.ClientOptions {
+	return *awsutil.NewClientOptions().
+		SetCredentials(credentials.NewEnvCredentials()).
+		SetRegion("us-east-1")
 }

--- a/internal/testutil/aws.go
+++ b/internal/testutil/aws.go
@@ -41,7 +41,6 @@ func ValidIntegrationAWSOptions(hc *http.Client) awsutil.ClientOptions {
 
 // ValidNonIntegrationAWSOpts returns valid options to create an AWS client that
 // doesn't make any actual requests to AWS.
-// kim: TODO: remove http Client parameter.
 func ValidNonIntegrationAWSOptions() awsutil.ClientOptions {
 	return *awsutil.NewClientOptions().
 		SetCredentials(credentials.NewEnvCredentials()).

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 name := cocoa
 projectPath := github.com/evergreen-ci/cocoa
 buildDir := build
-testPackages := $(name) ecs secret mock awsutil
+testPackages := $(name) ecs secret tag mock awsutil
 allPackages := $(testPackages) internal-testcase internal-testutil
 lintPackages := $(allPackages)
 

--- a/mock/secrets_manager_client.go
+++ b/mock/secrets_manager_client.go
@@ -256,7 +256,7 @@ func (c *SecretsManagerClient) ListSecrets(ctx context.Context, in *secretsmanag
 				continue
 			}
 
-			matchingValues := map[string]StoredSecret{}
+			var matchingValues map[string]StoredSecret
 			switch utility.FromStringPtr(f.Key) {
 			case "name":
 				matchingValues = c.secretsMatchingAnyNameValue(utility.FromStringPtrSlice(f.Values))

--- a/mock/secrets_manager_client.go
+++ b/mock/secrets_manager_client.go
@@ -257,31 +257,8 @@ func (c *SecretsManagerClient) ListSecrets(ctx context.Context, in *secretsmanag
 			}
 
 			matchingValues := map[string]StoredSecret{}
-			// kim: TODO: remove
-			// for _, v := range filter.Values {
-			//     if v == nil {
-			//         continue
-			//     }
-			//
-			//     switch utility.FromStringPtr(filter.Key) {
-			//     case "name":
-			//         for arn, s := range c.secretsMatchingAnyNameValue(utility.FromStringPtr(v)) {
-			//             matchingValues[arn] = GlobalSecretCache[arn]
-			//         }
-			//     case "tag-key":
-			//         for _, arn := range c.arnsMatchingTagKeyPrefix(utility.FromStringPtr(v)) {
-			//             matchingValues[arn] = GlobalSecretCache[arn]
-			//         }
-			//     case "tag-value":
-			//         for _, arn := range c.arnsMatchingTagKeyPrefix(utility.FromStringPtr(v)) {
-			//             matchingValues[arn] = GlobalSecretCache[arn]
-			//         }
-			//     }
-			// }
 			switch utility.FromStringPtr(f.Key) {
 			case "name":
-				// kim: TODO: remove
-				// matchingValues = c.getMergedSet(matchingValues, c.secretsMatchingAnyNameValue(utility.FromStringPtrSlice(f.Values)))
 				matchingValues = c.secretsMatchingAnyNameValue(utility.FromStringPtrSlice(f.Values))
 				// This could support other filter keys, but it's not worth it
 				// unless the need arises.
@@ -322,18 +299,6 @@ func (c *SecretsManagerClient) getSetIntersection(a, b map[string]StoredSecret) 
 	return intersection
 }
 
-// kim: TODO: remove
-// func (c *SecretsManagerClient) getMergedSet(a, b map[string]StoredSecret) map[string]StoredSecret {
-//     merged := map[string]StoredSecret{}
-//     for _, s := range a {
-//         merged[s.ARN.String()] = s
-//     }
-//     for _, s := range b {
-//         merged[s.ARN.String()] = s
-//     }
-//     return merged
-// }
-
 // secretsMatchingAnyNameValue returns the ARNs of all secret names that match
 // any of the given values. If the value begins with a "!", the match is
 // negated.
@@ -355,72 +320,6 @@ func (c *SecretsManagerClient) secretsMatchingAnyNameValue(vals []string) map[st
 	}
 	return secrets
 }
-
-// kim: TODO: remove
-// arnsMatchingNameValue returns the ARNs of all secret names that match the
-// given value. If the value begins with a "!", the match is negated.
-// func (c *SecretsManagerClient) arnsMatchingNameValue(val string) []string {
-//     var arns []string
-//     for _, s := range GlobalSecretCache {
-//         if s.IsDeleted {
-//             continue
-//         }
-//
-//         if strings.HasPrefix(val, "!") && s.Name != val[1:] {
-//             arns = append(arns, s.ARN.String())
-//         }
-//         if !strings.HasPrefix(val, "!") && s.Name == val {
-//             arns = append(arns, s.ARN.String())
-//         }
-//     }
-//     return arns
-// }
-
-// kim: TODO: remove
-// arnsMatchingTagKeyPrefix returns the ARNs of all secrets containing tag keys
-// that match the given prefix. If the prefix begins with a "!", the match is
-// negated.
-// func (c *SecretsManagerClient) arnsMatchingTagKeyPrefix(prefix string) []string {
-//     var arns []string
-//     for _, s := range GlobalSecretCache {
-//         if s.IsDeleted {
-//             continue
-//         }
-//
-//         for k := range s.Tags {
-//             if strings.HasPrefix(prefix, "!") && !strings.HasPrefix(k, prefix[1:]) {
-//                 arns = append(arns, s.ARN.String())
-//             }
-//             if !strings.HasPrefix(prefix, "!") && strings.HasPrefix(k, prefix) {
-//                 arns = append(arns, s.ARN.String())
-//             }
-//         }
-//     }
-//     return arns
-// }
-
-// kim: TODO: remove
-// arnsMatchingTagValuePrefix returns the ARNs of all secrets containing tag
-// values that match the given prefix. If the prefix begins with a "!", the
-// match is negated.
-// func (c *SecretsManagerClient) arnsMatchingTagValuePrefix(prefix string) []string {
-//     var arns []string
-//     for _, s := range GlobalSecretCache {
-//         if s.IsDeleted {
-//             continue
-//         }
-//
-//         for _, v := range s.Tags {
-//             if strings.HasPrefix(prefix, "!") && !strings.HasPrefix(v, prefix[1:]) {
-//                 arns = append(arns, s.ARN.String())
-//             }
-//             if !strings.HasPrefix(prefix, "!") && strings.HasPrefix(v, prefix) {
-//                 arns = append(arns, s.ARN.String())
-//             }
-//         }
-//     }
-//     return arns
-// }
 
 // UpdateSecretValue saves the input options and returns an updated mock secret
 // value. The mock output can be customized. By default, it will update a cached

--- a/mock/secrets_manager_client.go
+++ b/mock/secrets_manager_client.go
@@ -13,7 +13,9 @@ import (
 // StoredSecret is a representation of a secret kept in the global secret
 // storage cache.
 type StoredSecret struct {
-	ARN          string
+	// For the sake of simplicity, the secret ARN is synonymous with the secret
+	// name.
+	Name         string
 	Value        string
 	BinaryValue  []byte
 	IsDeleted    bool
@@ -26,7 +28,7 @@ type StoredSecret struct {
 
 func newStoredSecret(in *secretsmanager.CreateSecretInput, ts time.Time) StoredSecret {
 	s := StoredSecret{
-		ARN:          utility.FromStringPtr(in.Name),
+		Name:         utility.FromStringPtr(in.Name),
 		Value:        utility.FromStringPtr(in.SecretString),
 		BinaryValue:  in.SecretBinary,
 		Created:      ts,
@@ -34,6 +36,18 @@ func newStoredSecret(in *secretsmanager.CreateSecretInput, ts time.Time) StoredS
 		Tags:         newSecretsManagerTags(in.Tags),
 	}
 	return s
+}
+
+func exportSecretListEntry(s StoredSecret) *secretsmanager.SecretListEntry {
+	return &secretsmanager.SecretListEntry{
+		ARN:              utility.ToStringPtr(s.Name),
+		Name:             utility.ToStringPtr(s.Name),
+		CreatedDate:      utility.ToTimePtr(s.Created),
+		LastAccessedDate: utility.ToTimePtr(s.LastAccessed),
+		LastChangedDate:  utility.ToTimePtr(s.LastUpdated),
+		DeletedDate:      utility.ToTimePtr(s.Deleted),
+		Tags:             exportSecretsManagerTags(s.Tags),
+	}
 }
 
 func newSecretsManagerTags(tags []*secretsmanager.Tag) map[string]string {
@@ -75,9 +89,10 @@ func ResetGlobalSecretCache() {
 }
 
 // SecretsManagerClient provides a mock implementation of a
-// cocoa.SecretsManagerClient. This makes it possible to introspect on inputs
-// to the client and control the client's output. It provides some default
-// implementations where possible.
+// cocoa.SecretsManagerClient. This makes it possible to introspect on inputs to
+// the client and control the client's output. It provides some default
+// implementations where possible. By default, it will issue the API calls to
+// the fake GlobalSecretCache.
 type SecretsManagerClient struct {
 	CreateSecretInput  *secretsmanager.CreateSecretInput
 	CreateSecretOutput *secretsmanager.CreateSecretOutput
@@ -106,6 +121,8 @@ type SecretsManagerClient struct {
 	TagResourceInput  *secretsmanager.TagResourceInput
 	TagResourceOutput *secretsmanager.TagResourceOutput
 	TagResourceError  error
+
+	CloseError error
 }
 
 // CreateSecret saves the input options and returns a new mock secret. The mock
@@ -129,15 +146,16 @@ func (c *SecretsManagerClient) CreateSecret(ctx context.Context, in *secretsmana
 	}
 
 	name := utility.FromStringPtr(in.Name)
-	if _, ok := GlobalSecretCache[name]; ok {
+	if s, ok := GlobalSecretCache[name]; ok && !s.IsDeleted {
 		return nil, awserr.New(secretsmanager.ErrCodeResourceExistsException, "secret already exists", nil)
 	}
 
-	GlobalSecretCache[name] = newStoredSecret(in, time.Now())
+	newSecret := newStoredSecret(in, time.Now())
+	GlobalSecretCache[newSecret.Name] = newSecret
 
 	return &secretsmanager.CreateSecretOutput{
-		ARN:  in.Name,
-		Name: in.Name,
+		ARN:  utility.ToStringPtr(newSecret.Name),
+		Name: utility.ToStringPtr(newSecret.Name),
 	}, nil
 }
 
@@ -155,8 +173,9 @@ func (c *SecretsManagerClient) GetSecretValue(ctx context.Context, in *secretsma
 		return nil, awserr.New(secretsmanager.ErrCodeInvalidParameterException, "missing secret ID", nil)
 	}
 
-	s, ok := GlobalSecretCache[*in.SecretId]
-	if !ok {
+	id := utility.FromStringPtr(in.SecretId)
+	s := c.getSecret(id)
+	if s == nil {
 		return nil, awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "secret not found", nil)
 	}
 
@@ -165,15 +184,27 @@ func (c *SecretsManagerClient) GetSecretValue(ctx context.Context, in *secretsma
 	}
 
 	s.LastAccessed = time.Now()
-	GlobalSecretCache[*in.SecretId] = s
+	GlobalSecretCache[id] = *s
 
 	return &secretsmanager.GetSecretValueOutput{
-		Name:         in.SecretId,
-		ARN:          in.SecretId,
+		ARN:          utility.ToStringPtr(s.Name),
+		Name:         utility.ToStringPtr(s.Name),
 		SecretString: utility.ToStringPtr(s.Value),
 		SecretBinary: s.BinaryValue,
 		CreatedDate:  utility.ToTimePtr(s.Created),
 	}, nil
+}
+
+func (c *SecretsManagerClient) getSecret(id string) *StoredSecret {
+	if s, ok := GlobalSecretCache[id]; ok {
+		return &s
+	}
+	for _, s := range GlobalSecretCache {
+		if s.Name == id {
+			return &s
+		}
+	}
+	return nil
 }
 
 // DescribeSecret saves the input options and returns an existing mock secret's
@@ -197,8 +228,8 @@ func (c *SecretsManagerClient) DescribeSecret(ctx context.Context, in *secretsma
 	}
 
 	return &secretsmanager.DescribeSecretOutput{
-		ARN:              in.SecretId,
-		Name:             in.SecretId,
+		ARN:              utility.ToStringPtr(s.Name),
+		Name:             utility.ToStringPtr(s.Name),
 		CreatedDate:      utility.ToTimePtr(s.Created),
 		LastAccessedDate: utility.ToTimePtr(s.LastAccessed),
 		LastChangedDate:  utility.ToTimePtr(s.LastUpdated),
@@ -217,44 +248,63 @@ func (c *SecretsManagerClient) ListSecrets(ctx context.Context, in *secretsmanag
 		return c.ListSecretsOutput, c.ListSecretsError
 	}
 
-	matched := map[string]StoredSecret{}
-	for _, filter := range in.Filters {
-		if filter == nil {
-			continue
-		}
-
-		if filter.Key != nil {
-			name := utility.FromStringPtr(filter.Key)
-			s, ok := GlobalSecretCache[name]
-			if !ok {
+	// Get the subset of secrets that match each and every one of the filters.
+	var matchingAllFilters map[string]StoredSecret
+	if len(in.Filters) != 0 {
+		for _, f := range in.Filters {
+			if f == nil {
 				continue
 			}
 
-			matched[name] = s
-		}
-
-		for _, v := range filter.Values {
-			if v == nil {
-				continue
+			matchingValues := map[string]StoredSecret{}
+			// kim: TODO: remove
+			// for _, v := range filter.Values {
+			//     if v == nil {
+			//         continue
+			//     }
+			//
+			//     switch utility.FromStringPtr(filter.Key) {
+			//     case "name":
+			//         for arn, s := range c.secretsMatchingAnyNameValue(utility.FromStringPtr(v)) {
+			//             matchingValues[arn] = GlobalSecretCache[arn]
+			//         }
+			//     case "tag-key":
+			//         for _, arn := range c.arnsMatchingTagKeyPrefix(utility.FromStringPtr(v)) {
+			//             matchingValues[arn] = GlobalSecretCache[arn]
+			//         }
+			//     case "tag-value":
+			//         for _, arn := range c.arnsMatchingTagKeyPrefix(utility.FromStringPtr(v)) {
+			//             matchingValues[arn] = GlobalSecretCache[arn]
+			//         }
+			//     }
+			// }
+			switch utility.FromStringPtr(f.Key) {
+			case "name":
+				// kim: TODO: remove
+				// matchingValues = c.getMergedSet(matchingValues, c.secretsMatchingAnyNameValue(utility.FromStringPtrSlice(f.Values)))
+				matchingValues = c.secretsMatchingAnyNameValue(utility.FromStringPtrSlice(f.Values))
+				// This could support other filter keys, but it's not worth it
+				// unless the need arises.
+			default:
+				return nil, awserr.New(secretsmanager.ErrCodeInvalidParameterException, "unsupported filter", nil)
 			}
 
-			for _, name := range c.namesMatchingValue(utility.FromStringPtr(v)) {
-				matched[name] = GlobalSecretCache[name]
+			if matchingAllFilters == nil {
+				// Initialize the candidate set of matching secrets.
+				matchingAllFilters = matchingValues
+			} else {
+				// Each matching secret must match all the given filters.
+				matchingAllFilters = c.getSetIntersection(matchingAllFilters, matchingValues)
 			}
 		}
+	} else {
+		// If no filters are given, return all the secrets.
+		matchingAllFilters = GlobalSecretCache
 	}
 
 	var converted []*secretsmanager.SecretListEntry
-	for name, s := range matched {
-		converted = append(converted, &secretsmanager.SecretListEntry{
-			ARN:              utility.ToStringPtr(s.ARN),
-			Name:             utility.ToStringPtr(name),
-			CreatedDate:      utility.ToTimePtr(s.Created),
-			LastAccessedDate: utility.ToTimePtr(s.LastAccessed),
-			LastChangedDate:  utility.ToTimePtr(s.LastUpdated),
-			DeletedDate:      utility.ToTimePtr(s.Deleted),
-			Tags:             exportSecretsManagerTags(s.Tags),
-		})
+	for _, s := range matchingAllFilters {
+		converted = append(converted, exportSecretListEntry(s))
 	}
 
 	return &secretsmanager.ListSecretsOutput{
@@ -262,20 +312,115 @@ func (c *SecretsManagerClient) ListSecrets(ctx context.Context, in *secretsmanag
 	}, nil
 }
 
-// namesMatchingValue returns the names of all secrets that match the given
-// value. If the value begins with a "!", the match is negated.
-func (c *SecretsManagerClient) namesMatchingValue(val string) []string {
-	var names []string
-	for name, s := range GlobalSecretCache {
-		if strings.HasPrefix(val, "!") && s.Value != val[1:] {
-			names = append(names, name)
-		}
-		if !strings.HasPrefix(val, "!") && s.Value == val {
-			names = append(names, name)
+func (c *SecretsManagerClient) getSetIntersection(a, b map[string]StoredSecret) map[string]StoredSecret {
+	intersection := map[string]StoredSecret{}
+	for id, s := range a {
+		if _, ok := b[id]; ok {
+			intersection[id] = s
 		}
 	}
-	return names
+	return intersection
 }
+
+// kim: TODO: remove
+// func (c *SecretsManagerClient) getMergedSet(a, b map[string]StoredSecret) map[string]StoredSecret {
+//     merged := map[string]StoredSecret{}
+//     for _, s := range a {
+//         merged[s.ARN.String()] = s
+//     }
+//     for _, s := range b {
+//         merged[s.ARN.String()] = s
+//     }
+//     return merged
+// }
+
+// secretsMatchingAnyNameValue returns the ARNs of all secret names that match
+// any of the given values. If the value begins with a "!", the match is
+// negated.
+func (c *SecretsManagerClient) secretsMatchingAnyNameValue(vals []string) map[string]StoredSecret {
+	secrets := map[string]StoredSecret{}
+	for _, s := range GlobalSecretCache {
+		if s.IsDeleted {
+			continue
+		}
+
+		for _, val := range vals {
+			if strings.HasPrefix(val, "!") && s.Name != val[1:] {
+				secrets[s.Name] = s
+			}
+			if !strings.HasPrefix(val, "!") && s.Name == val {
+				secrets[s.Name] = s
+			}
+		}
+	}
+	return secrets
+}
+
+// kim: TODO: remove
+// arnsMatchingNameValue returns the ARNs of all secret names that match the
+// given value. If the value begins with a "!", the match is negated.
+// func (c *SecretsManagerClient) arnsMatchingNameValue(val string) []string {
+//     var arns []string
+//     for _, s := range GlobalSecretCache {
+//         if s.IsDeleted {
+//             continue
+//         }
+//
+//         if strings.HasPrefix(val, "!") && s.Name != val[1:] {
+//             arns = append(arns, s.ARN.String())
+//         }
+//         if !strings.HasPrefix(val, "!") && s.Name == val {
+//             arns = append(arns, s.ARN.String())
+//         }
+//     }
+//     return arns
+// }
+
+// kim: TODO: remove
+// arnsMatchingTagKeyPrefix returns the ARNs of all secrets containing tag keys
+// that match the given prefix. If the prefix begins with a "!", the match is
+// negated.
+// func (c *SecretsManagerClient) arnsMatchingTagKeyPrefix(prefix string) []string {
+//     var arns []string
+//     for _, s := range GlobalSecretCache {
+//         if s.IsDeleted {
+//             continue
+//         }
+//
+//         for k := range s.Tags {
+//             if strings.HasPrefix(prefix, "!") && !strings.HasPrefix(k, prefix[1:]) {
+//                 arns = append(arns, s.ARN.String())
+//             }
+//             if !strings.HasPrefix(prefix, "!") && strings.HasPrefix(k, prefix) {
+//                 arns = append(arns, s.ARN.String())
+//             }
+//         }
+//     }
+//     return arns
+// }
+
+// kim: TODO: remove
+// arnsMatchingTagValuePrefix returns the ARNs of all secrets containing tag
+// values that match the given prefix. If the prefix begins with a "!", the
+// match is negated.
+// func (c *SecretsManagerClient) arnsMatchingTagValuePrefix(prefix string) []string {
+//     var arns []string
+//     for _, s := range GlobalSecretCache {
+//         if s.IsDeleted {
+//             continue
+//         }
+//
+//         for _, v := range s.Tags {
+//             if strings.HasPrefix(prefix, "!") && !strings.HasPrefix(v, prefix[1:]) {
+//                 arns = append(arns, s.ARN.String())
+//             }
+//             if !strings.HasPrefix(prefix, "!") && strings.HasPrefix(v, prefix) {
+//                 arns = append(arns, s.ARN.String())
+//             }
+//         }
+//     }
+//     return arns
+// }
 
 // UpdateSecretValue saves the input options and returns an updated mock secret
 // value. The mock output can be customized. By default, it will update a cached
@@ -297,9 +442,14 @@ func (c *SecretsManagerClient) UpdateSecretValue(ctx context.Context, in *secret
 		return nil, awserr.New(secretsmanager.ErrCodeInvalidParameterException, "must specify either secret binary or secret string", nil)
 	}
 
-	s, ok := GlobalSecretCache[*in.SecretId]
+	id := utility.FromStringPtr(in.SecretId)
+	s, ok := GlobalSecretCache[id]
 	if !ok {
 		return nil, awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "secret not found", nil)
+	}
+
+	if s.IsDeleted {
+		return nil, awserr.New(secretsmanager.ErrCodeInvalidRequestException, "secret is deleted", nil)
 	}
 
 	if in.SecretBinary != nil {
@@ -313,11 +463,11 @@ func (c *SecretsManagerClient) UpdateSecretValue(ctx context.Context, in *secret
 	s.LastAccessed = ts
 	s.LastUpdated = ts
 
-	GlobalSecretCache[*in.SecretId] = s
+	GlobalSecretCache[id] = s
 
 	return &secretsmanager.UpdateSecretOutput{
-		ARN:  in.SecretId,
-		Name: in.SecretId,
+		ARN:  utility.ToStringPtr(s.Name),
+		Name: utility.ToStringPtr(s.Name),
 	}, nil
 }
 
@@ -347,7 +497,8 @@ func (c *SecretsManagerClient) DeleteSecret(ctx context.Context, in *secretsmana
 		window = 30
 	}
 
-	s, ok := GlobalSecretCache[*in.SecretId]
+	id := utility.FromStringPtr(in.SecretId)
+	s, ok := GlobalSecretCache[id]
 	if !utility.FromBoolPtr(in.ForceDeleteWithoutRecovery) && !ok {
 		return nil, awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "secret not found", nil)
 	}
@@ -359,11 +510,11 @@ func (c *SecretsManagerClient) DeleteSecret(ctx context.Context, in *secretsmana
 		s.Deleted = ts.AddDate(0, 0, window)
 	}
 	s.IsDeleted = true
-	GlobalSecretCache[*in.SecretId] = s
+	GlobalSecretCache[id] = s
 
 	return &secretsmanager.DeleteSecretOutput{
-		ARN:          in.SecretId,
-		Name:         in.SecretId,
+		ARN:          utility.ToStringPtr(s.Name),
+		Name:         utility.ToStringPtr(s.Name),
 		DeletionDate: utility.ToTimePtr(s.Deleted),
 	}, nil
 }
@@ -384,6 +535,11 @@ func (c *SecretsManagerClient) TagResource(ctx context.Context, in *secretsmanag
 	if !ok {
 		return nil, awserr.New(secretsmanager.ErrCodeResourceExistsException, "secret not found", nil)
 	}
+
+	if s.IsDeleted {
+		return nil, awserr.New(secretsmanager.ErrCodeInvalidRequestException, "secret is deleted", nil)
+	}
+
 	for k, v := range newSecretsManagerTags(in.Tags) {
 		s.Tags[k] = v
 	}
@@ -393,5 +549,8 @@ func (c *SecretsManagerClient) TagResource(ctx context.Context, in *secretsmanag
 // Close closes the mock client. The mock output can be customized. By default,
 // it is a no-op that returns no error.
 func (c *SecretsManagerClient) Close(ctx context.Context) error {
+	if c.CloseError != nil {
+		return c.CloseError
+	}
 	return nil
 }

--- a/mock/tag_client.go
+++ b/mock/tag_client.go
@@ -1,0 +1,245 @@
+package mock
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	awsECS "github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/evergreen-ci/utility"
+)
+
+// taggedResource represents an arbitrary AWS resource with its tags.
+type taggedResource struct {
+	ID   string
+	Tags map[string]string
+}
+
+func exportTagMapping(res taggedResource) *resourcegroupstaggingapi.ResourceTagMapping {
+	return &resourcegroupstaggingapi.ResourceTagMapping{
+		ResourceARN: utility.ToStringPtr(res.ID),
+		Tags:        exportResourceTags(res.Tags),
+	}
+}
+
+func exportResourceTags(tags map[string]string) []*resourcegroupstaggingapi.Tag {
+	var exported []*resourcegroupstaggingapi.Tag
+	for k, v := range tags {
+		exported = append(exported, &resourcegroupstaggingapi.Tag{
+			Key:   utility.ToStringPtr(k),
+			Value: utility.ToStringPtr(v),
+		})
+	}
+	return exported
+}
+
+// TagClient provides a mock implementation of a cocoa.TagClient. This makes
+// it possible to introspect on inputs to the client and control the client's
+// output. It provides some default implementations where possible. By default,
+// it will issue the API calls to either the fake GlobalECSService for ECS or
+// fake GlobalSecretCache for Secrets Manager.
+type TagClient struct {
+	GetResourcesInput  *resourcegroupstaggingapi.GetResourcesInput
+	GetResourcesOutput *resourcegroupstaggingapi.GetResourcesOutput
+	GetResourcesError  error
+
+	CloseError error
+}
+
+// RegisterTaskDefinition saves the input and filters for the resources matching
+// the input filters. The mock output can be customized. By default, it will
+// search for matching resources in ECS or Secrets Manager.
+func (c *TagClient) GetResources(ctx context.Context, in *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	c.GetResourcesInput = in
+
+	if c.GetResourcesOutput != nil || c.GetResourcesError != nil {
+		return c.GetResourcesOutput, c.GetResourcesError
+	}
+
+	serviceToResourceType := map[string]string{
+		"secretsmanager": "secretsmanager:secret",
+		"ecs":            "ecs:task-definition",
+	}
+
+	// kim; TODO: logical AND across all tag filter, logical OR each individual
+	// tag filter key-values.
+	resourceTypes := map[string][]taggedResource{}
+	if len(in.ResourceTypeFilters) != 0 {
+		for _, f := range in.ResourceTypeFilters {
+			if f == nil {
+				continue
+			}
+
+			filter := utility.FromStringPtr(f)
+			var resourceType string
+			if !strings.Contains(filter, ":") {
+				var ok bool
+				resourceType, ok = serviceToResourceType[filter]
+				if !ok {
+					return nil, awserr.New(resourcegroupstaggingapi.ErrCodeInvalidParameterException, "unsupported service", nil)
+				}
+			} else {
+				resourceType = filter
+			}
+
+			resourceTypes[resourceType] = []taggedResource{}
+		}
+	} else {
+		// If no resource types are filtered, search all of them.
+		for _, resourceType := range serviceToResourceType {
+			resourceTypes[resourceType] = []taggedResource{}
+		}
+	}
+
+	for resourceType := range resourceTypes {
+		var matchingAllTags map[string]taggedResource
+
+		switch resourceType {
+		case "secretsmanager:secret":
+			if len(in.TagFilters) != 0 {
+				for _, f := range in.TagFilters {
+					if f == nil {
+						continue
+					}
+
+					matchingTag := c.secretsMatchingTag(utility.FromStringPtr(f.Key), utility.FromStringPtrSlice(f.Values))
+
+					if matchingAllTags == nil {
+						// Initialize the candidate set of matching secrets.
+						matchingAllTags = matchingTag
+					} else {
+						// Each matching secret must match all the given tag
+						// filters.
+						matchingAllTags = c.getSetIntersection(matchingAllTags, matchingTag)
+					}
+				}
+			} else {
+				matchingAllTags = map[string]taggedResource{}
+				for _, s := range GlobalSecretCache {
+					matchingAllTags[s.Name] = c.exportSecretTaggedResource(s)
+				}
+			}
+		case "ecs:task-definition":
+			if len(in.TagFilters) != 0 {
+				for _, f := range in.TagFilters {
+					if f == nil {
+						continue
+					}
+
+					matchingTag := c.taskDefsMatchingTag(utility.FromStringPtr(f.Key), utility.FromStringPtrSlice(f.Values))
+
+					if matchingAllTags == nil {
+						matchingAllTags = matchingTag
+					} else {
+						matchingAllTags = c.getSetIntersection(matchingAllTags, matchingTag)
+					}
+				}
+			} else {
+				matchingAllTags = map[string]taggedResource{}
+				for _, family := range GlobalECSService.TaskDefs {
+					for _, revision := range family {
+						matchingAllTags[revision.ARN] = c.exportTaskDefinitionTaggedResource(revision)
+					}
+				}
+			}
+		}
+
+		for _, res := range matchingAllTags {
+			resourceTypes[resourceType] = append(resourceTypes[resourceType], res)
+		}
+	}
+
+	var converted []*resourcegroupstaggingapi.ResourceTagMapping
+	for _, res := range resourceTypes {
+		for _, tags := range res {
+			converted = append(converted, exportTagMapping(tags))
+		}
+	}
+
+	return &resourcegroupstaggingapi.GetResourcesOutput{
+		ResourceTagMappingList: converted,
+	}, nil
+}
+
+func (c *TagClient) getSetIntersection(a, b map[string]taggedResource) map[string]taggedResource {
+	intersection := map[string]taggedResource{}
+	for k, v := range a {
+		if _, ok := b[k]; ok {
+			intersection[k] = v
+		}
+	}
+	return intersection
+}
+
+// secretsMatchingTag returns the tagged resources for all secrets containing a
+// matching tag key and matching one of the tag values.
+func (c *TagClient) secretsMatchingTag(key string, values []string) map[string]taggedResource {
+	res := map[string]taggedResource{}
+	for _, s := range GlobalSecretCache {
+		if s.IsDeleted {
+			continue
+		}
+
+		v, ok := s.Tags[key]
+		if !ok {
+			continue
+		}
+
+		if len(values) != 0 && !utility.StringSliceContains(values, v) {
+			continue
+		}
+
+		res[s.Name] = c.exportSecretTaggedResource(s)
+	}
+	return res
+}
+
+func (c *TagClient) exportSecretTaggedResource(s StoredSecret) taggedResource {
+	return taggedResource{
+		ID:   s.Name,
+		Tags: s.Tags,
+	}
+}
+
+// taskDefsMatchingTag returns the tagged resources for all secrets containing a
+// matching tag key and matching one of the tag values.
+func (c *TagClient) taskDefsMatchingTag(key string, values []string) map[string]taggedResource {
+	res := map[string]taggedResource{}
+	for _, family := range GlobalECSService.TaskDefs {
+		for _, def := range family {
+			if utility.FromStringPtr(def.Status) == awsECS.TaskDefinitionStatusInactive {
+				continue
+			}
+
+			v, ok := def.Tags[key]
+			if !ok {
+				continue
+			}
+
+			if len(values) != 0 && !utility.StringSliceContains(values, v) {
+				continue
+			}
+
+			res[def.ARN] = c.exportTaskDefinitionTaggedResource(def)
+		}
+	}
+	return res
+}
+
+func (c *TagClient) exportTaskDefinitionTaggedResource(def ECSTaskDefinition) taggedResource {
+	return taggedResource{
+		ID:   def.ARN,
+		Tags: def.Tags,
+	}
+}
+
+// Close closes the mock client. The mock output can be customized. By default,
+// it is a no-op that returns no error.
+func (c *TagClient) Close(ctx context.Context) error {
+	if c.CloseError != nil {
+		return c.CloseError
+	}
+
+	return nil
+}

--- a/mock/tag_client_test.go
+++ b/mock/tag_client_test.go
@@ -6,14 +6,11 @@ import (
 
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
-	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTagClient(t *testing.T) {
 	assert.Implements(t, (*cocoa.TagClient)(nil), &TagClient{})
-
-	testutil.CheckAWSEnvVarsForSecretsManager(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/mock/tag_client_test.go
+++ b/mock/tag_client_test.go
@@ -1,0 +1,52 @@
+package mock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/cocoa/internal/testcase"
+	"github.com/evergreen-ci/cocoa/internal/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagClient(t *testing.T) {
+	assert.Implements(t, (*cocoa.TagClient)(nil), &TagClient{})
+
+	testutil.CheckAWSEnvVarsForSecretsManager(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := &TagClient{}
+	defer func() {
+		assert.NoError(t, c.Close(ctx))
+	}()
+
+	for tName, tCase := range testcase.TagClientTests() {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
+			defer tcancel()
+
+			tCase(tctx, t, c)
+		})
+	}
+
+	smClient := &SecretsManagerClient{}
+	defer func() {
+		ResetGlobalSecretCache()
+
+		assert.NoError(t, smClient.Close(ctx))
+	}()
+
+	for tName, tCase := range testcase.TagClientSecretTests() {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
+			defer tcancel()
+
+			ResetGlobalSecretCache()
+
+			tCase(tctx, t, c, smClient)
+		})
+	}
+}

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -2,35 +2,15 @@ package secret
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/cocoa"
-	"github.com/evergreen-ci/cocoa/awsutil"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// validIntegrationAWSOpts returns valid options to create an AWS client for
-// integration testing that can make actual requests to AWS.
-func validIntegrationAWSOpts(hc *http.Client) awsutil.ClientOptions {
-	return *awsutil.NewClientOptions().
-		SetCredentials(credentials.NewEnvCredentials()).
-		SetRole(testutil.AWSRole()).
-		SetRegion(testutil.AWSRegion())
-}
-
-// validNonIntegrationAWSOpts returns valid options to create an AWS client that
-// doesn't make any actual requests to AWS.
-func validNonIntegrationAWSOpts(hc *http.Client) awsutil.ClientOptions {
-	return *awsutil.NewClientOptions().
-		SetCredentials(credentials.NewEnvCredentials()).
-		SetRegion("us-east-1")
-}
 
 func TestBasicSecretsManager(t *testing.T) {
 	assert.Implements(t, (*cocoa.Vault)(nil), &BasicSecretsManager{})
@@ -42,7 +22,7 @@ func TestBasicSecretsManager(t *testing.T) {
 	defer utility.PutHTTPClient(hc)
 
 	t.Run("NewBasicSecretsManager", func(t *testing.T) {
-		c, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+		c, err := NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, c.Close(ctx))
@@ -75,7 +55,7 @@ func TestSecretsManager(t *testing.T) {
 	hc := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(hc)
 
-	c, err := NewBasicSecretsManagerClient(validIntegrationAWSOpts(hc))
+	c, err := NewBasicSecretsManagerClient(testutil.ValidIntegrationAWSOptions(hc))
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupSecrets(ctx, t, c)
@@ -107,7 +87,7 @@ func TestBasicSecretsManagerOptions(t *testing.T) {
 		assert.Zero(t, *opts)
 	})
 	t.Run("SetClient", func(t *testing.T) {
-		c, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+		c, err := NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
 		require.NoError(t, err)
 		opts := NewBasicSecretsManagerOptions().SetClient(c)
 		assert.Equal(t, c, opts.Client)
@@ -129,7 +109,7 @@ func TestBasicSecretsManagerOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
-			smClient, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+			smClient, err := NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			opts := NewBasicSecretsManagerOptions().
 				SetClient(smClient).
@@ -144,7 +124,7 @@ func TestBasicSecretsManagerOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("FailsWithCacheTagButNoCache", func(t *testing.T) {
-			c, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+			c, err := NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			opts := NewBasicSecretsManagerOptions().
 				SetClient(c).
@@ -152,7 +132,7 @@ func TestBasicSecretsManagerOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("DefaultsCacheTagWithCache", func(t *testing.T) {
-			c, err := NewBasicSecretsManagerClient(validNonIntegrationAWSOpts(hc))
+			c, err := NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			opts := NewBasicSecretsManagerOptions().
 				SetClient(c).

--- a/tag.go
+++ b/tag.go
@@ -10,7 +10,7 @@ import (
 // AWS Resource Groups Tagging API. Implementations must handle retrying and
 // backoff.
 type TagClient interface {
-	// GetResources finds arbitrary AWS resources using tag filters.
+	// GetResources lists arbitrary AWS resources matching the input.
 	GetResources(ctx context.Context, in *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error)
 	// Close closes the client and cleans up its resources. Implementations
 	// should ensure that this is idempotent.

--- a/tag.go
+++ b/tag.go
@@ -1,0 +1,18 @@
+package cocoa
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+)
+
+// TagClient provides a common interface to interact with a client backed by the
+// AWS Resource Groups Tagging API. Implementations must handle retrying and
+// backoff.
+type TagClient interface {
+	// GetResources finds arbitrary AWS resources using tag filters.
+	GetResources(ctx context.Context, in *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error)
+	// Close closes the client and cleans up its resources. Implementations
+	// should ensure that this is idempotent.
+	Close(ctx context.Context) error
+}

--- a/tag/client.go
+++ b/tag/client.go
@@ -49,6 +49,7 @@ func (c *BasicTagClient) setup() error {
 	return nil
 }
 
+// GetResources finds arbitrary AWS resources that match the input filters.
 func (c *BasicTagClient) GetResources(ctx context.Context, in *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")

--- a/tag/client.go
+++ b/tag/client.go
@@ -1,0 +1,87 @@
+package tag
+
+import (
+	"context"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/evergreen-ci/cocoa/awsutil"
+	"github.com/evergreen-ci/utility"
+)
+
+// BasicTagClient provides a cocoa.TagClient implementation that wraps the AWS
+// Resource Groups Tagging API. It supports retrying requests using exponential
+// backoff and jitter.
+type BasicTagClient struct {
+	awsutil.BaseClient
+	rgt *resourcegroupstaggingapi.ResourceGroupsTaggingAPI
+}
+
+// NewBasicTagClient creates a new AWS Resource Groups Tagging API
+// client from the given options.
+func NewBasicTagClient(opts awsutil.ClientOptions) (*BasicTagClient, error) {
+	c := &BasicTagClient{
+		BaseClient: awsutil.NewBaseClient(opts),
+	}
+	if err := c.setup(); err != nil {
+		return nil, errors.Wrap(err, "setting up client")
+	}
+
+	return c, nil
+}
+
+func (c *BasicTagClient) setup() error {
+	if c.rgt != nil {
+		return nil
+	}
+
+	sess, err := c.GetSession()
+	if err != nil {
+		return errors.Wrap(err, "initializing session")
+	}
+
+	c.rgt = resourcegroupstaggingapi.New(sess)
+
+	return nil
+}
+
+func (c *BasicTagClient) GetResources(ctx context.Context, in *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	if err := c.setup(); err != nil {
+		return nil, errors.Wrap(err, "setting up client")
+	}
+
+	var out *resourcegroupstaggingapi.GetResourcesOutput
+	var err error
+	if err := utility.Retry(ctx, func() (bool, error) {
+		msg := awsutil.MakeAPILogMessage("GetResources", in)
+		out, err = c.rgt.GetResourcesWithContext(ctx, in)
+		if awsErr, ok := err.(awserr.Error); ok {
+			grip.Debug(message.WrapError(awsErr, msg))
+			if c.isNonRetryableErrorCode(awsErr.Code()) {
+				return false, err
+			}
+		}
+		return true, err
+	}, c.GetRetryOptions()); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Close cleans up all resources owned by the client.
+func (c *BasicTagClient) Close(ctx context.Context) error {
+	return c.BaseClient.Close(ctx)
+}
+
+func (c *BasicTagClient) isNonRetryableErrorCode(code string) bool {
+	switch code {
+	case resourcegroupstaggingapi.ErrCodeInvalidParameterException:
+		return true
+	default:
+		return false
+	}
+}

--- a/tag/client_test.go
+++ b/tag/client_test.go
@@ -1,4 +1,4 @@
-package secret
+package tag
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
+	"github.com/evergreen-ci/cocoa/secret"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,8 +18,8 @@ import (
 // Secrets Manager.
 const defaultTestTimeout = time.Minute
 
-func TestBasicSecretsManagerClient(t *testing.T) {
-	assert.Implements(t, (*cocoa.SecretsManagerClient)(nil), &BasicSecretsManagerClient{})
+func TestBasicTagClient(t *testing.T) {
+	assert.Implements(t, (*cocoa.TagClient)(nil), &BasicTagClient{})
 
 	testutil.CheckAWSEnvVarsForSecretsManager(t)
 
@@ -28,15 +29,13 @@ func TestBasicSecretsManagerClient(t *testing.T) {
 	hc := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(hc)
 
-	c, err := NewBasicSecretsManagerClient(testutil.ValidIntegrationAWSOptions(hc))
+	c, err := NewBasicTagClient(testutil.ValidIntegrationAWSOptions(hc))
 	require.NoError(t, err)
 	defer func() {
-		testutil.CleanupSecrets(ctx, t, c)
-
 		assert.NoError(t, c.Close(ctx))
 	}()
 
-	for tName, tCase := range testcase.SecretsManagerClientTests() {
+	for tName, tCase := range testcase.TagClientTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
@@ -45,4 +44,20 @@ func TestBasicSecretsManagerClient(t *testing.T) {
 		})
 	}
 
+	smClient, err := secret.NewBasicSecretsManagerClient(testutil.ValidIntegrationAWSOptions(hc))
+	require.NoError(t, err)
+	defer func() {
+		testutil.CleanupSecrets(ctx, t, smClient)
+
+		assert.NoError(t, smClient.Close(ctx))
+	}()
+
+	for tName, tCase := range testcase.TagClientSecretTests() {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
+			defer tcancel()
+
+			tCase(tctx, t, c, smClient)
+		})
+	}
 }

--- a/tag/client_test.go
+++ b/tag/client_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // defaultTestTimeout is the standard timeout for integration tests against
-// Secrets Manager.
+// the Resource Groups Tagging API.
 const defaultTestTimeout = time.Minute
 
 func TestBasicTagClient(t *testing.T) {

--- a/tag/doc.go
+++ b/tag/doc.go
@@ -1,0 +1,4 @@
+/*
+Package tag provides an interface to manage arbitrary tagged resources in AWS.
+*/
+package tag


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17398

* Add client for Resource Groups Tagging API. `GetResources` is a useful call to filter for AWS resources using tags, which is going to be used to find Evergreen-created resources.
* Refactor the other AWS clients to use more common base functionality in the `BaseClient` and use common test helpers for AWS-related setup.
* Add fake in-memory implementation for the tag client, which can only filter for secrets in Secrets Manager and task definitions in ECS.
* Clean up a couple tests.