### PR TITLE
EVG-17270: remove redundant ECS naming from ECS package

### DIFF
--- a/ecs/client.go
+++ b/ecs/client.go
@@ -16,16 +16,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-// BasicECSClient provides a cocoa.ECSClient implementation that wraps the AWS
+// BasicClient provides a cocoa.ECSClient implementation that wraps the AWS
 // ECS API. It supports retrying requests using exponential backoff and jitter.
-type BasicECSClient struct {
+type BasicClient struct {
 	awsutil.BaseClient
 	ecs *ecs.ECS
 }
 
-// NewBasicECSClient creates a new AWS ECS client from the given options.
-func NewBasicECSClient(opts awsutil.ClientOptions) (*BasicECSClient, error) {
-	c := &BasicECSClient{
+// NewBasicClient creates a new AWS ECS client from the given options.
+func NewBasicClient(opts awsutil.ClientOptions) (*BasicClient, error) {
+	c := &BasicClient{
 		BaseClient: awsutil.NewBaseClient(opts),
 	}
 	if err := c.setup(); err != nil {
@@ -35,7 +35,7 @@ func NewBasicECSClient(opts awsutil.ClientOptions) (*BasicECSClient, error) {
 	return c, nil
 }
 
-func (c *BasicECSClient) setup() error {
+func (c *BasicClient) setup() error {
 	if c.ecs != nil {
 		return nil
 	}
@@ -51,7 +51,7 @@ func (c *BasicECSClient) setup() error {
 }
 
 // RegisterTaskDefinition registers a new task definition.
-func (c *BasicECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
+func (c *BasicClient) RegisterTaskDefinition(ctx context.Context, in *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")
 	}
@@ -76,7 +76,7 @@ func (c *BasicECSClient) RegisterTaskDefinition(ctx context.Context, in *ecs.Reg
 }
 
 // DescribeTaskDefinition describes an existing task definition.
-func (c *BasicECSClient) DescribeTaskDefinition(ctx context.Context, in *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
+func (c *BasicClient) DescribeTaskDefinition(ctx context.Context, in *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")
 	}
@@ -101,7 +101,7 @@ func (c *BasicECSClient) DescribeTaskDefinition(ctx context.Context, in *ecs.Des
 
 // ListTaskDefinitions returns the ARNs for the task definitions that match the
 // input filters.
-func (c *BasicECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDefinitionsInput) (*ecs.ListTaskDefinitionsOutput, error) {
+func (c *BasicClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTaskDefinitionsInput) (*ecs.ListTaskDefinitionsOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")
 	}
@@ -125,7 +125,7 @@ func (c *BasicECSClient) ListTaskDefinitions(ctx context.Context, in *ecs.ListTa
 }
 
 // DeregisterTaskDefinition deregisters an existing task definition.
-func (c *BasicECSClient) DeregisterTaskDefinition(ctx context.Context, in *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error) {
+func (c *BasicClient) DeregisterTaskDefinition(ctx context.Context, in *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")
 	}
@@ -150,7 +150,7 @@ func (c *BasicECSClient) DeregisterTaskDefinition(ctx context.Context, in *ecs.D
 }
 
 // RunTask runs a new task.
-func (c *BasicECSClient) RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
+func (c *BasicClient) RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")
 	}
@@ -205,7 +205,7 @@ func (c *BasicECSClient) RunTask(ctx context.Context, in *ecs.RunTaskInput) (*ec
 }
 
 // DescribeTasks describes one or more existing tasks.
-func (c *BasicECSClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
+func (c *BasicClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")
 	}
@@ -229,7 +229,7 @@ func (c *BasicECSClient) DescribeTasks(ctx context.Context, in *ecs.DescribeTask
 }
 
 // ListTasks returns the ARNs for the task that match the input filters.
-func (c *BasicECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
+func (c *BasicClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")
 	}
@@ -253,7 +253,7 @@ func (c *BasicECSClient) ListTasks(ctx context.Context, in *ecs.ListTasksInput) 
 }
 
 // StopTask stops a running task.
-func (c *BasicECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.StopTaskOutput, error) {
+func (c *BasicClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.StopTaskOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")
 	}
@@ -280,7 +280,7 @@ func (c *BasicECSClient) StopTask(ctx context.Context, in *ecs.StopTaskInput) (*
 }
 
 // TagResource adds tags to an existing resource in ECS.
-func (c *BasicECSClient) TagResource(ctx context.Context, in *ecs.TagResourceInput) (*ecs.TagResourceOutput, error) {
+func (c *BasicClient) TagResource(ctx context.Context, in *ecs.TagResourceInput) (*ecs.TagResourceOutput, error) {
 	if err := c.setup(); err != nil {
 		return nil, errors.Wrap(err, "setting up client")
 	}
@@ -304,13 +304,13 @@ func (c *BasicECSClient) TagResource(ctx context.Context, in *ecs.TagResourceInp
 }
 
 // Close cleans up all resources owned by the client.
-func (c *BasicECSClient) Close(ctx context.Context) error {
+func (c *BasicClient) Close(ctx context.Context) error {
 	return c.BaseClient.Close(ctx)
 }
 
 // isNonRetryableErrorCode returns whether or not the error code from ECS is
 // known to be not retryable.
-func (c *BasicECSClient) isNonRetryableErrorCode(code string) bool {
+func (c *BasicClient) isNonRetryableErrorCode(code string) bool {
 	switch code {
 	case ecs.ErrCodeAccessDeniedException,
 		ecs.ErrCodeClientException,

--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -18,7 +18,7 @@ import (
 const defaultTestTimeout = time.Minute
 
 func TestBasicECSClient(t *testing.T) {
-	assert.Implements(t, (*cocoa.ECSClient)(nil), &BasicECSClient{})
+	assert.Implements(t, (*cocoa.ECSClient)(nil), &BasicClient{})
 
 	testutil.CheckAWSEnvVarsForECS(t)
 
@@ -28,7 +28,7 @@ func TestBasicECSClient(t *testing.T) {
 	hc := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(hc)
 
-	c, err := NewBasicECSClient(testutil.ValidIntegrationAWSOptions(hc))
+	c, err := NewBasicClient(testutil.ValidIntegrationAWSOptions(hc))
 	require.NoError(t, err)
 	require.NotNil(t, c)
 

--- a/ecs/pod.go
+++ b/ecs/pod.go
@@ -10,54 +10,54 @@ import (
 	"github.com/pkg/errors"
 )
 
-// BasicECSPod represents a pod that is backed by AWS ECS.
-type BasicECSPod struct {
+// BasicPod represents a pod that is backed by AWS ECS.
+type BasicPod struct {
 	client     cocoa.ECSClient
 	vault      cocoa.Vault
 	resources  cocoa.ECSPodResources
 	statusInfo cocoa.ECSPodStatusInfo
 }
 
-// BasicECSPodOptions are options to create a basic ECS pod.
-type BasicECSPodOptions struct {
+// BasicPodOptions are options to create a basic ECS pod.
+type BasicPodOptions struct {
 	Client     cocoa.ECSClient
 	Vault      cocoa.Vault
 	Resources  *cocoa.ECSPodResources
 	StatusInfo *cocoa.ECSPodStatusInfo
 }
 
-// NewBasicECSPodOptions returns new uninitialized options to create a basic ECS
+// NewBasicPodOptions returns new uninitialized options to create a basic ECS
 // pod.
-func NewBasicECSPodOptions() *BasicECSPodOptions {
-	return &BasicECSPodOptions{}
+func NewBasicPodOptions() *BasicPodOptions {
+	return &BasicPodOptions{}
 }
 
 // SetClient sets the client the pod uses to communicate with ECS.
-func (o *BasicECSPodOptions) SetClient(c cocoa.ECSClient) *BasicECSPodOptions {
+func (o *BasicPodOptions) SetClient(c cocoa.ECSClient) *BasicPodOptions {
 	o.Client = c
 	return o
 }
 
 // SetVault sets the vault that the pod uses to manage secrets.
-func (o *BasicECSPodOptions) SetVault(v cocoa.Vault) *BasicECSPodOptions {
+func (o *BasicPodOptions) SetVault(v cocoa.Vault) *BasicPodOptions {
 	o.Vault = v
 	return o
 }
 
 // SetResources sets the resources used by the pod.
-func (o *BasicECSPodOptions) SetResources(res cocoa.ECSPodResources) *BasicECSPodOptions {
+func (o *BasicPodOptions) SetResources(res cocoa.ECSPodResources) *BasicPodOptions {
 	o.Resources = &res
 	return o
 }
 
 // SetStatusInfo sets the current status for the pod.
-func (o *BasicECSPodOptions) SetStatusInfo(s cocoa.ECSPodStatusInfo) *BasicECSPodOptions {
+func (o *BasicPodOptions) SetStatusInfo(s cocoa.ECSPodStatusInfo) *BasicPodOptions {
 	o.StatusInfo = &s
 	return o
 }
 
 // Validate checks that the required parameters to initialize a pod are given.
-func (o *BasicECSPodOptions) Validate() error {
+func (o *BasicPodOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(o.Client == nil, "must specify a client")
 	if o.Resources != nil {
@@ -73,11 +73,11 @@ func (o *BasicECSPodOptions) Validate() error {
 	return catcher.Resolve()
 }
 
-// MergeECSPodOptions merges all the given options describing an ECS pod.
+// MergePodOptions merges all the given options describing an ECS pod.
 // Options are applied in the order that they're specified and conflicting
 // options are overwritten.
-func MergeECSPodOptions(opts ...*BasicECSPodOptions) BasicECSPodOptions {
-	merged := BasicECSPodOptions{}
+func MergePodOptions(opts ...*BasicPodOptions) BasicPodOptions {
+	merged := BasicPodOptions{}
 
 	for _, opt := range opts {
 		if opt == nil {
@@ -104,13 +104,13 @@ func MergeECSPodOptions(opts ...*BasicECSPodOptions) BasicECSPodOptions {
 	return merged
 }
 
-// NewBasicECSPod initializes a new pod that is backed by ECS.
-func NewBasicECSPod(opts ...*BasicECSPodOptions) (*BasicECSPod, error) {
-	merged := MergeECSPodOptions(opts...)
+// NewBasicPod initializes a new pod that is backed by ECS.
+func NewBasicPod(opts ...*BasicPodOptions) (*BasicPod, error) {
+	merged := MergePodOptions(opts...)
 	if err := merged.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid options")
 	}
-	return &BasicECSPod{
+	return &BasicPod{
 		client:     merged.Client,
 		vault:      merged.Vault,
 		resources:  *merged.Resources,
@@ -119,17 +119,17 @@ func NewBasicECSPod(opts ...*BasicECSPodOptions) (*BasicECSPod, error) {
 }
 
 // Resources returns information about the resources used by the pod.
-func (p *BasicECSPod) Resources() cocoa.ECSPodResources {
+func (p *BasicPod) Resources() cocoa.ECSPodResources {
 	return p.resources
 }
 
 // StatusInfo returns the cached status information for the pod.
-func (p *BasicECSPod) StatusInfo() cocoa.ECSPodStatusInfo {
+func (p *BasicPod) StatusInfo() cocoa.ECSPodStatusInfo {
 	return p.statusInfo
 }
 
 // LatestStatusInfo returns the most up-to-date status information for the pod.
-func (p *BasicECSPod) LatestStatusInfo(ctx context.Context) (*cocoa.ECSPodStatusInfo, error) {
+func (p *BasicPod) LatestStatusInfo(ctx context.Context) (*cocoa.ECSPodStatusInfo, error) {
 	out, err := p.client.DescribeTasks(ctx, &ecs.DescribeTasksInput{
 		Cluster: p.resources.Cluster,
 		Tasks:   []*string{p.resources.TaskID},
@@ -156,7 +156,7 @@ func (p *BasicECSPod) LatestStatusInfo(ctx context.Context) (*cocoa.ECSPodStatus
 
 // Stop stops the running pod without cleaning up any of its underlying
 // resources.
-func (p *BasicECSPod) Stop(ctx context.Context) error {
+func (p *BasicPod) Stop(ctx context.Context) error {
 	switch p.statusInfo.Status {
 	case cocoa.StatusStopped, cocoa.StatusDeleted:
 		return nil
@@ -183,7 +183,7 @@ func (p *BasicECSPod) Stop(ctx context.Context) error {
 }
 
 // Delete deletes the pod and its owned resources.
-func (p *BasicECSPod) Delete(ctx context.Context) error {
+func (p *BasicPod) Delete(ctx context.Context) error {
 	catcher := grip.NewBasicCatcher()
 
 	catcher.Wrap(p.Stop(ctx), "stopping pod")

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBasicECSPodCreator(t *testing.T) {
-	assert.Implements(t, (*cocoa.ECSPodCreator)(nil), &BasicECSPodCreator{})
+func TestBasicPodCreator(t *testing.T) {
+	assert.Implements(t, (*cocoa.ECSPodCreator)(nil), &BasicPodCreator{})
 
 	testutil.CheckAWSEnvVarsForECSAndSecretsManager(t)
 
@@ -24,22 +24,22 @@ func TestBasicECSPodCreator(t *testing.T) {
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, c cocoa.ECSClient, v cocoa.Vault){
 		"NewPodCreatorFailsWithMissingClientAndVault": func(ctx context.Context, t *testing.T, c cocoa.ECSClient, v cocoa.Vault) {
-			podCreator, err := NewBasicECSPodCreator(nil, nil)
+			podCreator, err := NewBasicPodCreator(nil, nil)
 			require.Error(t, err)
 			require.Zero(t, podCreator)
 		},
 		"NewPodCreatorFailsWithMissingClient": func(ctx context.Context, t *testing.T, c cocoa.ECSClient, v cocoa.Vault) {
-			podCreator, err := NewBasicECSPodCreator(nil, v)
+			podCreator, err := NewBasicPodCreator(nil, v)
 			require.Error(t, err)
 			require.Zero(t, podCreator)
 		},
 		"NewPodCreatorSucceedsWithNoVault": func(ctx context.Context, t *testing.T, c cocoa.ECSClient, v cocoa.Vault) {
-			podCreator, err := NewBasicECSPodCreator(c, nil)
+			podCreator, err := NewBasicPodCreator(c, nil)
 			require.NoError(t, err)
 			require.NotZero(t, podCreator)
 		},
 		"NewPodCreatorSucceedsWithClientAndVault": func(ctx context.Context, t *testing.T, c cocoa.ECSClient, v cocoa.Vault) {
-			podCreator, err := NewBasicECSPodCreator(c, v)
+			podCreator, err := NewBasicPodCreator(c, v)
 			require.NoError(t, err)
 			require.NotZero(t, podCreator)
 		},
@@ -53,7 +53,7 @@ func TestBasicECSPodCreator(t *testing.T) {
 
 			awsOpts := testutil.ValidNonIntegrationAWSOptions()
 
-			c, err := NewBasicECSClient(awsOpts)
+			c, err := NewBasicClient(awsOpts)
 			require.NoError(t, err)
 			defer func() {
 				assert.NoError(t, c.Close(ctx))
@@ -86,7 +86,7 @@ func TestECSPodCreator(t *testing.T) {
 
 	awsOpts := testutil.ValidIntegrationAWSOptions(hc)
 
-	c, err := NewBasicECSClient(awsOpts)
+	c, err := NewBasicClient(awsOpts)
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupTaskDefinitions(ctx, t, c)
@@ -100,7 +100,7 @@ func TestECSPodCreator(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
-			pc, err := NewBasicECSPodCreator(c, nil)
+			pc, err := NewBasicPodCreator(c, nil)
 			require.NoError(t, err)
 
 			tCase(tctx, t, pc)
@@ -124,7 +124,7 @@ func TestECSPodCreator(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, m)
 
-			pc, err := NewBasicECSPodCreator(c, m)
+			pc, err := NewBasicPodCreator(c, m)
 			require.NoError(t, err)
 
 			tCase(tctx, t, pc)
@@ -144,7 +144,7 @@ func TestECSPodCreator(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
 
-			pc, err := NewBasicECSPodCreator(c, nil)
+			pc, err := NewBasicPodCreator(c, nil)
 			require.NoError(t, err)
 
 			tCase(tctx, t, pc, *registerOut.TaskDefinition)

--- a/ecs/pod_definition_manager_test.go
+++ b/ecs/pod_definition_manager_test.go
@@ -23,7 +23,7 @@ func TestBasicPodDefinitionManager(t *testing.T) {
 	defer utility.PutHTTPClient(hc)
 
 	t.Run("NewPodDefinitionManager", func(t *testing.T) {
-		c, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
+		c, err := NewBasicClient(testutil.ValidNonIntegrationAWSOptions())
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, c.Close(ctx))
@@ -52,7 +52,7 @@ func TestECSPodDefinitionManager(t *testing.T) {
 
 	awsOpts := testutil.ValidIntegrationAWSOptions(hc)
 
-	c, err := NewBasicECSClient(awsOpts)
+	c, err := NewBasicClient(awsOpts)
 	require.NoError(t, err)
 	require.NotZero(t, c)
 	defer func() {
@@ -113,7 +113,7 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 		assert.Zero(t, *opts)
 	})
 	t.Run("SetClient", func(t *testing.T) {
-		c, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
+		c, err := NewBasicClient(testutil.ValidNonIntegrationAWSOptions())
 		require.NoError(t, err)
 		opts := NewBasicPodDefinitionManagerOptions().SetClient(c)
 		assert.Equal(t, c, opts.Client)
@@ -143,7 +143,7 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("SucceedsWithAllFieldsPopulated", func(t *testing.T) {
-			ecsClient, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
+			ecsClient, err := NewBasicClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			smClient, err := secret.NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("FailsWithCacheTagButNoCache", func(t *testing.T) {
-			c, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
+			c, err := NewBasicClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			opts := NewBasicPodDefinitionManagerOptions().
 				SetClient(c).
@@ -176,7 +176,7 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		})
 		t.Run("DefaultsCacheTagWithCache", func(t *testing.T) {
-			c, err := NewBasicECSClient(testutil.ValidNonIntegrationAWSOptions())
+			c, err := NewBasicClient(testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
 			opts := NewBasicPodDefinitionManagerOptions().
 				SetClient(c).

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -51,7 +51,7 @@ func TestECSPodCreator(t *testing.T) {
 			require.NoError(t, err)
 			mv := NewVault(v)
 
-			pc, err := ecs.NewBasicECSPodCreator(c, mv)
+			pc, err := ecs.NewBasicPodCreator(c, mv)
 			require.NoError(t, err)
 
 			mpc := NewECSPodCreator(pc)
@@ -72,7 +72,7 @@ func TestECSPodCreator(t *testing.T) {
 				assert.NoError(t, c.Close(ctx))
 			}()
 
-			pc, err := ecs.NewBasicECSPodCreator(c, nil)
+			pc, err := ecs.NewBasicPodCreator(c, nil)
 			require.NoError(t, err)
 
 			mpc := NewECSPodCreator(pc)
@@ -102,7 +102,7 @@ func TestECSPodCreator(t *testing.T) {
 			require.NoError(t, err)
 			mv := NewVault(v)
 
-			pc, err := ecs.NewBasicECSPodCreator(c, mv)
+			pc, err := ecs.NewBasicPodCreator(c, mv)
 			require.NoError(t, err)
 
 			mpc := NewECSPodCreator(pc)
@@ -129,7 +129,7 @@ func TestECSPodCreator(t *testing.T) {
 				assert.NoError(t, sm.Close(tctx))
 			}()
 
-			pc, err := ecs.NewBasicECSPodCreator(c, nil)
+			pc, err := ecs.NewBasicPodCreator(c, nil)
 			require.NoError(t, err)
 
 			mpc := NewECSPodCreator(pc)

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -47,7 +47,7 @@ func TestECSPod(t *testing.T) {
 			require.NoError(t, err)
 			mv := NewVault(v)
 
-			pc, err := ecs.NewBasicECSPodCreator(c, mv)
+			pc, err := ecs.NewBasicPodCreator(c, mv)
 			require.NoError(t, err)
 			mpc := NewECSPodCreator(pc)
 
@@ -76,7 +76,7 @@ func TestECSPod(t *testing.T) {
 			require.NoError(t, err)
 			mv := NewVault(v)
 
-			pc, err := ecs.NewBasicECSPodCreator(c, mv)
+			pc, err := ecs.NewBasicPodCreator(c, mv)
 			require.NoError(t, err)
 			mpc := NewECSPodCreator(pc)
 
@@ -120,8 +120,8 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			SetExecutionOptions(*execOpts)
 	}
 
-	makePod := func(opts *ecs.BasicECSPodOptions) (*ECSPod, error) {
-		p, err := ecs.NewBasicECSPod(opts)
+	makePod := func(opts *ecs.BasicPodOptions) (*ECSPod, error) {
+		p, err := ecs.NewBasicPod(opts)
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +177,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			res.Containers = nil
 			ps := p.StatusInfo()
 			ps.Containers = nil
-			podOpts := ecs.NewBasicECSPodOptions().
+			podOpts := ecs.NewBasicPodOptions().
 				SetClient(c).
 				SetResources(res).
 				SetStatusInfo(ps)
@@ -224,7 +224,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 
 			res := p.Resources()
 			res.TaskDefinition = nil
-			podOpts := ecs.NewBasicECSPodOptions().
+			podOpts := ecs.NewBasicPodOptions().
 				SetClient(c).
 				SetResources(res).
 				SetStatusInfo(p.StatusInfo())
@@ -316,7 +316,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			p, err := pc.CreatePod(ctx, *opts)
 			require.NoError(t, err)
 
-			podOpts := ecs.NewBasicECSPodOptions().
+			podOpts := ecs.NewBasicPodOptions().
 				SetClient(c).
 				SetResources(p.Resources()).
 				SetStatusInfo(p.StatusInfo())
@@ -347,7 +347,7 @@ func ecsPodTests() map[string]func(ctx context.Context, t *testing.T, pc cocoa.E
 			res.Containers = nil
 			ps := p.StatusInfo()
 			ps.Containers = nil
-			podOpts := ecs.NewBasicECSPodOptions().
+			podOpts := ecs.NewBasicPodOptions().
 				SetClient(c).
 				SetResources(res).
 				SetStatusInfo(ps)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17270

Idiomatic Go code tries to avoid [stutter](https://sben.dev/stutter/) in naming, which is basically redundantly repeating the package name again in the types/functions/methods within the package (e.g. `ecs.BasicECSClient`). This is just a rename of the types to reduce the stuttering in the `ecs` package - it's already obvious enough that it's an ECS construct if it's taken from the `ecs` package.