### PR TITLE
EVG-19155: Add log configurations to container definitions

### DIFF
--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -555,7 +555,11 @@ func exportLogConfiguration(logConfiguration *cocoa.LogConfiguration) *ecs.LogCo
 	}
 	var converted ecs.LogConfiguration
 	converted.SetLogDriver(utility.FromStringPtr(logConfiguration.LogDriver))
-	converted.SetOptions(logConfiguration.Options)
+	options := map[string]*string{}
+	for k, v := range logConfiguration.Options {
+		options[k] = utility.ToStringPtr(v)
+	}
+	converted.SetOptions(options)
 	return &converted
 }
 

--- a/ecs/pod_creator.go
+++ b/ecs/pod_creator.go
@@ -539,12 +539,24 @@ func exportContainerDefinitions(defs []cocoa.ECSContainerDefinition) []*ecs.Cont
 			SetName(utility.FromStringPtr(def.Name)).
 			SetEnvironment(exportEnvVars(def.EnvVars)).
 			SetSecrets(exportSecrets(def.EnvVars)).
+			SetLogConfiguration(exportLogConfiguration(def.LogConfiguration)).
 			SetRepositoryCredentials(exportRepoCreds(def.RepoCreds)).
 			SetPortMappings(exportPortMappings(def.PortMappings))
 		containerDefs = append(containerDefs, &containerDef)
 	}
 
 	return containerDefs
+}
+
+// exportLogConfiguration exports the log configuration into ECS log configuration.
+func exportLogConfiguration(logConfiguration *cocoa.LogConfiguration) *ecs.LogConfiguration {
+	if logConfiguration == nil {
+		return nil
+	}
+	var converted ecs.LogConfiguration
+	converted.SetLogDriver(utility.FromStringPtr(logConfiguration.LogDriver))
+	converted.SetOptions(logConfiguration.Options)
+	return &converted
 }
 
 // exportRepoCreds exports the repository credentials into ECS repository

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -912,6 +912,13 @@ func (c *LogConfiguration) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(c.LogDriver == nil, "must specify a log driver")
 	catcher.NewWhen(c.Options == nil, "must specify log driver options")
+	if c.Options != nil {
+		_, groupDefined := c.Options["awslogs-group"]
+		_, regionDefined := c.Options["awslogs-region"]
+		catcher.NewWhen(!groupDefined, "must specify awslogs-group in options")
+		catcher.NewWhen(!regionDefined, "must specify awslogs-region in options")
+	}
+	catcher.NewWhen(c.Options != nil && c.Options["awslogs-group"] == nil, "must specify log driver options")
 	return catcher.Resolve()
 }
 

--- a/ecs_pod_creator.go
+++ b/ecs_pod_creator.go
@@ -907,7 +907,7 @@ func (c *LogConfiguration) SetOptions(o map[string]string) *LogConfiguration {
 	return c
 }
 
-// Validate checks that the log driver as well as required groups "awslogs-group" and "awslogs-region" are set.
+// Validate checks that the log driver as well as required groups "awslogs-group" and "awslogs-region" are both set.
 func (c *LogConfiguration) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(c.LogDriver == nil, "must specify a log driver")

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -903,7 +903,7 @@ func TestECSContainerDefinition(t *testing.T) {
 			})
 
 		def := NewECSContainerDefinition().SetLogConfiguration(*lc)
-		assert.Len(t, def.LogConfiguration.Options, 3)
+		assert.Len(t, def.LogConfiguration.Options, 2)
 		assert.Equal(t, awsECS.LogDriverAwslogs, utility.FromStringPtr(def.LogConfiguration.LogDriver))
 
 		def = NewECSContainerDefinition().SetLogConfiguration(LogConfiguration{})

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -2,6 +2,7 @@ package cocoa
 
 import (
 	"fmt"
+	awsECS "github.com/aws/aws-sdk-go/service/ecs"
 	"testing"
 
 	"github.com/evergreen-ci/utility"
@@ -705,6 +706,39 @@ func TestECSPodDefinition(t *testing.T) {
 
 			assert.NotEqual(t, h0, h1, "container repo creds name should affect hash")
 		})
+		t.Run("ChangesForDifferentLogConfiguration", func(t *testing.T) {
+			opts := getValidPodDefOpts()
+			creds := NewRepositoryCredentials().SetID("id")
+			opts.ContainerDefinitions[0].SetRepositoryCredentials(*creds)
+			assert.NotEqual(t, baseHash, opts.Hash(), "container repo creds should affect hash")
+		})
+		t.Run("ChangesForDifferentLogConfigurationDriver", func(t *testing.T) {
+			opts := getValidPodDefOpts()
+
+			logConf := NewLogConfiguration()
+			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf)
+			h0 := opts.Hash()
+
+			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf.SetLogDriver(awsECS.LogDriverAwslogs))
+			h1 := opts.Hash()
+
+			assert.NotEqual(t, h0, h1, "log configuration driver should affect hash")
+		})
+		t.Run("ChangesForDifferentLogConfigurationOptions", func(t *testing.T) {
+			opts := getValidPodDefOpts()
+
+			logConf := NewLogConfiguration()
+			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf)
+			h0 := opts.Hash()
+
+			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf.SetOptions(map[string]*string{"key": utility.ToStringPtr("value")}))
+			h1 := opts.Hash()
+
+			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf.SetOptions(map[string]*string{"key": utility.ToStringPtr("value"), "key2": utility.ToStringPtr("value")}))
+			h2 := opts.Hash()
+
+			assert.NotEqual(t, h0, h1, h2, "log configuration options should affect hash")
+		})
 		t.Run("ChangesForDifferentPortMappings", func(t *testing.T) {
 			opts := getValidPodDefOpts()
 
@@ -859,6 +893,22 @@ func TestECSContainerDefinition(t *testing.T) {
 
 		def.AddPortMappings()
 		assert.ElementsMatch(t, pms, def.PortMappings)
+	})
+	t.Run("SetLogConfiguration", func(t *testing.T) {
+		lc := NewLogConfiguration().
+			SetLogDriver(awsECS.LogDriverAwslogs).
+			SetOptions(map[string]*string{
+				"awslogs-group":         utility.ToStringPtr("group"),
+				"awslogs-region":        utility.ToStringPtr("region"),
+				"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+			})
+
+		def := NewECSContainerDefinition().SetLogConfiguration(*lc)
+		assert.Len(t, def.LogConfiguration.Options, 3)
+		assert.Equal(t, awsECS.LogDriverAwslogs, utility.FromStringPtr(def.LogConfiguration.LogDriver))
+
+		def = NewECSContainerDefinition().SetLogConfiguration(LogConfiguration{})
+		assert.Empty(t, def.LogConfiguration)
 	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
@@ -1241,6 +1291,61 @@ func TestPortMappings(t *testing.T) {
 				SetContainerPort(1337).
 				SetHostPort(100000)
 			assert.Error(t, pm.Validate())
+		})
+	})
+}
+
+func TestLogConfiguration(t *testing.T) {
+	t.Run("NewLogConfiguration", func(t *testing.T) {
+		lc := NewLogConfiguration()
+		require.NotZero(t, lc)
+		assert.Zero(t, *lc)
+	})
+	t.Run("SetLogDriver", func(t *testing.T) {
+		driver := awsECS.LogDriverAwslogs
+		lc := NewLogConfiguration().SetLogDriver(awsECS.LogDriverAwslogs)
+		assert.Equal(t, driver, utility.FromStringPtr(lc.LogDriver))
+	})
+	t.Run("SetOptions", func(t *testing.T) {
+		options := map[string]*string{
+			"awslogs-group":         utility.ToStringPtr("group"),
+			"awslogs-region":        utility.ToStringPtr("region"),
+			"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+		}
+		lc := NewLogConfiguration().SetOptions(map[string]*string{
+			"awslogs-group":         utility.ToStringPtr("group"),
+			"awslogs-region":        utility.ToStringPtr("region"),
+			"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+		})
+		assert.Equal(t, options, lc.Options)
+	})
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("FailsWithNoFieldsPopulated", func(t *testing.T) {
+			pm := NewLogConfiguration()
+			assert.Error(t, pm.Validate())
+		})
+		t.Run("FailsWithNoDriverPopulated", func(t *testing.T) {
+			lc := NewLogConfiguration().
+				SetOptions(map[string]*string{
+					"awslogs-group":         utility.ToStringPtr("group"),
+					"awslogs-region":        utility.ToStringPtr("region"),
+					"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+				})
+			assert.Error(t, lc.Validate())
+		})
+		t.Run("FailsWithNoOptionsPopulated", func(t *testing.T) {
+			lc := NewLogConfiguration().SetLogDriver(awsECS.LogDriverAwslogs)
+			assert.Error(t, lc.Validate())
+		})
+		t.Run("SucceedsWithDriverAndOptions", func(t *testing.T) {
+			lc := NewLogConfiguration().
+				SetLogDriver(awsECS.LogDriverAwslogs).
+				SetOptions(map[string]*string{
+					"awslogs-group":         utility.ToStringPtr("group"),
+					"awslogs-region":        utility.ToStringPtr("region"),
+					"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+				})
+			assert.NoError(t, lc.Validate())
 		})
 	})
 }

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -2,9 +2,9 @@ package cocoa
 
 import (
 	"fmt"
-	awsECS "github.com/aws/aws-sdk-go/service/ecs"
 	"testing"
 
+	awsECS "github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -898,9 +898,8 @@ func TestECSContainerDefinition(t *testing.T) {
 		lc := NewLogConfiguration().
 			SetLogDriver(awsECS.LogDriverAwslogs).
 			SetOptions(map[string]*string{
-				"awslogs-group":         utility.ToStringPtr("group"),
-				"awslogs-region":        utility.ToStringPtr("region"),
-				"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+				"awslogs-group":  utility.ToStringPtr("group"),
+				"awslogs-region": utility.ToStringPtr("region"),
 			})
 
 		def := NewECSContainerDefinition().SetLogConfiguration(*lc)
@@ -1308,14 +1307,12 @@ func TestLogConfiguration(t *testing.T) {
 	})
 	t.Run("SetOptions", func(t *testing.T) {
 		options := map[string]*string{
-			"awslogs-group":         utility.ToStringPtr("group"),
-			"awslogs-region":        utility.ToStringPtr("region"),
-			"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+			"awslogs-group":  utility.ToStringPtr("group"),
+			"awslogs-region": utility.ToStringPtr("region"),
 		}
 		lc := NewLogConfiguration().SetOptions(map[string]*string{
-			"awslogs-group":         utility.ToStringPtr("group"),
-			"awslogs-region":        utility.ToStringPtr("region"),
-			"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+			"awslogs-group":  utility.ToStringPtr("group"),
+			"awslogs-region": utility.ToStringPtr("region"),
 		})
 		assert.Equal(t, options, lc.Options)
 	})
@@ -1327,9 +1324,8 @@ func TestLogConfiguration(t *testing.T) {
 		t.Run("FailsWithNoDriverPopulated", func(t *testing.T) {
 			lc := NewLogConfiguration().
 				SetOptions(map[string]*string{
-					"awslogs-group":         utility.ToStringPtr("group"),
-					"awslogs-region":        utility.ToStringPtr("region"),
-					"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+					"awslogs-group":  utility.ToStringPtr("group"),
+					"awslogs-region": utility.ToStringPtr("region"),
 				})
 			assert.Error(t, lc.Validate())
 		})
@@ -1337,13 +1333,28 @@ func TestLogConfiguration(t *testing.T) {
 			lc := NewLogConfiguration().SetLogDriver(awsECS.LogDriverAwslogs)
 			assert.Error(t, lc.Validate())
 		})
+		t.Run("FailsWithNoLogGroupOption", func(t *testing.T) {
+			lc := NewLogConfiguration().
+				SetLogDriver(awsECS.LogDriverAwslogs).
+				SetOptions(map[string]*string{
+					"awslogs-region": utility.ToStringPtr("region"),
+				})
+			assert.Error(t, lc.Validate())
+		})
+		t.Run("FailsWithNoRegionOption", func(t *testing.T) {
+			lc := NewLogConfiguration().
+				SetLogDriver(awsECS.LogDriverAwslogs).
+				SetOptions(map[string]*string{
+					"awslogs-group": utility.ToStringPtr("group"),
+				})
+			assert.Error(t, lc.Validate())
+		})
 		t.Run("SucceedsWithDriverAndOptions", func(t *testing.T) {
 			lc := NewLogConfiguration().
 				SetLogDriver(awsECS.LogDriverAwslogs).
 				SetOptions(map[string]*string{
-					"awslogs-group":         utility.ToStringPtr("group"),
-					"awslogs-region":        utility.ToStringPtr("region"),
-					"awslogs-stream-prefix": utility.ToStringPtr("prefix"),
+					"awslogs-group":  utility.ToStringPtr("group"),
+					"awslogs-region": utility.ToStringPtr("region"),
 				})
 			assert.NoError(t, lc.Validate())
 		})

--- a/ecs_pod_creator_test.go
+++ b/ecs_pod_creator_test.go
@@ -731,13 +731,28 @@ func TestECSPodDefinition(t *testing.T) {
 			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf)
 			h0 := opts.Hash()
 
-			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf.SetOptions(map[string]*string{"key": utility.ToStringPtr("value")}))
+			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf.SetOptions(map[string]string{"key": "value"}))
 			h1 := opts.Hash()
 
-			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf.SetOptions(map[string]*string{"key": utility.ToStringPtr("value"), "key2": utility.ToStringPtr("value")}))
+			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf.SetOptions(map[string]string{"key": "value", "key2": "value"}))
 			h2 := opts.Hash()
 
 			assert.NotEqual(t, h0, h1, h2, "log configuration options should affect hash")
+		})
+		t.Run("ReturnsSameValueForSameUnorderedLogConfigurationOptions", func(t *testing.T) {
+			opts := getValidPodDefOpts()
+
+			logConf := NewLogConfiguration()
+			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf)
+			logConfOptions := map[string]string{}
+
+			for i := 0; i < 10; i++ {
+				logConfOptions[utility.RandomString()] = utility.RandomString()
+			}
+			opts.ContainerDefinitions[0].SetLogConfiguration(*logConf.SetOptions(logConfOptions))
+			h0 := opts.Hash()
+			h1 := opts.Hash()
+			assert.Equal(t, h0, h1, "order of log configuration options should not affect hash")
 		})
 		t.Run("ChangesForDifferentPortMappings", func(t *testing.T) {
 			opts := getValidPodDefOpts()
@@ -897,9 +912,9 @@ func TestECSContainerDefinition(t *testing.T) {
 	t.Run("SetLogConfiguration", func(t *testing.T) {
 		lc := NewLogConfiguration().
 			SetLogDriver(awsECS.LogDriverAwslogs).
-			SetOptions(map[string]*string{
-				"awslogs-group":  utility.ToStringPtr("group"),
-				"awslogs-region": utility.ToStringPtr("region"),
+			SetOptions(map[string]string{
+				"awslogs-group":  "group",
+				"awslogs-region": "region",
 			})
 
 		def := NewECSContainerDefinition().SetLogConfiguration(*lc)
@@ -1306,13 +1321,13 @@ func TestLogConfiguration(t *testing.T) {
 		assert.Equal(t, driver, utility.FromStringPtr(lc.LogDriver))
 	})
 	t.Run("SetOptions", func(t *testing.T) {
-		options := map[string]*string{
-			"awslogs-group":  utility.ToStringPtr("group"),
-			"awslogs-region": utility.ToStringPtr("region"),
+		options := map[string]string{
+			"awslogs-group":  "group",
+			"awslogs-region": "region",
 		}
-		lc := NewLogConfiguration().SetOptions(map[string]*string{
-			"awslogs-group":  utility.ToStringPtr("group"),
-			"awslogs-region": utility.ToStringPtr("region"),
+		lc := NewLogConfiguration().SetOptions(map[string]string{
+			"awslogs-group":  "group",
+			"awslogs-region": "region",
 		})
 		assert.Equal(t, options, lc.Options)
 	})
@@ -1323,9 +1338,9 @@ func TestLogConfiguration(t *testing.T) {
 		})
 		t.Run("FailsWithNoDriverPopulated", func(t *testing.T) {
 			lc := NewLogConfiguration().
-				SetOptions(map[string]*string{
-					"awslogs-group":  utility.ToStringPtr("group"),
-					"awslogs-region": utility.ToStringPtr("region"),
+				SetOptions(map[string]string{
+					"awslogs-group":  "group",
+					"awslogs-region": "region",
 				})
 			assert.Error(t, lc.Validate())
 		})
@@ -1336,25 +1351,25 @@ func TestLogConfiguration(t *testing.T) {
 		t.Run("FailsWithNoLogGroupOption", func(t *testing.T) {
 			lc := NewLogConfiguration().
 				SetLogDriver(awsECS.LogDriverAwslogs).
-				SetOptions(map[string]*string{
-					"awslogs-region": utility.ToStringPtr("region"),
+				SetOptions(map[string]string{
+					"awslogs-region": "region",
 				})
 			assert.Error(t, lc.Validate())
 		})
 		t.Run("FailsWithNoRegionOption", func(t *testing.T) {
 			lc := NewLogConfiguration().
 				SetLogDriver(awsECS.LogDriverAwslogs).
-				SetOptions(map[string]*string{
-					"awslogs-group": utility.ToStringPtr("group"),
+				SetOptions(map[string]string{
+					"awslogs-group": "group",
 				})
 			assert.Error(t, lc.Validate())
 		})
 		t.Run("SucceedsWithDriverAndOptions", func(t *testing.T) {
 			lc := NewLogConfiguration().
 				SetLogDriver(awsECS.LogDriverAwslogs).
-				SetOptions(map[string]*string{
-					"awslogs-group":  utility.ToStringPtr("group"),
-					"awslogs-region": utility.ToStringPtr("region"),
+				SetOptions(map[string]string{
+					"awslogs-group":  "group",
+					"awslogs-region": "region",
 				})
 			assert.NoError(t, lc.Validate())
 		})


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-19155

This adds a `LogConfiguration` parameter in our container definitions that is meant to follow the standard defined in the [AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html) to enable logging for our ECS cluster

* Added hashing and validation to the new `LogConfiguration` struct
* Tested originally with some hardcoded values and confirmed container logs are now viewable in AWS. Will make a separate Evergreen-side PR to make this more flexibly configurable as well.