### PR TITLE
EVG-18036: support pod override options

### DIFF
--- a/ecs/client.go
+++ b/ecs/client.go
@@ -365,5 +365,10 @@ func ConvertFailureToError(f *ecs.Failure) error {
 // isTaskNotFoundFailure returns whether or not the failure reason returned from
 // ECS is because the task cannot be found.
 func isTaskNotFoundFailure(f ecs.Failure) bool {
-	return f.Arn != nil && utility.FromStringPtr(f.Reason) == "MISSING"
+	return f.Arn != nil && utility.FromStringPtr(f.Reason) == ReasonTaskMissing
 }
+
+// ReasonTaskMissing indicates that a task cannot be found because it is
+// missing. This can happen for reasons such as the task never existed, or it
+// has been stopped for a long time.
+const ReasonTaskMissing = "MISSING"

--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	awsECS "github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/evergreen-ci/cocoa"
-	"github.com/evergreen-ci/cocoa/ecs"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/utility"
@@ -89,7 +88,7 @@ func TestConvertFailureToError(t *testing.T) {
 	t.Run("ConvertsMissingTaskFailureToTaskNotFound", func(t *testing.T) {
 		err := ConvertFailureToError(&awsECS.Failure{
 			Arn:    aws.String("arn"),
-			Reason: aws.String(ecs.ReasonTaskMissing),
+			Reason: aws.String(ReasonTaskMissing),
 		})
 		assert.True(t, cocoa.IsECSTaskNotFoundError(err))
 	})

--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
+	awsECS "github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/cocoa/ecs"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/utility"
@@ -52,7 +53,7 @@ func TestBasicECSClient(t *testing.T) {
 
 	registerOut := testutil.RegisterTaskDefinition(ctx, t, c, testutil.ValidRegisterTaskDefinitionInput(t))
 	defer func() {
-		_, err := c.DeregisterTaskDefinition(ctx, &ecs.DeregisterTaskDefinitionInput{
+		_, err := c.DeregisterTaskDefinition(ctx, &awsECS.DeregisterTaskDefinitionInput{
 			TaskDefinition: registerOut.TaskDefinition.TaskDefinitionArn,
 		})
 		assert.NoError(t, err)
@@ -75,7 +76,7 @@ func TestConvertFailureToError(t *testing.T) {
 			reason = "some reason"
 			detail = "some detail"
 		)
-		err := ConvertFailureToError(&ecs.Failure{
+		err := ConvertFailureToError(&awsECS.Failure{
 			Arn:    aws.String(arn),
 			Reason: aws.String(reason),
 			Detail: aws.String(detail),
@@ -86,9 +87,9 @@ func TestConvertFailureToError(t *testing.T) {
 		assert.Contains(t, err.Error(), detail)
 	})
 	t.Run("ConvertsMissingTaskFailureToTaskNotFound", func(t *testing.T) {
-		err := ConvertFailureToError(&ecs.Failure{
+		err := ConvertFailureToError(&awsECS.Failure{
 			Arn:    aws.String("arn"),
-			Reason: aws.String("MISSING"),
+			Reason: aws.String(ecs.ReasonTaskMissing),
 		})
 		assert.True(t, cocoa.IsECSTaskNotFoundError(err))
 	})

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -309,7 +309,7 @@ func (pc *BasicPodCreator) exportOverrides(opts *cocoa.ECSOverridePodDefinitionO
 }
 
 // exportOverrideContainerDefinitions converts options to override container
-// definition into equivalent ECS container overrides.
+// definitions into equivalent ECS container overrides.
 func (pc *BasicPodCreator) exportOverrideContainerDefinitions(defs []cocoa.ECSOverrideContainerDefinition) []*ecs.ContainerOverride {
 	var containerOverrides []*ecs.ContainerOverride
 

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -281,6 +281,66 @@ func ExportTags(tags map[string]string) []*ecs.Tag {
 	return ecsTags
 }
 
+// exportOverrides converts options to override the pod definition into its
+// equivalent ECS task override options.
+// kim: TODO: test
+func (pc *BasicPodCreator) exportOverrides(opts *cocoa.ECSOverridablePodDefinitionOptions) *ecs.TaskOverride {
+	if opts == nil {
+		return nil
+	}
+
+	var overrides ecs.TaskOverride
+
+	overrides.SetContainerOverrides(pc.exportOverrideContainerDefinitions(opts.ContainerDefinitions))
+
+	if opts.MemoryMB != nil {
+		overrides.SetMemory(strconv.Itoa(*opts.MemoryMB))
+	}
+	if opts.CPU != nil {
+		overrides.SetCpu(strconv.Itoa(*opts.CPU))
+	}
+	if opts.TaskRole != nil {
+		overrides.SetTaskRoleArn(*opts.TaskRole)
+	}
+	if opts.ExecutionRole != nil {
+		overrides.SetExecutionRoleArn(*opts.ExecutionRole)
+	}
+
+	return &overrides
+}
+
+// exportOverrideContainerDefinitions converts options to override container
+// definition into equivalent ECS container overrides.
+func (pc *BasicPodCreator) exportOverrideContainerDefinitions(defs []cocoa.ECSOverridableContainerDefinition) []*ecs.ContainerOverride {
+	var containerOverrides []*ecs.ContainerOverride
+
+	for _, def := range defs {
+		var containerOverride ecs.ContainerOverride
+		if def.Command != nil {
+			containerOverride.SetCommand(utility.ToStringPtrSlice(def.Command))
+		}
+		if def.MemoryMB != nil {
+			containerOverride.SetMemory(int64(*def.MemoryMB))
+		}
+		if def.CPU != nil {
+			containerOverride.SetCpu(int64(*def.CPU))
+		}
+
+		var envVars []*ecs.KeyValuePair
+		for name, value := range def.EnvVars {
+			var pair ecs.KeyValuePair
+			pair.SetName(name).SetValue(value)
+			envVars = append(envVars, &pair)
+		}
+		containerOverride.SetEnvironment(envVars)
+
+		containerOverride.SetName(utility.FromStringPtr(def.Name))
+		containerOverrides = append(containerOverrides, &containerOverride)
+	}
+
+	return containerOverrides
+}
+
 // exportStrategy converts the strategy and parameter into an ECS placement
 // strategy.
 func (pc *BasicPodCreator) exportStrategy(opts *cocoa.ECSPodPlacementOptions) []*ecs.PlacementStrategy {
@@ -433,11 +493,9 @@ func translateContainerStatusInfo(containers []*ecs.Container) []cocoa.ECSContai
 func exportPodDefinitionOptions(opts cocoa.ECSPodDefinitionOptions) *ecs.RegisterTaskDefinitionInput {
 	var taskDef ecs.RegisterTaskDefinitionInput
 
-	var containerDefs []*ecs.ContainerDefinition
-	for _, def := range opts.ContainerDefinitions {
-		containerDefs = append(containerDefs, exportContainerDefinition(def))
-	}
-	taskDef.SetContainerDefinitions(containerDefs)
+	taskDef.SetContainerDefinitions(exportContainerDefinitions(opts.ContainerDefinitions)).
+		SetFamily(utility.FromStringPtr(opts.Name)).
+		SetTags(ExportTags(opts.Tags))
 
 	if mem := utility.FromIntPtr(opts.MemoryMB); mem != 0 {
 		taskDef.SetMemory(strconv.Itoa(mem))
@@ -447,39 +505,47 @@ func exportPodDefinitionOptions(opts cocoa.ECSPodDefinitionOptions) *ecs.Registe
 		taskDef.SetCpu(strconv.Itoa(cpu))
 	}
 
+	if opts.TaskRole != nil {
+		taskDef.SetTaskRoleArn(*opts.TaskRole)
+	}
+	if opts.ExecutionRole != nil {
+		taskDef.SetExecutionRoleArn(*opts.ExecutionRole)
+	}
+
 	if opts.NetworkMode != nil {
 		taskDef.SetNetworkMode(string(*opts.NetworkMode))
 	}
 
-	taskDef.SetFamily(utility.FromStringPtr(opts.Name)).
-		SetTaskRoleArn(utility.FromStringPtr(opts.TaskRole)).
-		SetExecutionRoleArn(utility.FromStringPtr(opts.ExecutionRole)).
-		SetTags(ExportTags(opts.Tags))
-
 	return &taskDef
 }
 
-// exportContainerDefinition converts a container definition into an ECS
-// container definition input.
-func exportContainerDefinition(def cocoa.ECSContainerDefinition) *ecs.ContainerDefinition {
-	var containerDef ecs.ContainerDefinition
-	if mem := utility.FromIntPtr(def.MemoryMB); mem != 0 {
-		containerDef.SetMemory(int64(mem))
+// exportContainerDefinition converts container definitions into their
+// equivalent ECS container definition.
+func exportContainerDefinitions(defs []cocoa.ECSContainerDefinition) []*ecs.ContainerDefinition {
+	var containerDefs []*ecs.ContainerDefinition
+
+	for _, def := range defs {
+		var containerDef ecs.ContainerDefinition
+		if mem := utility.FromIntPtr(def.MemoryMB); mem != 0 {
+			containerDef.SetMemory(int64(mem))
+		}
+		if cpu := utility.FromIntPtr(def.CPU); cpu != 0 {
+			containerDef.SetCpu(int64(cpu))
+		}
+		if dir := utility.FromStringPtr(def.WorkingDir); dir != "" {
+			containerDef.SetWorkingDirectory(dir)
+		}
+		containerDef.SetCommand(utility.ToStringPtrSlice(def.Command)).
+			SetImage(utility.FromStringPtr(def.Image)).
+			SetName(utility.FromStringPtr(def.Name)).
+			SetEnvironment(exportEnvVars(def.EnvVars)).
+			SetSecrets(exportSecrets(def.EnvVars)).
+			SetRepositoryCredentials(exportRepoCreds(def.RepoCreds)).
+			SetPortMappings(exportPortMappings(def.PortMappings))
+		containerDefs = append(containerDefs, &containerDef)
 	}
-	if cpu := utility.FromIntPtr(def.CPU); cpu != 0 {
-		containerDef.SetCpu(int64(cpu))
-	}
-	if dir := utility.FromStringPtr(def.WorkingDir); dir != "" {
-		containerDef.SetWorkingDirectory(dir)
-	}
-	containerDef.SetCommand(utility.ToStringPtrSlice(def.Command)).
-		SetImage(utility.FromStringPtr(def.Image)).
-		SetName(utility.FromStringPtr(def.Name)).
-		SetEnvironment(exportEnvVars(def.EnvVars)).
-		SetSecrets(exportSecrets(def.EnvVars)).
-		SetRepositoryCredentials(exportRepoCreds(def.RepoCreds)).
-		SetPortMappings(exportPortMappings(def.PortMappings))
-	return &containerDef
+
+	return containerDefs
 }
 
 // exportRepoCreds exports the repository credentials into ECS repository
@@ -502,6 +568,7 @@ func (pc *BasicPodCreator) exportTaskExecutionOptions(opts cocoa.ECSPodExecution
 		SetTaskDefinition(utility.FromStringPtr(taskDef.ID)).
 		SetTags(ExportTags(opts.Tags)).
 		SetEnableExecuteCommand(utility.FromBoolPtr(opts.SupportsDebugMode)).
+		SetOverrides(pc.exportOverrides(opts.OverridableOpts)).
 		SetPlacementStrategy(pc.exportStrategy(opts.PlacementOpts)).
 		SetPlacementConstraints(pc.exportPlacementConstraints(opts.PlacementOpts)).
 		SetNetworkConfiguration(pc.exportAWSVPCOptions(opts.AWSVPCOpts))

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -283,8 +283,7 @@ func ExportTags(tags map[string]string) []*ecs.Tag {
 
 // exportOverrides converts options to override the pod definition into its
 // equivalent ECS task override options.
-// kim: TODO: test
-func (pc *BasicPodCreator) exportOverrides(opts *cocoa.ECSOverridablePodDefinitionOptions) *ecs.TaskOverride {
+func (pc *BasicPodCreator) exportOverrides(opts *cocoa.ECSOverridePodDefinitionOptions) *ecs.TaskOverride {
 	if opts == nil {
 		return nil
 	}
@@ -311,7 +310,7 @@ func (pc *BasicPodCreator) exportOverrides(opts *cocoa.ECSOverridablePodDefiniti
 
 // exportOverrideContainerDefinitions converts options to override container
 // definition into equivalent ECS container overrides.
-func (pc *BasicPodCreator) exportOverrideContainerDefinitions(defs []cocoa.ECSOverridableContainerDefinition) []*ecs.ContainerOverride {
+func (pc *BasicPodCreator) exportOverrideContainerDefinitions(defs []cocoa.ECSOverrideContainerDefinition) []*ecs.ContainerOverride {
 	var containerOverrides []*ecs.ContainerOverride
 
 	for _, def := range defs {
@@ -327,9 +326,9 @@ func (pc *BasicPodCreator) exportOverrideContainerDefinitions(defs []cocoa.ECSOv
 		}
 
 		var envVars []*ecs.KeyValuePair
-		for name, value := range def.EnvVars {
+		for _, envVar := range def.EnvVars {
 			var pair ecs.KeyValuePair
-			pair.SetName(name).SetValue(value)
+			pair.SetName(utility.FromStringPtr(envVar.Name)).SetValue(utility.FromStringPtr(envVar.Value))
 			envVars = append(envVars, &pair)
 		}
 		containerOverride.SetEnvironment(envVars)
@@ -568,7 +567,7 @@ func (pc *BasicPodCreator) exportTaskExecutionOptions(opts cocoa.ECSPodExecution
 		SetTaskDefinition(utility.FromStringPtr(taskDef.ID)).
 		SetTags(ExportTags(opts.Tags)).
 		SetEnableExecuteCommand(utility.FromBoolPtr(opts.SupportsDebugMode)).
-		SetOverrides(pc.exportOverrides(opts.OverridableOpts)).
+		SetOverrides(pc.exportOverrides(opts.OverrideOpts)).
 		SetPlacementStrategy(pc.exportStrategy(opts.PlacementOpts)).
 		SetPlacementConstraints(pc.exportPlacementConstraints(opts.PlacementOpts)).
 		SetNetworkConfiguration(pc.exportAWSVPCOptions(opts.AWSVPCOpts))

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -1122,6 +1122,9 @@ type ECSPodExecutionOptions struct {
 	CapacityProvider *string
 	// OverrideOpts specify options that override the settings in the pod's
 	// definition.
+	// Warning: the size of the options when serialized to JSON cannot exceed 8
+	// kB, so care should be taken to not rely too heavily on overriding the
+	// pod definition's settings.
 	OverrideOpts *ECSOverridePodDefinitionOptions
 	// PlacementOptions specify options that determine how a pod is assigned to
 	// a container instance.

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -1259,7 +1259,7 @@ func MergeECSPodExecutionOptions(opts ...ECSPodExecutionOptions) ECSPodExecution
 	return merged
 }
 
-// ECSPodExecutionOverrideOptions are options that can be specified when
+// ECSOverridePodDefinitionOptions are options that can be specified when
 // starting a pod that override those in the pod's definition.
 type ECSOverridePodDefinitionOptions struct {
 	// ContainerDefinitions defines settings that apply to individual containers
@@ -1280,8 +1280,8 @@ type ECSOverridePodDefinitionOptions struct {
 	ExecutionRole *string
 }
 
-// NewECSOverrideContainerDefinitionOptions returns new uninitialized settings
-// to override a pod definition.
+// NewECSOverridePodDefinitionOptions returns new uninitialized settings to
+// override a pod definition.
 func NewECSOverridePodDefinitionOptions() *ECSOverridePodDefinitionOptions {
 	return &ECSOverridePodDefinitionOptions{}
 }

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -1262,6 +1262,23 @@ func MergeECSPodExecutionOptions(opts ...ECSPodExecutionOptions) ECSPodExecution
 	return merged
 }
 
+// Note for future maintainenace: many of fields in
+// ECSOverridePodDefinitionOptions are shared with the ECSPodDefinitionOptions
+// because the overridable fields are a subset of the options available when
+// registering a pod definition. One natural question that arises is, if they
+// share similar fields, can the overridable fields be embedded in the pod
+// definition options? It is true that the fields available are duplicate;
+// however, the possibility of an embedded struct was explicitly rejected
+// because embedding the struct would result in more issues than just having
+// some duplicated fields. For example, since only a subset of container
+// definition fields can be overridden, ContainerDefinitions is not a suitable
+// field to embed because the override and non-override container definitions
+// support different fields. In addition, the behavior of the override fields
+// (such as for validation rules) differs depending methods on whether the
+// fields are specified when registering a pod definition or starting a pod. For
+// these reasons, it's easier to maintain two separate options structs rather
+// than try to consolidate them.
+
 // ECSOverridePodDefinitionOptions are options that can be specified when
 // starting a pod that override those in the pod's definition.
 type ECSOverridePodDefinitionOptions struct {

--- a/internal/testcase/ecs_pod_creator.go
+++ b/internal/testcase/ecs_pod_creator.go
@@ -216,33 +216,6 @@ func ECSPodCreatorVaultTests() map[string]ECSPodCreatorTestCase {
 			require.Len(t, res.Containers, 1)
 			require.Len(t, res.Containers[0].Secrets, 1)
 		},
-		"CreatePodFailsWithNewSecretsButNoExecutionRole": func(ctx context.Context, t *testing.T, c cocoa.ECSPodCreator) {
-			envVar := cocoa.NewEnvironmentVariable().SetName("envVar").
-				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName(t)).
-					SetNewValue("value"))
-			containerDef := cocoa.NewECSContainerDefinition().SetImage("image").
-				AddEnvironmentVariables(*envVar).
-				SetMemoryMB(128).
-				SetCPU(128).
-				SetName("container")
-
-			defOpts := cocoa.NewECSPodDefinitionOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t)).
-				AddContainerDefinitions(*containerDef).
-				SetMemoryMB(128).
-				SetCPU(128).
-				SetTaskRole(testutil.ECSTaskRole())
-
-			opts := cocoa.NewECSPodCreationOptions().
-				SetDefinitionOptions(*defOpts).
-				SetExecutionOptions(*validECSPodExecutionOptions())
-			assert.Error(t, opts.Validate())
-
-			p, err := c.CreatePod(ctx, *opts)
-			require.Error(t, err)
-			require.Zero(t, p)
-		},
 	}
 }
 

--- a/internal/testcase/ecs_pod_definition_manager.go
+++ b/internal/testcase/ecs_pod_definition_manager.go
@@ -176,28 +176,5 @@ func ECSPodDefinitionManagerVaultTests() map[string]ECSPodDefinitionManagerTestC
 			assert.NotZero(t, pdi.ID)
 			assert.NotZero(t, pdi.DefinitionOpts)
 		},
-		"CreatePodDefinitionFailsWithNewSecretsButNoExecutionRole": func(ctx context.Context, t *testing.T, pdm cocoa.ECSPodDefinitionManager) {
-			envVar := cocoa.NewEnvironmentVariable().SetName("envVar").
-				SetSecretOptions(*cocoa.NewSecretOptions().
-					SetName(testutil.NewSecretName(t)).
-					SetNewValue("value"))
-			containerDef := cocoa.NewECSContainerDefinition().SetImage("image").
-				AddEnvironmentVariables(*envVar).
-				SetMemoryMB(128).
-				SetCPU(128).
-				SetName("container")
-
-			opts := cocoa.NewECSPodDefinitionOptions().
-				SetName(testutil.NewTaskDefinitionFamily(t)).
-				AddContainerDefinitions(*containerDef).
-				SetMemoryMB(128).
-				SetCPU(128).
-				SetTaskRole(testutil.ECSTaskRole())
-			assert.Error(t, opts.Validate())
-
-			pdi, err := pdm.CreatePodDefinition(ctx, *opts)
-			assert.Error(t, err)
-			assert.Zero(t, pdi)
-		},
 	}
 }

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -133,6 +133,7 @@ type ECSTask struct {
 	CapacityProvider  *string
 	ContainerInstance *string
 	Containers        []ECSContainer
+	Overrides         *awsECS.TaskOverride
 	Group             *string
 	ExecEnabled       *bool
 	Status            *string
@@ -161,6 +162,7 @@ func newECSTask(in *awsECS.RunTaskInput, taskDef ECSTaskDefinition) ECSTask {
 		GoalStatus:       utility.ToStringPtr(awsECS.DesiredStatusRunning),
 		Created:          utility.ToTimePtr(time.Now()),
 		TaskDef:          taskDef,
+		Overrides:        in.Overrides,
 		Tags:             newECSTags(in.Tags),
 	}
 
@@ -179,6 +181,7 @@ func (t *ECSTask) export(includeTags bool) *awsECS.Task {
 		EnableExecuteCommand: t.ExecEnabled,
 		Group:                t.Group,
 		TaskDefinitionArn:    utility.ToStringPtr(t.TaskDef.ARN),
+		Overrides:            t.Overrides,
 		Cpu:                  t.TaskDef.CPU,
 		Memory:               t.TaskDef.MemoryMB,
 		LastStatus:           t.Status,
@@ -654,7 +657,7 @@ func (c *ECSClient) DescribeTasks(ctx context.Context, in *awsECS.DescribeTasksI
 				Arn: utility.ToStringPtr(id),
 				// This reason specifically matches the one returned by ECS when
 				// it cannot find the task.
-				Reason: utility.ToStringPtr("MISSING"),
+				Reason: utility.ToStringPtr(ecs.ReasonTaskMissing),
 			})
 			continue
 		}

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -148,7 +148,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 				SetName("env_var_name").
 				SetValue("env_var_value")
 			containerDef := cocoa.NewECSContainerDefinition().
-				SetName("name").
+				SetName("container_name").
 				SetImage("image").
 				SetCommand([]string{"echo", "foo"}).
 				SetWorkingDir("working_dir").
@@ -167,6 +167,7 @@ func ecsPodCreatorTests() map[string]func(ctx context.Context, t *testing.T, pc 
 				SetName("override_env_var_name").
 				SetValue("override_env_var_value")
 			overrideContainerDef := cocoa.NewECSOverrideContainerDefinition().
+				SetName("container_name").
 				SetMemoryMB(1000).
 				SetCPU(2000).
 				SetCommand([]string{"echo", "override"}).


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18036

This exposes a feature in the ECS SDK that will alleviate the issues where Evergreen is not reusing the same pod definition. The issue there is that the `POD_ID` environment variable is unique for each newly-created pod, so each pod definition ends up being different for each pod.

We can work around this by setting the `POD_ID` environment variable when running the pod instead of when registering its definition. `RunTask` offers [options to explicitly override the settings that were set when the definition was registered](https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#TaskOverride). This PR makes the necessary changes to the Cocoa API so that callers can set the overriding values when running the task.

* Add settings to override pod definition settings when running the pod.
* Add a const for the failure message when the task ARN does not exist. Not really related to the rest of the PR, it was just a little cleanup.