### PR TITLE
EVG-18305: Add overrides to ECS options merge function

### DIFF
--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -1257,6 +1257,10 @@ func MergeECSPodExecutionOptions(opts ...ECSPodExecutionOptions) ECSPodExecution
 		if opt.Tags != nil {
 			merged.Tags = opt.Tags
 		}
+
+		if opt.OverrideOpts != nil {
+			merged.OverrideOpts = opt.OverrideOpts
+		}
 	}
 
 	return merged


### PR DESCRIPTION
[EVG-18305](https://jira.mongodb.org/browse/EVG-18305)

### Description 
Now that we've moved environment variables to the override options, the [MergeECSPodExecutionOptions](https://github.com/evergreen-ci/cocoa/blob/main/ecs_pod_creator.go#L1233) needs to respect the OverrideOpts as well.
### Testing
Tested in staging. 