### PR TITLE
DEVPROD-6951 cache AWS config

### DIFF
--- a/awsutil/base_client.go
+++ b/awsutil/base_client.go
@@ -47,9 +47,3 @@ func (c *BaseClient) GetRetryOptions() utility.RetryOptions {
 	}
 	return *c.opts.RetryOpts
 }
-
-// Close closes the client and cleans up its resources.
-func (c *BaseClient) Close(ctx context.Context) error {
-	c.opts.Close()
-	return nil
-}

--- a/awsutil/client_options.go
+++ b/awsutil/client_options.go
@@ -33,7 +33,6 @@ type ClientOptions struct {
 
 	stsClient   *sts.Client
 	stsProvider *stscreds.AssumeRoleProvider
-	config      *aws.Config
 }
 
 // NewClientOptions returns new unconfigured client options.
@@ -97,6 +96,8 @@ func getAWSConfig(ctx context.Context, region string, httpClient *http.Client, c
 	if err != nil {
 		return nil, errors.Wrap(err, "loading default AWS config")
 	}
+	otelaws.AppendMiddlewares(&config.APIOptions)
+
 	if cachableConfig {
 		configCache[region] = &config
 	}
@@ -139,9 +140,5 @@ func (o *ClientOptions) GetConfig(ctx context.Context) (*aws.Config, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "creating config")
 	}
-	otelaws.AppendMiddlewares(&config.APIOptions)
-
-	o.config = config
-
-	return o.config, nil
+	return config, nil
 }

--- a/awsutil/client_options.go
+++ b/awsutil/client_options.go
@@ -34,8 +34,6 @@ type ClientOptions struct {
 	stsClient   *sts.Client
 	stsProvider *stscreds.AssumeRoleProvider
 	config      *aws.Config
-
-	ownsHTTPClient bool
 }
 
 // NewClientOptions returns new unconfigured client options.
@@ -75,11 +73,6 @@ func (o *ClientOptions) SetHTTPClient(hc *http.Client) *ClientOptions {
 
 // Validate sets defaults for unspecified options.
 func (o *ClientOptions) Validate() error {
-	if o.HTTPClient == nil {
-		o.HTTPClient = utility.GetHTTPClient()
-		o.ownsHTTPClient = true
-	}
-
 	if o.RetryOpts == nil {
 		o.RetryOpts = &utility.RetryOptions{}
 	}
@@ -136,11 +129,4 @@ func (o *ClientOptions) GetConfig(ctx context.Context) (*aws.Config, error) {
 	o.config = &config
 
 	return o.config, nil
-}
-
-// Close cleans up the HTTP client if it is owned by this client.
-func (o *ClientOptions) Close() {
-	if o.ownsHTTPClient {
-		utility.PutHTTPClient(o.HTTPClient)
-	}
 }

--- a/awsutil/client_options.go
+++ b/awsutil/client_options.go
@@ -2,7 +2,6 @@ package awsutil
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -19,6 +18,7 @@ type ClientOptions struct {
 	// CredsProvider is a credentials provider, which may be used to either connect to
 	// the AWS API directly, or authenticate to STS to retrieve temporary
 	// credentials to access the API (if Role is specified).
+	// If not specified the AWS SDK will attempt to retrieve one from its credentials chain.
 	CredsProvider aws.CredentialsProvider
 	// Role is the STS role that should be used to perform authorized actions.
 	// If specified, Creds will be used to retrieve temporary credentials from
@@ -29,7 +29,8 @@ type ClientOptions struct {
 	// RetryOpts sets the retry policy for API requests.
 	RetryOpts *utility.RetryOptions
 	// HTTPClient is the HTTP client to use to make requests.
-	HTTPClient *http.Client
+	// If not specified the AWS SDK's default client will be used.
+	HTTPClient config.HTTPClient
 
 	stsClient   *sts.Client
 	stsProvider *stscreds.AssumeRoleProvider
@@ -65,7 +66,7 @@ func (o *ClientOptions) SetRetryOptions(opts utility.RetryOptions) *ClientOption
 }
 
 // SetHTTPClient sets the HTTP client to use.
-func (o *ClientOptions) SetHTTPClient(hc *http.Client) *ClientOptions {
+func (o *ClientOptions) SetHTTPClient(hc config.HTTPClient) *ClientOptions {
 	o.HTTPClient = hc
 	return o
 }
@@ -82,7 +83,7 @@ func (o *ClientOptions) Validate() error {
 
 var configCache = make(map[string]*aws.Config)
 
-func getAWSConfig(ctx context.Context, region string, httpClient *http.Client, credsProvider aws.CredentialsProvider) (*aws.Config, error) {
+func getAWSConfig(ctx context.Context, region string, httpClient config.HTTPClient, credsProvider aws.CredentialsProvider) (*aws.Config, error) {
 	cachableConfig := httpClient == nil && credsProvider == nil
 	if cachableConfig && configCache[region] != nil {
 		return configCache[region], nil

--- a/awsutil/client_options.go
+++ b/awsutil/client_options.go
@@ -83,6 +83,8 @@ func (o *ClientOptions) Validate() error {
 
 var configCache = make(map[string]*aws.Config)
 
+// getAWSConfig fetches an aws.Config for the provided region, httpClient, and credsProvider. The config is cached since the AWS SDK will make a call
+// to STS each time config.LoadDefaultConfig is called if a credsProvider is not provided and we're running in Kubernetes.
 func getAWSConfig(ctx context.Context, region string, httpClient config.HTTPClient, credsProvider aws.CredentialsProvider) (*aws.Config, error) {
 	cachableConfig := httpClient == nil && credsProvider == nil
 	if cachableConfig && configCache[region] != nil {

--- a/awsutil/client_options.go
+++ b/awsutil/client_options.go
@@ -81,6 +81,29 @@ func (o *ClientOptions) Validate() error {
 	return nil
 }
 
+var configCache = make(map[string]*aws.Config)
+
+func getAWSConfig(ctx context.Context, region string, httpClient *http.Client, credsProvider aws.CredentialsProvider) (*aws.Config, error) {
+	cachableConfig := httpClient == nil && credsProvider == nil
+	if cachableConfig && configCache[region] != nil {
+		return configCache[region], nil
+	}
+
+	config, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+		config.WithHTTPClient(httpClient),
+		config.WithCredentialsProvider(credsProvider),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading default AWS config")
+	}
+	if cachableConfig {
+		configCache[region] = &config
+	}
+
+	return &config, nil
+}
+
 // GetCredentialsProvider retrieves the appropriate credentials provider to use for the client.
 func (o *ClientOptions) GetCredentialsProvider(ctx context.Context) (aws.CredentialsProvider, error) {
 	if o.Role == nil {
@@ -92,16 +115,12 @@ func (o *ClientOptions) GetCredentialsProvider(ctx context.Context) (aws.Credent
 	}
 
 	if o.stsClient == nil {
-		config, err := config.LoadDefaultConfig(ctx,
-			config.WithRegion(utility.FromStringPtr(o.Region)),
-			config.WithHTTPClient(o.HTTPClient),
-			config.WithCredentialsProvider(o.CredsProvider),
-		)
+		config, err := getAWSConfig(ctx, utility.FromStringPtr(o.Region), o.HTTPClient, o.CredsProvider)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating STS config")
 		}
 
-		o.stsClient = sts.NewFromConfig(config)
+		o.stsClient = sts.NewFromConfig(*config)
 	}
 
 	o.stsProvider = stscreds.NewAssumeRoleProvider(o.stsClient, *o.Role)
@@ -116,17 +135,13 @@ func (o *ClientOptions) GetConfig(ctx context.Context) (*aws.Config, error) {
 		return nil, errors.Wrap(err, "getting credentials")
 	}
 
-	config, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(utility.FromStringPtr(o.Region)),
-		config.WithHTTPClient(o.HTTPClient),
-		config.WithCredentialsProvider(creds),
-	)
+	config, err := getAWSConfig(ctx, utility.FromStringPtr(o.Region), o.HTTPClient, creds)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating config")
 	}
 	otelaws.AppendMiddlewares(&config.APIOptions)
 
-	o.config = &config
+	o.config = config
 
 	return o.config, nil
 }

--- a/awsutil/client_options_test.go
+++ b/awsutil/client_options_test.go
@@ -44,7 +44,6 @@ func TestClientOptions(t *testing.T) {
 		opts := NewClientOptions().SetHTTPClient(hc)
 		require.NotNil(t, opts.HTTPClient)
 		assert.Equal(t, hc, opts.HTTPClient)
-		assert.False(t, opts.ownsHTTPClient)
 	})
 	t.Run("Validate", func(t *testing.T) {
 		t.Run("SucceedsWithAllOptionSet", func(t *testing.T) {
@@ -68,7 +67,6 @@ func TestClientOptions(t *testing.T) {
 			assert.Equal(t, role, *opts.Role)
 			assert.Equal(t, retryOpts, *opts.RetryOpts)
 			assert.Equal(t, hc, opts.HTTPClient)
-			assert.False(t, opts.ownsHTTPClient)
 		})
 		t.Run("SucceedsWithoutCredentialsWhenRoleIsGiven", func(t *testing.T) {
 			role := "role"
@@ -103,32 +101,6 @@ func TestClientOptions(t *testing.T) {
 				SetHTTPClient(hc)
 
 			assert.NoError(t, opts.Validate())
-		})
-
-		t.Run("DefaultsHTTPClient", func(t *testing.T) {
-			creds := credentials.NewStaticCredentialsProvider("", "", "")
-			role := "role"
-			region := "region"
-			retryOpts := utility.RetryOptions{
-				MaxAttempts: 10,
-				MinDelay:    100 * time.Millisecond,
-				MaxDelay:    time.Second,
-			}
-			opts := NewClientOptions().
-				SetCredentialsProvider(creds).
-				SetRole(role).
-				SetRegion(region).
-				SetRetryOptions(retryOpts)
-
-			require.NoError(t, opts.Validate())
-			defer opts.Close()
-
-			assert.Equal(t, creds, opts.CredsProvider)
-			assert.Equal(t, region, *opts.Region)
-			assert.Equal(t, role, *opts.Role)
-			assert.Equal(t, retryOpts, *opts.RetryOpts)
-			assert.NotZero(t, opts.HTTPClient)
-			assert.True(t, opts.ownsHTTPClient)
 		})
 	})
 }

--- a/ecs/client.go
+++ b/ecs/client.go
@@ -285,11 +285,6 @@ func (c *BasicClient) TagResource(ctx context.Context, in *ecs.TagResourceInput)
 	return out, nil
 }
 
-// Close cleans up all resources owned by the client.
-func (c *BasicClient) Close(ctx context.Context) error {
-	return c.BaseClient.Close(ctx)
-}
-
 // isNonRetryableError returns whether or not the error type from ECS is
 // known to be not retryable.
 func (c *BasicClient) isNonRetryableError(err error) bool {

--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -37,16 +37,12 @@ func TestBasicECSClient(t *testing.T) {
 	defer func() {
 		testutil.CleanupTaskDefinitions(ctx, t, c)
 		testutil.CleanupTasks(ctx, t, c)
-
-		assert.NoError(t, c.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.ECSClientTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
 			defer tcancel()
-
-			defer c.Close(tctx)
 
 			tCase(tctx, t, c)
 		})

--- a/ecs/client_test.go
+++ b/ecs/client_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
-	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,10 +25,7 @@ func TestBasicECSClient(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(hc)
-
-	awsOpts := testutil.ValidIntegrationAWSOptions(ctx, hc)
+	awsOpts := testutil.ValidIntegrationAWSOptions()
 	c, err := NewBasicClient(ctx, awsOpts)
 	require.NoError(t, err)
 	require.NotNil(t, c)

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -65,16 +65,10 @@ func TestBasicPodCreator(t *testing.T) {
 
 			c, err := NewBasicClient(ctx, awsOpts)
 			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
 
 			smc, err := secret.NewBasicSecretsManagerClient(ctx, awsOpts)
 			require.NoError(t, err)
 			require.NotNil(t, c)
-			defer func() {
-				assert.NoError(t, smc.Close(tctx))
-			}()
 
 			m, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
 			require.NoError(t, err)
@@ -102,8 +96,6 @@ func TestECSPodCreator(t *testing.T) {
 	defer func() {
 		testutil.CleanupTaskDefinitions(ctx, t, c)
 		testutil.CleanupTasks(ctx, t, c)
-
-		assert.NoError(t, c.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.ECSPodCreatorTests() {
@@ -122,8 +114,6 @@ func TestECSPodCreator(t *testing.T) {
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupSecrets(ctx, t, smc)
-
-		assert.NoError(t, smc.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.ECSPodCreatorVaultTests() {

--- a/ecs/pod_creator_test.go
+++ b/ecs/pod_creator_test.go
@@ -87,10 +87,7 @@ func TestECSPodCreator(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(hc)
-
-	awsOpts := testutil.ValidIntegrationAWSOptions(ctx, hc)
+	awsOpts := testutil.ValidIntegrationAWSOptions()
 	c, err := NewBasicClient(ctx, awsOpts)
 	require.NoError(t, err)
 	defer func() {

--- a/ecs/pod_definition_manager_test.go
+++ b/ecs/pod_definition_manager_test.go
@@ -25,9 +25,6 @@ func TestBasicPodDefinitionManager(t *testing.T) {
 	t.Run("NewPodDefinitionManager", func(t *testing.T) {
 		c, err := NewBasicClient(ctx, testutil.ValidNonIntegrationAWSOptions())
 		require.NoError(t, err)
-		defer func() {
-			assert.NoError(t, c.Close(ctx))
-		}()
 		t.Run("FailsWithZeroOptions", func(t *testing.T) {
 			pdm, err := NewBasicPodDefinitionManager(*NewBasicPodDefinitionManagerOptions())
 			assert.Error(t, err)
@@ -56,7 +53,6 @@ func TestECSPodDefinitionManager(t *testing.T) {
 	require.NotZero(t, c)
 	defer func() {
 		testutil.CleanupTaskDefinitions(ctx, t, c)
-		assert.NoError(t, c.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.ECSPodDefinitionManagerTests() {
@@ -77,8 +73,6 @@ func TestECSPodDefinitionManager(t *testing.T) {
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupSecrets(ctx, t, smc)
-
-		assert.NoError(t, smc.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.ECSPodDefinitionManagerVaultTests() {

--- a/ecs/pod_definition_manager_test.go
+++ b/ecs/pod_definition_manager_test.go
@@ -44,10 +44,7 @@ func TestECSPodDefinitionManager(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(hc)
-
-	awsOpts := testutil.ValidIntegrationAWSOptions(ctx, hc)
+	awsOpts := testutil.ValidIntegrationAWSOptions()
 	c, err := NewBasicClient(ctx, awsOpts)
 	require.NoError(t, err)
 	require.NotZero(t, c)

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -71,16 +71,12 @@ func TestECSPod(t *testing.T) {
 	defer func() {
 		testutil.CleanupTaskDefinitions(ctx, t, c)
 		testutil.CleanupTasks(ctx, t, c)
-
-		assert.NoError(t, c.Close(ctx))
 	}()
 
 	smc, err := secret.NewBasicSecretsManagerClient(ctx, awsOpts)
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupSecrets(ctx, t, smc)
-
-		assert.NoError(t, smc.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.ECSPodTests() {

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -50,9 +50,6 @@ func TestBasicPod(t *testing.T) {
 
 			c, err := NewBasicClient(tctx, testutil.ValidNonIntegrationAWSOptions())
 			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
 
 			tCase(tctx, t, c)
 		})

--- a/ecs/pod_test.go
+++ b/ecs/pod_test.go
@@ -62,10 +62,7 @@ func TestECSPod(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(hc)
-
-	awsOpts := testutil.ValidIntegrationAWSOptions(ctx, hc)
+	awsOpts := testutil.ValidIntegrationAWSOptions()
 	c, err := NewBasicClient(ctx, awsOpts)
 	require.NoError(t, err)
 	defer func() {

--- a/ecs_client.go
+++ b/ecs_client.go
@@ -29,7 +29,4 @@ type ECSClient interface {
 	StopTask(ctx context.Context, in *ecs.StopTaskInput) (*ecs.StopTaskOutput, error)
 	// TagResource adds tags to an ECS resource.
 	TagResource(ctx context.Context, in *ecs.TagResourceInput) (*ecs.TagResourceOutput, error)
-	// Close closes the client and cleans up its resources. Implementations
-	// should ensure that this is idempotent.
-	Close(ctx context.Context) error
 }

--- a/internal/testutil/aws.go
+++ b/internal/testutil/aws.go
@@ -1,8 +1,6 @@
 package testutil
 
 import (
-	"context"
-	"net/http"
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -27,8 +25,8 @@ func AWSRole() string {
 
 // ValidIntegrationAWSOptions returns valid options to create an AWS client that
 // can make actual requests to AWS for integration testing. Credentials and the region
-// will be extracted from the standard environment variables.
-func ValidIntegrationAWSOptions(ctx context.Context, hc *http.Client) awsutil.ClientOptions {
+// will be extracted automatically by the SDK from the standard environment variables.
+func ValidIntegrationAWSOptions() awsutil.ClientOptions {
 	options := awsutil.NewClientOptions()
 	if role := AWSRole(); role != "" {
 		options.SetRole(role)

--- a/mock/ecs_client.go
+++ b/mock/ecs_client.go
@@ -459,8 +459,6 @@ type ECSClient struct {
 	TagResourceInput  *awsECS.TagResourceInput
 	TagResourceOutput *awsECS.TagResourceOutput
 	TagResourceError  error
-
-	CloseError error
 }
 
 // RegisterTaskDefinition saves the input and returns a new mock task
@@ -790,14 +788,4 @@ func (c *ECSClient) TagResource(ctx context.Context, in *awsECS.TagResourceInput
 	}
 
 	return nil, &types.ResourceNotFoundException{Message: aws.String("task or task definition not found")}
-}
-
-// Close closes the mock client. The mock output can be customized. By default,
-// it is a no-op that returns no error.
-func (c *ECSClient) Close(ctx context.Context) error {
-	if c.CloseError != nil {
-		return c.CloseError
-	}
-
-	return nil
 }

--- a/mock/ecs_client_test.go
+++ b/mock/ecs_client_test.go
@@ -23,8 +23,6 @@ func TestECSClient(t *testing.T) {
 	c := &ECSClient{}
 	defer func() {
 		resetECSAndSecretsManagerCache()
-
-		assert.NoError(t, c.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.ECSClientTests() {

--- a/mock/ecs_pod_creator_test.go
+++ b/mock/ecs_pod_creator_test.go
@@ -41,14 +41,7 @@ func TestECSPodCreator(t *testing.T) {
 			pdc := NewECSPodDefinitionCache(&testutil.NoopECSPodDefinitionCache{Tag: "cache-tag"})
 
 			c := &ECSClient{}
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
 			sm := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, sm.Close(tctx))
-			}()
 
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(sm))
 			require.NoError(t, err)
@@ -71,10 +64,6 @@ func TestECSPodCreator(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &ECSClient{}
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
 			pc, err := ecs.NewBasicPodCreator(*ecs.NewBasicPodCreatorOptions().SetClient(c))
 			require.NoError(t, err)
 
@@ -92,15 +81,7 @@ func TestECSPodCreator(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &ECSClient{}
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
 			sm := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, sm.Close(tctx))
-			}()
-
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(sm))
 			require.NoError(t, err)
 			mv := NewVault(v)
@@ -122,15 +103,7 @@ func TestECSPodCreator(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &ECSClient{}
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
 			registerOut := testutil.RegisterTaskDefinition(ctx, t, c, testutil.ValidRegisterTaskDefinitionInput(t))
-
-			sm := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, sm.Close(tctx))
-			}()
 
 			pc, err := ecs.NewBasicPodCreator(*ecs.NewBasicPodCreatorOptions().SetClient(c))
 			require.NoError(t, err)

--- a/mock/ecs_pod_definition_manager_test.go
+++ b/mock/ecs_pod_definition_manager_test.go
@@ -30,15 +30,7 @@ func TestECSPodDefinitionManager(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &ECSClient{}
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
 			sm := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, sm.Close(tctx))
-			}()
-
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(sm))
 			require.NoError(t, err)
 			mv := NewVault(v)
@@ -65,10 +57,6 @@ func TestECSPodDefinitionManager(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &ECSClient{}
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
 			opts := ecs.NewBasicPodDefinitionManagerOptions().SetClient(c)
 
 			pdm, err := ecs.NewBasicPodDefinitionManager(*opts)
@@ -88,15 +76,7 @@ func TestECSPodDefinitionManager(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &ECSClient{}
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
 			smc := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, smc.Close(ctx))
-			}()
-
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
 			require.NoError(t, err)
 			mv := NewVault(v)

--- a/mock/ecs_pod_test.go
+++ b/mock/ecs_pod_test.go
@@ -35,15 +35,7 @@ func TestECSPod(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &ECSClient{}
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
 			smc := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, smc.Close(tctx))
-			}()
-
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
 			require.NoError(t, err)
 			mv := NewVault(v)
@@ -64,15 +56,7 @@ func TestECSPod(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &ECSClient{}
-			defer func() {
-				assert.NoError(t, c.Close(ctx))
-			}()
-
 			smc := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, smc.Close(tctx))
-			}()
-
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(smc))
 			require.NoError(t, err)
 			mv := NewVault(v)

--- a/mock/secrets_manager_client.go
+++ b/mock/secrets_manager_client.go
@@ -119,8 +119,6 @@ type SecretsManagerClient struct {
 	TagResourceInput  *secretsmanager.TagResourceInput
 	TagResourceOutput *secretsmanager.TagResourceOutput
 	TagResourceError  error
-
-	CloseError error
 }
 
 // CreateSecret saves the input options and returns a new mock secret. The mock
@@ -437,13 +435,4 @@ func (c *SecretsManagerClient) TagResource(ctx context.Context, in *secretsmanag
 		s.Tags[k] = v
 	}
 	return &secretsmanager.TagResourceOutput{}, nil
-}
-
-// Close closes the mock client. The mock output can be customized. By default,
-// it is a no-op that returns no error.
-func (c *SecretsManagerClient) Close(ctx context.Context) error {
-	if c.CloseError != nil {
-		return c.CloseError
-	}
-	return nil
 }

--- a/mock/secrets_manager_client_test.go
+++ b/mock/secrets_manager_client_test.go
@@ -23,10 +23,6 @@ func TestSecretsManagerClient(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, c.Close(tctx))
-			}()
-
 			tCase(tctx, t, c)
 		})
 	}

--- a/mock/secrets_manager_vault_test.go
+++ b/mock/secrets_manager_vault_test.go
@@ -28,10 +28,6 @@ func TestVaultWithSecretsManager(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, c.Close(tctx))
-			}()
-
 			sc := NewSecretCache(&testutil.NoopSecretCache{Tag: "cache-tag"})
 
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().
@@ -60,9 +56,6 @@ func TestVaultWithSecretsManager(t *testing.T) {
 			resetECSAndSecretsManagerCache()
 
 			c := &SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, c.Close(tctx))
-			}()
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().SetClient(c))
 			require.NoError(t, err)
 			mv := NewVault(v)

--- a/mock/tag_client.go
+++ b/mock/tag_client.go
@@ -44,8 +44,6 @@ type TagClient struct {
 	GetResourcesInput  *resourcegroupstaggingapi.GetResourcesInput
 	GetResourcesOutput *resourcegroupstaggingapi.GetResourcesOutput
 	GetResourcesError  error
-
-	CloseError error
 }
 
 // GetResources saves the input and filters for the resources matching the input
@@ -155,16 +153,6 @@ func (c *TagClient) getSetIntersection(a, b map[string]taggedResource) map[strin
 		}
 	}
 	return intersection
-}
-
-// Close closes the mock client. The mock output can be customized. By default,
-// it is a no-op that returns no error.
-func (c *TagClient) Close(ctx context.Context) error {
-	if c.CloseError != nil {
-		return c.CloseError
-	}
-
-	return nil
 }
 
 // serviceToResourceFinders maps the AWS service name to the taggable resources

--- a/mock/tag_client_test.go
+++ b/mock/tag_client_test.go
@@ -16,10 +16,6 @@ func TestTagClient(t *testing.T) {
 	defer cancel()
 
 	c := &TagClient{}
-	defer func() {
-		assert.NoError(t, c.Close(ctx))
-	}()
-
 	for tName, tCase := range testcase.TagClientTests() {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, defaultTestTimeout)
@@ -32,8 +28,6 @@ func TestTagClient(t *testing.T) {
 	smClient := &SecretsManagerClient{}
 	defer func() {
 		ResetGlobalSecretCache()
-
-		assert.NoError(t, smClient.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.TagClientSecretTests() {

--- a/secret/secrets_manager_client.go
+++ b/secret/secrets_manager_client.go
@@ -207,11 +207,6 @@ func (c *BasicSecretsManagerClient) DeleteSecret(ctx context.Context, in *secret
 	return out, nil
 }
 
-// Close cleans up all resources owned by the client.
-func (c *BasicSecretsManagerClient) Close(ctx context.Context) error {
-	return c.BaseClient.Close(ctx)
-}
-
 // isNonRetryableError returns whether or not the error type from Secrets
 // Manager is known to be not retryable.
 func (c *BasicSecretsManagerClient) isNonRetryableError(err error) bool {

--- a/secret/secrets_manager_client_test.go
+++ b/secret/secrets_manager_client_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
-	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,10 +24,7 @@ func TestBasicSecretsManagerClient(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(hc)
-
-	awsOpts := testutil.ValidIntegrationAWSOptions(ctx, hc)
+	awsOpts := testutil.ValidIntegrationAWSOptions()
 	c, err := NewBasicSecretsManagerClient(ctx, awsOpts)
 	require.NoError(t, err)
 	defer func() {

--- a/secret/secrets_manager_client_test.go
+++ b/secret/secrets_manager_client_test.go
@@ -33,8 +33,6 @@ func TestBasicSecretsManagerClient(t *testing.T) {
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupSecrets(ctx, t, c)
-
-		assert.NoError(t, c.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.SecretsManagerClientTests() {

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -24,9 +24,6 @@ func TestBasicSecretsManager(t *testing.T) {
 	t.Run("NewBasicSecretsManager", func(t *testing.T) {
 		c, err := NewBasicSecretsManagerClient(ctx, testutil.ValidNonIntegrationAWSOptions())
 		require.NoError(t, err)
-		defer func() {
-			assert.NoError(t, c.Close(ctx))
-		}()
 		t.Run("FailsWithZeroOptions", func(t *testing.T) {
 			sm, err := NewBasicSecretsManager(*NewBasicSecretsManagerOptions())
 			assert.Error(t, err)
@@ -60,8 +57,6 @@ func TestSecretsManager(t *testing.T) {
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupSecrets(ctx, t, c)
-
-		assert.NoError(t, c.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.VaultTests(cleanupSecret) {

--- a/secret/secrets_manager_vault_test.go
+++ b/secret/secrets_manager_vault_test.go
@@ -49,10 +49,7 @@ func TestSecretsManager(t *testing.T) {
 		}
 	}
 
-	hc := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(hc)
-
-	awsOpts := testutil.ValidIntegrationAWSOptions(ctx, hc)
+	awsOpts := testutil.ValidIntegrationAWSOptions()
 	c, err := NewBasicSecretsManagerClient(ctx, awsOpts)
 	require.NoError(t, err)
 	defer func() {

--- a/secrets_manager_client.go
+++ b/secrets_manager_client.go
@@ -25,7 +25,4 @@ type SecretsManagerClient interface {
 	DeleteSecret(ctx context.Context, in *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error)
 	// TagResource adds tags to an existing secret.
 	TagResource(ctx context.Context, in *secretsmanager.TagResourceInput) (*secretsmanager.TagResourceOutput, error)
-	// Close closes the client and cleans up its resources. Implementations
-	// should ensure that this is idempotent.
-	Close(ctx context.Context) error
 }

--- a/tag.go
+++ b/tag.go
@@ -12,7 +12,4 @@ import (
 type TagClient interface {
 	// GetResources lists arbitrary AWS resources matching the input.
 	GetResources(ctx context.Context, in *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error)
-	// Close closes the client and cleans up its resources. Implementations
-	// should ensure that this is idempotent.
-	Close(ctx context.Context) error
 }

--- a/tag/client.go
+++ b/tag/client.go
@@ -73,11 +73,6 @@ func (c *BasicTagClient) GetResources(ctx context.Context, in *resourcegroupstag
 	return out, nil
 }
 
-// Close cleans up all resources owned by the client.
-func (c *BasicTagClient) Close(ctx context.Context) error {
-	return c.BaseClient.Close(ctx)
-}
-
 func (c *BasicTagClient) isNonRetryableError(err error) bool {
 	return utility.MatchesError[*types.InvalidParameterException](err)
 }

--- a/tag/client_test.go
+++ b/tag/client_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/cocoa/internal/testcase"
 	"github.com/evergreen-ci/cocoa/internal/testutil"
 	"github.com/evergreen-ci/cocoa/secret"
-	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,10 +25,7 @@ func TestBasicTagClient(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	hc := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(hc)
-
-	awsOpts := testutil.ValidIntegrationAWSOptions(ctx, hc)
+	awsOpts := testutil.ValidIntegrationAWSOptions()
 	c, err := NewBasicTagClient(ctx, awsOpts)
 	require.NoError(t, err)
 

--- a/tag/client_test.go
+++ b/tag/client_test.go
@@ -32,9 +32,6 @@ func TestBasicTagClient(t *testing.T) {
 	awsOpts := testutil.ValidIntegrationAWSOptions(ctx, hc)
 	c, err := NewBasicTagClient(ctx, awsOpts)
 	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, c.Close(ctx))
-	}()
 
 	for tName, tCase := range testcase.TagClientTests() {
 		t.Run(tName, func(t *testing.T) {
@@ -49,8 +46,6 @@ func TestBasicTagClient(t *testing.T) {
 	require.NoError(t, err)
 	defer func() {
 		testutil.CleanupSecrets(ctx, t, smClient)
-
-		assert.NoError(t, smClient.Close(ctx))
 	}()
 
 	for tName, tCase := range testcase.TagClientSecretTests() {


### PR DESCRIPTION
[DEVPROD-6951](https://jira.mongodb.org/browse/DEVPROD-6951)

In CloudTrail there still are sporadic bursts of STS calls that I think are attributable to the pod lifecycle. This PR caches the `aws.Config` in memory so we don't incur a call to STS for each call to NewBasicClient/NewBasicSecretsManagerClient/MakeTagClient.

Caching required that we use the same HTTP client each time instead of fetching a new one from the pool. This seems okay since we'll be caching the config so we'll always use the same HTTP client for all the calls. Once fetching a client from the pool was removed, the chain of `Close()` functions became extraneous so they were removed.

An alternative to all of this could be to cache the Basic/SecretsManager/Tag clients where we get them in Evergreen (e.g. [here](https://github.com/evergreen-ci/evergreen/blob/aaa7c1981e0dbef164ba8896d7c9d61bf6f2e8b1/cloud/pod_util.go#L25-L52)) but caching at this lower level has an advantage that all the top-level clients get to share a single aws.Config. Also, this way other theoretical users of cocoa benefit from caching. Though we could go the other way instead if deemed necessary.