### PR TITLE
EVG-17516: refactor cache tag into method

### DIFF
--- a/ecs/pod_definition_manager_test.go
+++ b/ecs/pod_definition_manager_test.go
@@ -132,11 +132,6 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 		require.NotZero(t, opts.Cache)
 		assert.Equal(t, pdc, opts.Cache)
 	})
-	t.Run("SetCacheTag", func(t *testing.T) {
-		tag := "tag"
-		opts := NewBasicPodDefinitionManagerOptions().SetCacheTag(tag)
-		assert.Equal(t, tag, utility.FromStringPtr(opts.CacheTag))
-	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("FailsWithEmpty", func(t *testing.T) {
 			opts := NewBasicPodDefinitionManagerOptions()
@@ -152,8 +147,7 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			opts := NewBasicPodDefinitionManagerOptions().
 				SetClient(ecsClient).
 				SetVault(v).
-				SetCache(&testutil.NoopECSPodDefinitionCache{}).
-				SetCacheTag("tag")
+				SetCache(&testutil.NoopECSPodDefinitionCache{Tag: "tag"})
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("FailsWithoutClient", func(t *testing.T) {
@@ -163,26 +157,8 @@ func TestBasicPodDefinitionManagerOptions(t *testing.T) {
 			require.NoError(t, err)
 			opts := NewBasicPodDefinitionManagerOptions().
 				SetVault(v).
-				SetCache(&testutil.NoopECSPodDefinitionCache{}).
-				SetCacheTag("tag")
+				SetCache(&testutil.NoopECSPodDefinitionCache{Tag: "tag"})
 			assert.Error(t, opts.Validate())
-		})
-		t.Run("FailsWithCacheTagButNoCache", func(t *testing.T) {
-			c, err := NewBasicClient(testutil.ValidNonIntegrationAWSOptions())
-			require.NoError(t, err)
-			opts := NewBasicPodDefinitionManagerOptions().
-				SetClient(c).
-				SetCacheTag("tag")
-			assert.Error(t, opts.Validate())
-		})
-		t.Run("DefaultsCacheTagWithCache", func(t *testing.T) {
-			c, err := NewBasicClient(testutil.ValidNonIntegrationAWSOptions())
-			require.NoError(t, err)
-			opts := NewBasicPodDefinitionManagerOptions().
-				SetClient(c).
-				SetCache(&testutil.NoopECSPodDefinitionCache{})
-			assert.NoError(t, opts.Validate())
-			assert.Equal(t, defaultCacheTrackingTag, utility.FromStringPtr(opts.CacheTag))
 		})
 	})
 }

--- a/ecs_pod_definition_cache.go
+++ b/ecs_pod_definition_cache.go
@@ -1,0 +1,16 @@
+package cocoa
+
+import "context"
+
+// ECSPodDefinitionCache represents an external cache that tracks pod
+// definitions.
+type ECSPodDefinitionCache interface {
+	// Put adds a new pod definition item or or updates an existing pod
+	// definition item.
+	Put(ctx context.Context, item ECSPodDefinitionItem) error
+	// Delete deletes by its unique identifier in ECS.
+	Delete(ctx context.Context, id string) error
+	// GetTag returns the name of the tracking tag to use for the pod
+	// definition. Implementations are allowed to return an empty string.
+	GetTag() string
+}

--- a/ecs_pod_definition_manager.go
+++ b/ecs_pod_definition_manager.go
@@ -2,16 +2,6 @@ package cocoa
 
 import "context"
 
-// ECSPodDefinitionCache represents an external cache that tracks pod
-// definitions.
-type ECSPodDefinitionCache interface {
-	// Put adds a new pod definition item or or updates an existing pod
-	// definition item.
-	Put(ctx context.Context, item ECSPodDefinitionItem) error
-	// Delete deletes by its unique identifier in ECS.
-	Delete(ctx context.Context, id string) error
-}
-
 // ECSPodDefinitionItem represents an item that can be cached in a
 // ECSPodDefinitionCache.
 type ECSPodDefinitionItem struct {

--- a/internal/testutil/ecs_pod_definition_cache.go
+++ b/internal/testutil/ecs_pod_definition_cache.go
@@ -7,8 +7,10 @@ import (
 )
 
 // NoopECSPodDefinitionCache is an implementation of cocoa.ECSPodDefinitionCache
-// that no-ops for all operations.
-type NoopECSPodDefinitionCache struct{}
+// that no-ops for all cache modification operations.
+type NoopECSPodDefinitionCache struct {
+	Tag string
+}
 
 // Put is a no-op.
 func (c *NoopECSPodDefinitionCache) Put(context.Context, cocoa.ECSPodDefinitionItem) error {
@@ -18,4 +20,9 @@ func (c *NoopECSPodDefinitionCache) Put(context.Context, cocoa.ECSPodDefinitionI
 // Delete is a no-op.
 func (c *NoopECSPodDefinitionCache) Delete(context.Context, string) error {
 	return nil
+}
+
+// GetTag returns the cache tag field.
+func (c *NoopECSPodDefinitionCache) GetTag() string {
+	return c.Tag
 }

--- a/internal/testutil/secret_cache.go
+++ b/internal/testutil/secret_cache.go
@@ -7,8 +7,10 @@ import (
 )
 
 // NoopSecretCache is an implementation of cocoa.SecretCache that no-ops for all
-// operations.
-type NoopSecretCache struct{}
+// cache modification operations.
+type NoopSecretCache struct {
+	Tag string
+}
 
 // Put is a no-op.
 func (c *NoopSecretCache) Put(context.Context, cocoa.SecretCacheItem) error {
@@ -18,4 +20,9 @@ func (c *NoopSecretCache) Put(context.Context, cocoa.SecretCacheItem) error {
 // Delete is a no-op.
 func (c *NoopSecretCache) Delete(context.Context, string) error {
 	return nil
+}
+
+// GetTag returns the cache tag field.
+func (c *NoopSecretCache) GetTag() string {
+	return c.Tag
 }

--- a/mock/ecs_pod_definition_cache.go
+++ b/mock/ecs_pod_definition_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/utility"
 )
 
 // ECSPodDefinitionCache provides a mock implementation of a
@@ -17,6 +18,8 @@ type ECSPodDefinitionCache struct {
 
 	DeleteInput *string
 	DeleteError error
+
+	Tag *string
 }
 
 // NewECSPodDefinitionCache creates a mock ECS pod definition cache backed
@@ -52,4 +55,14 @@ func (c *ECSPodDefinitionCache) Delete(ctx context.Context, id string) error {
 	}
 
 	return c.ECSPodDefinitionCache.Delete(ctx, id)
+}
+
+// GetTag returns the cache tracking tag. The mock output can be customized. By
+// default, it will return the tag from the backing ECS pod definition cache.
+func (c *ECSPodDefinitionCache) GetTag() string {
+	if c.Tag != nil {
+		return utility.FromStringPtr(c.Tag)
+	}
+
+	return c.ECSPodDefinitionCache.GetTag()
 }

--- a/mock/secret_cache.go
+++ b/mock/secret_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/utility"
 )
 
 // SecretCache provides a mock implementation of a cocoa.SecretCache backed by
@@ -16,6 +17,8 @@ type SecretCache struct {
 
 	DeleteInput *string
 	DeleteError error
+
+	Tag *string
 }
 
 // NewSecretCache creates a mock secret cache backed by the given secret cache.
@@ -49,4 +52,14 @@ func (c *SecretCache) Delete(ctx context.Context, id string) error {
 	}
 
 	return c.SecretCache.Delete(ctx, id)
+}
+
+// GetTag returns the cache tracking tag. The mock output can be customized. By
+// default, it will return the tag from the backing secret cache.
+func (c *SecretCache) GetTag() string {
+	if c.Tag != nil {
+		return utility.FromStringPtr(c.Tag)
+	}
+
+	return c.SecretCache.GetTag()
 }

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -98,11 +98,6 @@ func TestBasicSecretsManagerOptions(t *testing.T) {
 		require.NotZero(t, opts.Cache)
 		assert.Equal(t, sc, opts.Cache)
 	})
-	t.Run("SetCacheTag", func(t *testing.T) {
-		tag := "tag"
-		opts := NewBasicSecretsManagerOptions().SetCacheTag(tag)
-		assert.Equal(t, tag, utility.FromStringPtr(opts.CacheTag))
-	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("FailsWithEmpty", func(t *testing.T) {
 			opts := NewBasicSecretsManagerOptions()
@@ -113,32 +108,13 @@ func TestBasicSecretsManagerOptions(t *testing.T) {
 			require.NoError(t, err)
 			opts := NewBasicSecretsManagerOptions().
 				SetClient(smClient).
-				SetCache(&testutil.NoopSecretCache{}).
-				SetCacheTag("tag")
+				SetCache(&testutil.NoopSecretCache{Tag: "tag"})
 			assert.NoError(t, opts.Validate())
 		})
 		t.Run("FailsWithoutClient", func(t *testing.T) {
 			opts := NewBasicSecretsManagerOptions().
-				SetCache(&testutil.NoopSecretCache{}).
-				SetCacheTag("tag")
-			assert.Error(t, opts.Validate())
-		})
-		t.Run("FailsWithCacheTagButNoCache", func(t *testing.T) {
-			c, err := NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
-			require.NoError(t, err)
-			opts := NewBasicSecretsManagerOptions().
-				SetClient(c).
-				SetCacheTag("tag")
-			assert.Error(t, opts.Validate())
-		})
-		t.Run("DefaultsCacheTagWithCache", func(t *testing.T) {
-			c, err := NewBasicSecretsManagerClient(testutil.ValidNonIntegrationAWSOptions())
-			require.NoError(t, err)
-			opts := NewBasicSecretsManagerOptions().
-				SetClient(c).
 				SetCache(&testutil.NoopSecretCache{})
-			assert.NoError(t, opts.Validate())
-			assert.Equal(t, defaultCacheTrackingTag, utility.FromStringPtr(opts.CacheTag))
+			assert.Error(t, opts.Validate())
 		})
 	})
 }

--- a/secret_cache.go
+++ b/secret_cache.go
@@ -10,6 +10,9 @@ type SecretCache interface {
 	// Delete deletes an existing secret with the given external resource
 	// identifier from the cache.
 	Delete(ctx context.Context, id string) error
+	// GetTag returns the name of the tracking tag to use for the secret.
+	// Implementations are allowed to return an empty string.
+	GetTag() string
 }
 
 // SecretCacheItem represents an item that can be cached in a SecretCache.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17516

Refactor the cache tag parameter out of the Secrets Manager/ECS manager construction options and into the cache tag interface since the tag is only relevant if the cache is being used. There's no logical change here, just moving a field elsewhere.