### PR TITLE
EVG-17754: retry for transient ECS-side errors

### DIFF
--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -75,7 +75,7 @@ func TestConvertFailureToError(t *testing.T) {
 			reason = "some reason"
 			detail = "some detail"
 		)
-		err := ConvertFailureToError(ecs.Failure{
+		err := ConvertFailureToError(&ecs.Failure{
 			Arn:    aws.String(arn),
 			Reason: aws.String(reason),
 			Detail: aws.String(detail),
@@ -86,7 +86,7 @@ func TestConvertFailureToError(t *testing.T) {
 		assert.Contains(t, err.Error(), detail)
 	})
 	t.Run("ConvertsMissingTaskFailureToTaskNotFound", func(t *testing.T) {
-		err := ConvertFailureToError(ecs.Failure{
+		err := ConvertFailureToError(&ecs.Failure{
 			Arn:    aws.String("arn"),
 			Reason: aws.String("MISSING"),
 		})

--- a/ecs/pod.go
+++ b/ecs/pod.go
@@ -141,10 +141,7 @@ func (p *BasicECSPod) LatestStatusInfo(ctx context.Context) (*cocoa.ECSPodStatus
 	if len(out.Failures) != 0 {
 		catcher := grip.NewBasicCatcher()
 		for _, f := range out.Failures {
-			if f == nil {
-				continue
-			}
-			catcher.Add(ConvertFailureToError(*f))
+			catcher.Add(ConvertFailureToError(f))
 		}
 		return nil, errors.Wrap(catcher.Resolve(), "describing task")
 	}

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -177,10 +177,7 @@ func (pc *BasicECSPodCreator) validateRunTaskOutput(out *ecs.RunTaskOutput) erro
 	if len(out.Failures) > 0 {
 		catcher := grip.NewBasicCatcher()
 		for _, f := range out.Failures {
-			if f == nil {
-				continue
-			}
-			catcher.Add(ConvertFailureToError(*f))
+			catcher.Add(ConvertFailureToError(f))
 		}
 		return errors.Wrap(catcher.Resolve(), "running task")
 	}

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -49,6 +49,7 @@ functions:
         AWS_ECS_TASK_DEFINITION_PREFIX: ${aws_ecs_task_definition_prefix}
         AWS_ECS_TASK_ROLE: ${aws_ecs_task_role}
         AWS_ECS_EXECUTION_ROLE: ${aws_ecs_execution_role}
+        AWS_ECS_CAPACITY_PROVIDER: ${aws_ecs_capacity_provider}
   parse-results:
     command: gotest.parse_files
     type: setup

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/mongodb/grip v0.0.0-20220401165023-6a1d9bb90c21
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,9 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 h1:XDXtA5hveEEV8JB2l7nhMTp3t3cHp9ZpwcdjqyEWLlo=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/testcase/ecs_client.go
+++ b/internal/testcase/ecs_client.go
@@ -64,7 +64,10 @@ func ECSClientTests() map[string]ECSClientTestCase {
 		},
 		"RunTaskFailsWithValidButNonexistentInput": func(ctx context.Context, t *testing.T, c cocoa.ECSClient) {
 			out, err := c.RunTask(ctx, &awsECS.RunTaskInput{
-				Cluster:        aws.String(testutil.ECSClusterName()),
+				Cluster: aws.String(testutil.ECSClusterName()),
+				CapacityProviderStrategy: []*awsECS.CapacityProviderStrategyItem{
+					{CapacityProvider: aws.String(testutil.ECSCapacityProvider())},
+				},
 				TaskDefinition: aws.String(testutil.NewTaskDefinitionFamily(t) + ":1"),
 			})
 			assert.Error(t, err)
@@ -255,7 +258,10 @@ func ECSClientRegisteredTaskDefinitionTests() map[string]ECSClientRegisteredTask
 			assert.Equal(t, awsECS.TaskDefinitionStatusActive, utility.FromStringPtr(def.Status))
 
 			runOut, err := c.RunTask(ctx, &awsECS.RunTaskInput{
-				Cluster:        aws.String(testutil.ECSClusterName()),
+				Cluster: aws.String(testutil.ECSClusterName()),
+				CapacityProviderStrategy: []*awsECS.CapacityProviderStrategyItem{
+					{CapacityProvider: aws.String(testutil.ECSCapacityProvider())},
+				},
 				TaskDefinition: def.TaskDefinitionArn,
 			})
 			require.NoError(t, err)
@@ -278,7 +284,10 @@ func ECSClientRegisteredTaskDefinitionTests() map[string]ECSClientRegisteredTask
 			assert.Equal(t, awsECS.TaskDefinitionStatusActive, *def.Status)
 
 			runOut, err := c.RunTask(ctx, &awsECS.RunTaskInput{
-				Cluster:        aws.String(testutil.ECSClusterName()),
+				Cluster: aws.String(testutil.ECSClusterName()),
+				CapacityProviderStrategy: []*awsECS.CapacityProviderStrategyItem{
+					{CapacityProvider: aws.String(testutil.ECSCapacityProvider())},
+				},
 				TaskDefinition: def.TaskDefinitionArn,
 			})
 			require.NoError(t, err)
@@ -326,7 +335,10 @@ func ECSClientRegisteredTaskDefinitionTests() map[string]ECSClientRegisteredTask
 		},
 		"ListTasksSucceeds": func(ctx context.Context, t *testing.T, c cocoa.ECSClient, def awsECS.TaskDefinition) {
 			runOut, err := c.RunTask(ctx, &awsECS.RunTaskInput{
-				Cluster:        aws.String(testutil.ECSClusterName()),
+				Cluster: aws.String(testutil.ECSClusterName()),
+				CapacityProviderStrategy: []*awsECS.CapacityProviderStrategyItem{
+					{CapacityProvider: aws.String(testutil.ECSCapacityProvider())},
+				},
 				TaskDefinition: def.TaskDefinitionArn,
 			})
 			require.NoError(t, err)

--- a/internal/testcase/ecs_pod.go
+++ b/internal/testcase/ecs_pod.go
@@ -56,7 +56,8 @@ func ECSPodTests() map[string]ECSPodTestCase {
 			SetTaskRole(testutil.ECSTaskRole()).
 			SetExecutionRole(testutil.ECSExecutionRole())
 		execOpts := cocoa.NewECSPodExecutionOptions().
-			SetCluster(testutil.ECSClusterName())
+			SetCluster(testutil.ECSClusterName()).
+			SetCapacityProvider(testutil.ECSCapacityProvider())
 		return cocoa.NewECSPodCreationOptions().
 			SetDefinitionOptions(*defOpts).
 			SetExecutionOptions(*execOpts)

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -30,7 +30,6 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				AddPortMappings(*cocoa.NewPortMapping().SetContainerPort(1337)).
 				SetName("container")
 
-			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
@@ -40,7 +39,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 
 			opts := cocoa.NewECSPodCreationOptions().
 				SetDefinitionOptions(*defOpts).
-				SetExecutionOptions(*execOpts)
+				SetExecutionOptions(*validECSPodExecutionOptions())
 			assert.NoError(t, opts.Validate())
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -72,7 +71,6 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				AddEnvironmentVariables(*envVar).
 				SetName("container")
 
-			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
@@ -81,8 +79,9 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetTaskRole(testutil.ECSTaskRole()).
 				SetExecutionRole(testutil.ECSExecutionRole())
 
-			opts := cocoa.NewECSPodCreationOptions().SetDefinitionOptions(*defOpts).
-				SetExecutionOptions(*execOpts)
+			opts := cocoa.NewECSPodCreationOptions().
+				SetDefinitionOptions(*defOpts).
+				SetExecutionOptions(*validECSPodExecutionOptions())
 			assert.NoError(t, opts.Validate())
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -101,7 +100,6 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 				SetRepositoryCredentials(*creds).
 				SetName("container")
 
-			execOpts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
@@ -112,7 +110,7 @@ func ECSPodCreatorTests() map[string]ECSPodCreatorTestCase {
 
 			opts := cocoa.NewECSPodCreationOptions().
 				SetDefinitionOptions(*defOpts).
-				SetExecutionOptions(*execOpts)
+				SetExecutionOptions(*validECSPodExecutionOptions())
 			assert.NoError(t, opts.Validate())
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -148,9 +146,6 @@ func ECSPodCreatorVaultTests() map[string]ECSPodCreatorTestCase {
 				SetCPU(128).
 				SetName("container")
 
-			execOpts := cocoa.NewECSPodExecutionOptions().
-				SetCluster(testutil.ECSClusterName())
-
 			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
@@ -161,7 +156,7 @@ func ECSPodCreatorVaultTests() map[string]ECSPodCreatorTestCase {
 
 			opts := cocoa.NewECSPodCreationOptions().
 				SetDefinitionOptions(*defOpts).
-				SetExecutionOptions(*execOpts)
+				SetExecutionOptions(*validECSPodExecutionOptions())
 			assert.NoError(t, opts.Validate())
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -194,9 +189,6 @@ func ECSPodCreatorVaultTests() map[string]ECSPodCreatorTestCase {
 				SetCPU(128).
 				SetName("container")
 
-			execOpts := cocoa.NewECSPodExecutionOptions().
-				SetCluster(testutil.ECSClusterName())
-
 			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
@@ -207,7 +199,7 @@ func ECSPodCreatorVaultTests() map[string]ECSPodCreatorTestCase {
 
 			opts := cocoa.NewECSPodCreationOptions().
 				SetDefinitionOptions(*defOpts).
-				SetExecutionOptions(*execOpts)
+				SetExecutionOptions(*validECSPodExecutionOptions())
 			assert.NoError(t, opts.Validate())
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -235,9 +227,6 @@ func ECSPodCreatorVaultTests() map[string]ECSPodCreatorTestCase {
 				SetCPU(128).
 				SetName("container")
 
-			execOpts := cocoa.NewECSPodExecutionOptions().
-				SetCluster(testutil.ECSClusterName())
-
 			defOpts := cocoa.NewECSPodDefinitionOptions().
 				SetName(testutil.NewTaskDefinitionFamily(t)).
 				AddContainerDefinitions(*containerDef).
@@ -247,7 +236,7 @@ func ECSPodCreatorVaultTests() map[string]ECSPodCreatorTestCase {
 
 			opts := cocoa.NewECSPodCreationOptions().
 				SetDefinitionOptions(*defOpts).
-				SetExecutionOptions(*execOpts)
+				SetExecutionOptions(*validECSPodExecutionOptions())
 			assert.Error(t, opts.Validate())
 
 			p, err := c.CreatePod(ctx, *opts)
@@ -268,9 +257,8 @@ func ECSPodCreatorRegisteredTaskDefinitionTests() map[string]func(ctx context.Co
 	return map[string]func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator, def ecs.TaskDefinition){
 		"CreatePodFromExistingDefinitionSucceeds": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator, def ecs.TaskDefinition) {
 			taskDef := cocoa.NewECSTaskDefinition().SetID(utility.FromStringPtr(def.TaskDefinitionArn))
-			opts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 
-			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *opts)
+			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *validECSPodExecutionOptions())
 			require.NoError(t, err)
 			require.NotZero(t, p)
 
@@ -288,7 +276,7 @@ func ECSPodCreatorRegisteredTaskDefinitionTests() map[string]func(ctx context.Co
 		},
 		"CreatePodFromExistingDefinitionFailsWithNonexistentCluster": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator, def ecs.TaskDefinition) {
 			taskDef := cocoa.NewECSTaskDefinition().SetID(utility.FromStringPtr(def.TaskDefinitionArn))
-			opts := cocoa.NewECSPodExecutionOptions().SetCluster("foo")
+			opts := validECSPodExecutionOptions().SetCluster("foo")
 
 			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *opts)
 			require.Error(t, err)
@@ -296,9 +284,8 @@ func ECSPodCreatorRegisteredTaskDefinitionTests() map[string]func(ctx context.Co
 		},
 		"CreatePodFromExistingDefinitionFailsWithNonexistentTaskDefinition": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator, def ecs.TaskDefinition) {
 			taskDef := cocoa.NewECSTaskDefinition().SetID(testutil.NewTaskDefinitionFamily(t) + ":1")
-			opts := cocoa.NewECSPodExecutionOptions().SetCluster(testutil.ECSClusterName())
 
-			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *opts)
+			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *validECSPodExecutionOptions())
 			require.Error(t, err)
 			require.Zero(t, p)
 		},
@@ -307,13 +294,17 @@ func ECSPodCreatorRegisteredTaskDefinitionTests() map[string]func(ctx context.Co
 			require.NoError(t, taskDef.Validate())
 			placementOpts := cocoa.NewECSPodPlacementOptions().SetStrategy("foo")
 			require.Error(t, placementOpts.Validate())
-			opts := cocoa.NewECSPodExecutionOptions().
-				SetCluster(testutil.ECSClusterName()).
-				SetPlacementOptions(*placementOpts)
+			opts := validECSPodExecutionOptions().SetPlacementOptions(*placementOpts)
 
 			p, err := c.CreatePodFromExistingDefinition(ctx, *taskDef, *opts)
 			require.Error(t, err)
 			require.Zero(t, p)
 		},
 	}
+}
+
+func validECSPodExecutionOptions() *cocoa.ECSPodExecutionOptions {
+	return cocoa.NewECSPodExecutionOptions().
+		SetCluster(testutil.ECSClusterName()).
+		SetCapacityProvider(testutil.ECSCapacityProvider())
 }

--- a/internal/testutil/ecs.go
+++ b/internal/testutil/ecs.go
@@ -38,6 +38,12 @@ func ECSClusterName() string {
 	return os.Getenv("AWS_ECS_CLUSTER")
 }
 
+// ECSCapacityProvider returns the ECS capacity provider from the environment
+// variable.
+func ECSCapacityProvider() string {
+	return os.Getenv("AWS_ECS_CAPACITY_PROVIDER")
+}
+
 // ECSTaskRole returns the ECS task role from the environment variable.
 func ECSTaskRole() string {
 	return os.Getenv("AWS_ECS_TASK_ROLE")

--- a/internal/testutil/env.go
+++ b/internal/testutil/env.go
@@ -31,6 +31,7 @@ func CheckAWSEnvVarsForECS(t *testing.T) {
 		"AWS_ECS_TASK_DEFINITION_PREFIX",
 		"AWS_ECS_TASK_ROLE",
 		"AWS_ECS_EXECUTION_ROLE",
+		"AWS_ECS_CAPACITY_PROVIDER",
 	)
 }
 
@@ -59,6 +60,7 @@ func CheckAWSEnvVarsForECSAndSecretsManager(t *testing.T) {
 		"AWS_ECS_TASK_DEFINITION_PREFIX",
 		"AWS_ECS_TASK_ROLE",
 		"AWS_ECS_EXECUTION_ROLE",
+		"AWS_ECS_CAPACITY_PROVIDER",
 	)
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17754

* Add retries for errors that occur due to transient problems in ECS (due to waiting to scale out).
* Include capacity provider with `RunTask` requests because the cluster infrastructure no longer has a default capacity provider.